### PR TITLE
Fix bad import in ebi.py

### DIFF
--- a/qiita_ware/ebi.py
+++ b/qiita_ware/ebi.py
@@ -11,7 +11,7 @@ from xml.dom import minidom
 from xml.sax.saxutils import escape
 
 from future.utils import viewitems
-from skbio.util.misc import safe_md5
+from skbio.util import safe_md5
 
 from qiita_core.qiita_settings import qiita_config
 


### PR DESCRIPTION
With the newest version of scikit-bio, the safe_md5 import didn't work. This fixes it.
