### PR TITLE
BUG: Fix incorrect investigation type for studies

### DIFF
--- a/qiita_pet/handlers/study_handlers.py
+++ b/qiita_pet/handlers/study_handlers.py
@@ -205,6 +205,15 @@ class StudyDescriptionHandler(BaseHandler):
                 investigation_type not in ena.terms):
             raise HTTPError(400, "You need to have an investigation type")
 
+        # FIXME: new studies that get created should be submitted with this
+        # investigation type regardless of what the user selects from the GUI.
+        #
+        # Once #522 is merged this will have to be removed.
+        #
+        # See this comment for more information:
+        # https://github.com/biocore/qiita/pull/522#issuecomment-60692714
+        investigation_type = 'Amplicon Sequencing'
+
         study_id = int(study_id)
         study = Study(study_id)
 


### PR DESCRIPTION
All the studies that we are currently processing are amplicon sequencing and
thus not defined in the ontology given by EBI, see link below. Since we knew
this, the objects and underlying code submit as "Other" and with a value for
"new_study_type". However the GUI only allowed you to select from one of the
choices that EBI provides.

The problem is explained in more detail in #522 and once that PR is merged it
should be fixed, this change makes it so that the submissions include correct
information.

https://www.ebi.ac.uk/ega/sites/ebi.ac.uk.ega/files/documents/Study.xml
