### PR TITLE
Adds study_id to run_alias

### DIFF
--- a/qiita_ware/ebi.py
+++ b/qiita_ware/ebi.py
@@ -166,6 +166,12 @@ class EBISubmission(object):
         safe_study_id = escape(clean_whitespace(str(self.study_id)))
         return 'qiime_submission_' + safe_study_id
 
+    def _get_run_alias(self, file_base_name):
+        """Format alias using `file_base_name`
+        """
+        return '%s_%s_run' % (self._get_study_alias(),
+                              basename(file_base_name))
+
     def _get_library_name(self, sample_name, row_number):
         """Format alias using `sample_name`, `row_number`
 
@@ -504,7 +510,7 @@ class EBISubmission(object):
                     md5 = safe_md5(fp).hexdigest()
 
                 run = ET.SubElement(run_set, 'RUN', {
-                    'alias': basename(file_path) + '_run',
+                    'alias': self._get_run_alias(basename(file_path)),
                     'center_name': 'CCME-COLORADO'}
                 )
                 ET.SubElement(run, 'EXPERIMENT_REF', {

--- a/qiita_ware/test/test_ebi.py
+++ b/qiita_ware/test/test_ebi.py
@@ -218,7 +218,8 @@ class TestEBISubmission(TestCase):
         xml = minidom.parseString(ET.tostring(xmlelement))
         # insert the proper EBI directory, since it is a timestamp and hard
         # to predict
-        RUNXML_mod = RUNXML % submission.ebi_dir
+        RUNXML_mod = RUNXML % (submission._get_study_alias(),
+                               submission.ebi_dir)
         xmlstring = xml.toprettyxml(indent='  ', encoding='UTF-8')
         obs_stripped = ''.join([l.strip() for l in xmlstring.splitlines()])
         exp_stripped = ''.join([l.strip() for l in RUNXML_mod.splitlines()])
@@ -476,7 +477,7 @@ RUNXML = """
 <?xml version="1.0" encoding="UTF-8"?>
 <RUN_SET xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:no\
 NamespaceSchemaLocation="ftp://ftp.sra.ebi.ac.uk/meta/xsd/sra_1_3/SRA.run.xsd">
-  <RUN alias="__init__.py_run" center_name="CCME-COLORADO">
+  <RUN alias="%s___init__.py_run" center_name="CCME-COLORADO">
     <EXPERIMENT_REF refname="qiime_study_001:test1:0"/>
     <DATA_BLOCK>
       <FILES>


### PR DESCRIPTION
EBI apparently does not allow the same run alias even for different experiments. This addresses that issue.
