### PR TITLE
ENH: Add --no-ask-for-confirmation to drop command

### DIFF
--- a/qiita_db/environment_manager.py
+++ b/qiita_db/environment_manager.py
@@ -216,7 +216,7 @@ def make_environment(load_ontologies, download_reference, add_demo_user):
         print('Production environment successfully created')
 
 
-def drop_environment():
+def drop_environment(ask_for_confirmation):
     """Drops the database specified in the configuration
     """
     # Connect to the postgres server
@@ -229,12 +229,15 @@ def drop_environment():
     if is_test_environment:
         do_drop = True
     else:
-        confirm = ''
-        while confirm not in ('Y', 'y', 'N', 'n'):
-            confirm = raw_input("THIS IS NOT A TEST ENVIRONMENT.\n"
-                                "Proceed with drop? (y/n)")
+        if ask_for_confirmation:
+            confirm = ''
+            while confirm not in ('Y', 'y', 'N', 'n'):
+                confirm = raw_input("THIS IS NOT A TEST ENVIRONMENT.\n"
+                                    "Proceed with drop? (y/n)")
 
-        do_drop = confirm in ('Y', 'y')
+            do_drop = confirm in ('Y', 'y')
+        else:
+            do_drop = True
 
     if do_drop:
         admin_conn = SQLConnectionHandler(admin=True)

--- a/scripts/qiita_env
+++ b/scripts/qiita_env
@@ -78,13 +78,16 @@ def make(load_ontologies, download_reference, add_demo_user):
 
 
 @env.command()
-def drop():
+@click.option('--ask-for-confirmation/--no-ask-for-confirmation',
+              default=True, help='If True, will ask for confirmation before '
+              'dropping the production environment.')
+def drop(ask_for_confirmation):
     """Drops the database specified in config"""
     # TODO: use password from config, see issue #363
     # Or figure out a way to use
     # http://click.pocoo.org/3/options/#password-prompts
     # and have it work with Travis...
-    drop_environment()
+    drop_environment(ask_for_confirmation)
 
 
 @env.command()


### PR DESCRIPTION
qiita_env drop can now receive a --no-ask-for-confirmation flag that prevents
the user from having to press `y` before dropping the database.
