### PR TITLE
tweak try-except to handle SQL errors better

### DIFF
--- a/qiita_db/sql_connection.py
+++ b/qiita_db/sql_connection.py
@@ -105,7 +105,7 @@ class SQLConnectionHandler(object):
                 raise QiitaDBExecutionError(("\nError running SQL query: %s"
                                              "\nARGS: %s"
                                              "\nError: %s" %
-                                             (sql, sql_args, e)))
+                                             (sql, str(sql_args), e)))
 
     def execute_fetchall(self, sql, sql_args=None):
         """ Executes a fetchall SQL query


### PR DESCRIPTION
This should hopefully fix any issues with mogrifying SQL queries to see what went wrong with an SQL call. The weird impracticalities of mogrifying both executemany and execute statements is not worth the hassle. This gets rid of that and just prints the sql, the arguments being fed in, and the error thrown.
