### PR TITLE
BUG: fix undeclared var in StudyDescriptionHandler

### DIFF
--- a/qiita_pet/handlers/study_handlers.py
+++ b/qiita_pet/handlers/study_handlers.py
@@ -121,6 +121,7 @@ class StudyDescriptionHandler(BaseHandler):
         # make sure study is accessible and exists, raise error if not
         study = None
         study_id = int(study_id)
+        ebi_status = None
         try:
             study = Study(study_id)
         except QiitaDBUnknownIDError:


### PR DESCRIPTION
The flow of this block of code was missing the declaration for this variable
in some cases, it is now declared before the branching of the if statements
and is set as None.

Fixes #540
