### PR TITLE
Create database and tear down/recreate at end of each test. Fixes #195

### DIFF
--- a/qiita_core/util.py
+++ b/qiita_core/util.py
@@ -69,8 +69,6 @@ def reset_test_database(wrapped_fn):
         # Populate the database
         with open(POPULATE_FP, 'U') as f:
             conn_handler.execute(f.read())
-        # Execute the setup function
-        return setup_fn(*args, **kwargs)
         # Execute the wrapped function
         return wrapped_fn(*args, **kwargs)
 

--- a/qiita_db/environment_manager.py
+++ b/qiita_db/environment_manager.py
@@ -189,6 +189,7 @@ def make_environment(env, base_data_dir, base_work_dir, user, password, host):
             conn.commit()
             cur.close()
             conn.close()
+            print('Test environment successfully created')
         else:
             # Commit all the changes and close the connections
             conn.commit()
@@ -245,7 +246,7 @@ def clean_test_environment(user, password, host):
     r"""Cleans the test database environment.
 
     In case that the test database is dirty (i.e. the 'qiita' schema is
-    present), this cleans it up by dropping the 'qiita' schema and 
+    present), this cleans it up by dropping the 'qiita' schema and
     re-populating it.
 
     Parameters


### PR DESCRIPTION
This pull request means that there is always a populated test database that is wiped and re-created at the end of each test. This gets around some issues we've had where a database was required before tests were even run.
