### PR TITLE
ENH: Fix typo where->were

### DIFF
--- a/qiita_pet/handlers/study_handlers.py
+++ b/qiita_pet/handlers/study_handlers.py
@@ -253,7 +253,7 @@ class StudyDescriptionHandler(BaseHandler):
             self.display_template(int(study_id), msg)
             return
 
-        msg = "Your samples where processed"
+        msg = "Your samples were processed"
         self.display_template(int(study_id), msg)
 
 


### PR DESCRIPTION
Change "Your samples where processed" to "Your samples were processed".
