### PR TITLE
BUG: Fix TypeError on environment creation

### DIFF
--- a/qiita_db/environment_manager.py
+++ b/qiita_db/environment_manager.py
@@ -174,7 +174,7 @@ def make_environment(load_ontologies, download_reference, add_demo_user):
         _add_ontology_data(conn)
 
     if download_reference:
-        _download_reference_files(conn)
+        _download_reference_files()
 
     # we don't do this if it's a test environment because populate.sql
     # already adds this user...


### PR DESCRIPTION
I got this exception when creating a new environment

``` python
Traceback (most recent call last):
  File "/Users/yoshikivazquezbaeza/git_sw/qiita/scripts/qiita_env", line 105, in <module>
    env()
  File "/Users/yoshikivazquezbaeza/.virtualenvs/qiita/lib/python2.7/site-packages/click/core.py", line 384, in __call__
    return self.main(*args, **kwargs)
  File "/Users/yoshikivazquezbaeza/.virtualenvs/qiita/lib/python2.7/site-packages/click/core.py", line 370, in main
    self.invoke(ctx)
  File "/Users/yoshikivazquezbaeza/.virtualenvs/qiita/lib/python2.7/site-packages/click/core.py", line 614, in invoke
    return self.invoke_subcommand(ctx, cmd, cmd_name, ctx.args[1:])
  File "/Users/yoshikivazquezbaeza/.virtualenvs/qiita/lib/python2.7/site-packages/click/core.py", line 623, in invoke_subcommand
    return cmd.invoke(cmd_ctx)
  File "/Users/yoshikivazquezbaeza/.virtualenvs/qiita/lib/python2.7/site-packages/click/core.py", line 524, in invoke
    ctx.invoke(self.callback, **ctx.params)
  File "/Users/yoshikivazquezbaeza/.virtualenvs/qiita/lib/python2.7/site-packages/click/core.py", line 236, in invoke
    return callback(*args, **kwargs)
  File "/Users/yoshikivazquezbaeza/git_sw/qiita/scripts/qiita_env", line 77, in make
    make_environment(load_ontologies, download_reference, add_demo_user)
  File "/Users/yoshikivazquezbaeza/git_sw/qiita/qiita_db/environment_manager.py", line 177, in make_environment
    _download_reference_files(conn)
TypeError: _download_reference_files() takes no arguments (1 given)
```
