### PR TITLE
BUG: Fix query that relied on insert order

### DIFF
--- a/qiita_db/analysis.py
+++ b/qiita_db/analysis.py
@@ -618,7 +618,8 @@ class Analysis(QiitaStatusObject):
             sample_template_id = s.sample_template
             # you can have multiple different prep templates but we are only
             # using the one for 16S i. e. the last one ... sorry ;l
-            prep_template_id = s.raw_data()[-1]
+            # see issue https://github.com/biocore/qiita/issues/465
+            prep_template_id = s.raw_data()[0]
 
             if study_id in all_studies:
                 # samples already added by other processed data file


### PR DESCRIPTION
Creating a meta-analysis was broken because one of the central queries that
builds the metadata for the meta-analysis, relied on the fact an id imposed by
a study would be the same for sample and raw data tables.

This has been corrected, the query now retrieves the data correctly.
