### PR TITLE
Remove python 3 from travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 env:
-  - PYTHON_VERSION=3.3
   - PYTHON_VERSION=2.7
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh -O miniconda.sh


### PR DESCRIPTION
We should add it back in when biom is python 3 compatible (see #250)
