### PR TITLE
Password support for redis

### DIFF
--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -155,7 +155,13 @@ class ConfigurationManager(object):
 
     def _get_redis(self, config):
         """Get the configuration of the redis section"""
-        pass
+        sec_get = partial(config.get, 'redis')
+        sec_getint = partial(config.getint, 'redis')
+
+        self.redis_host = sec_get('HOST')
+        self.redis_password = sec_get('PASSWORD')
+        self.redis_db = sec_getint('DB')
+        self.redis_port = sec_getint('PORT')
 
     def _get_ipython(self, config):
         """Get the configuration of the ipython section"""

--- a/qiita_core/support_files/config_test.txt
+++ b/qiita_core/support_files/config_test.txt
@@ -64,6 +64,10 @@ EMAIL = donotreply@qiita.colorado.edu
 
 # ----------------------------- Redis settings --------------------------------
 [redis]
+HOST = localhost
+PORT = 6379
+PASSWORD =
+DB = 0
 
 # ----------------------------- Postgres settings -----------------------------
 [postgres]

--- a/qiita_pet/handlers/analysis_handlers.py
+++ b/qiita_pet/handlers/analysis_handlers.py
@@ -15,11 +15,11 @@ from collections import defaultdict, Counter
 
 from tornado.web import authenticated, HTTPError
 from pyparsing import ParseException
-from redis import Redis
 
 from qiita_pet.handlers.base_handlers import BaseHandler
 from qiita_ware.dispatchable import run_analysis
 from qiita_ware.context import submit
+from qiita_ware import r_server
 from qiita_db.user import User
 from qiita_db.analysis import Analysis
 from qiita_db.data import ProcessedData
@@ -303,7 +303,6 @@ class AnalysisResultsHandler(BaseHandler):
                     basefolder=get_db_files_base_dir())
 
         # wipe out cached messages for this analysis
-        r_server = Redis()
         key = '%s:messages' % self.current_user
         oldmessages = r_server.lrange(key, 0, -1)
         if oldmessages is not None:

--- a/qiita_ware/__init__.py
+++ b/qiita_ware/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 from __future__ import division
 
-from redis import Redis
-
 # -----------------------------------------------------------------------------
 # Copyright (c) 2014--, The Qiita Development Team.
 #
@@ -10,4 +8,11 @@ from redis import Redis
 #
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
-r_server = Redis()
+from redis import Redis
+
+from qiita_core.qiita_settings import qiita_config
+
+r_server = Redis(host=qiita_config.redis_host,
+                 port=qiita_config.redis_port,
+                 password=qiita_config.redis_password,
+                 db=qiita_config.redis_db)

--- a/qiita_ware/test/test_analysis_pipeline.py
+++ b/qiita_ware/test/test_analysis_pipeline.py
@@ -2,12 +2,11 @@ from unittest import TestCase, main
 from os.path import exists, join
 from os import remove, rename
 
-from redis import Redis
-
 from qiita_core.util import qiita_test_checker
 from qiita_db.analysis import Analysis
 from qiita_db.job import Job
 from qiita_db.util import get_db_files_base_dir
+from qiita_ware import r_server
 from qiita_ware.analysis_pipeline import (
     RunAnalysis, _build_analysis_files, _job_comm_wrapper, _finish_analysis)
 
@@ -31,8 +30,7 @@ class TestRun(TestCase):
             remove(delfile)
 
     def test_finish_analysis(self):
-        redis = Redis()
-        pubsub = redis.pubsub()
+        pubsub = r_server.pubsub()
         pubsub.subscribe("demo@microbio.me")
         msgs = []
 
@@ -90,8 +88,7 @@ class TestRun(TestCase):
     def test_redis_comms(self):
         """Make sure redis communication happens"""
         msgs = []
-        redis = Redis()
-        pubsub = redis.pubsub()
+        pubsub = r_server.pubsub()
         pubsub.subscribe("demo@microbio.me")
 
         app = RunAnalysis()


### PR DESCRIPTION
Support for authentication with redis, and for configuring a redis server that is not local. 

THIS WILL REQUIRE MODIFICATIONS TO YOUR QIITA CONFIG. Specifically, the following will allow you to use your local redis server without modifications to the server

``` bash
[redis]
HOST = localhost
PORT = 6379
PASSWORD =
DB = 0
```
