### PR TITLE
ENH: Add data_types property for Study object

### DIFF
--- a/qiita_db/study.py
+++ b/qiita_db/study.py
@@ -411,6 +411,21 @@ class Study(QiitaStatusObject):
         return self._id
 
     @property
+    def data_types(self):
+        """Returns list of the data types for this study
+
+        Returns
+        -------
+        list of str
+        """
+        conn_handler = SQLConnectionHandler()
+        sql = ("SELECT DISTINCT DT.data_type FROM qiita.study_raw_data SRD "
+               "JOIN qiita.common_prep_info CPI ON SRD.raw_data_id = "
+               "CPI.raw_data_id JOIN qiita.data_type DT ON CPI.data_type_id = "
+               "DT.data_type_id WHERE SRD.study_id = %s")
+        return [x[0] for x in conn_handler.execute_fetchall(sql, (self._id,))]
+
+    @property
     def raw_data(self):
         """ Returns list of data ids for raw data info
 

--- a/qiita_db/test/test_study.py
+++ b/qiita_db/test/test_study.py
@@ -371,6 +371,14 @@ class TestStudy(TestCase):
     def test_retrieve_sample_template(self):
         self.assertEqual(self.study.sample_template, 1)
 
+    def test_retrieve_data_types(self):
+        self.assertEqual(self.study.data_types, ['18S'])
+
+    def test_retrieve_data_types_none(self):
+        new = Study.create(User('test@foo.bar'), 'Identification of the '
+                           'Microbiomes for Cannabis Soils', [1], self.info)
+        self.assertEqual(new.data_types, [])
+
     def test_retrieve_raw_data(self):
         self.assertEqual(self.study.raw_data, [1, 2])
 


### PR DESCRIPTION
The study object now queries the database to retrieve the unique data types
that it has access to. Note that these have to be unique as the information is
stored per sample associated to the study.
