### PR TITLE
URGENT: HOLD was not being generated as an ACTION

### DIFF
--- a/qiita_ware/ebi.py
+++ b/qiita_ware/ebi.py
@@ -577,8 +577,9 @@ class EBISubmission(object):
             'schema': 'run', 'source': basename(self.run_xml_fp)}
         )
 
-        if action is 'ADD':
-            ET.SubElement(actions, 'HOLD', {
+        if action == 'ADD':
+            hold_action = ET.SubElement(actions, 'ACTION')
+            ET.SubElement(hold_action, 'HOLD', {
                 'HoldUntilDate': str(date.today() + timedelta(365))}
             )
 


### PR DESCRIPTION
Please review and merge ASAP so we can try the EBI submission of American Gut Round 11 this morning.  Previously, the ACTIONS section of the XML for submission file was generated as:

```
<ACTIONS><ACTION><ADD schema="study" source="study.xml"/></ACTION><ACTION><ADD schema="sample" source="sample.xml"/></ACTION><ACTION><ADD schema="experiment" source="experiment.xml"/></ACTION><ACTION><ADD schema="run" source="run.xml"/></ACTION><HOLD HoldUntilDate="2015-10-21"/></ACTIONS>
```

Now it is

```
<ACTIONS><ACTION><ADD schema="study" source="study.xml"/></ACTION><ACTION><ADD schema="sample" source="sample.xml"/></ACTION><ACTION><ADD schema="experiment" source="experiment.xml"/></ACTION><ACTION><ADD schema="run" source="run.xml"/></ACTION><ACTION><HOLD HoldUntilDate="2015-10-22"/></ACTION></ACTIONS>
```

(Note that **HOLD** is now an ACTION)
