### PR TITLE
BUG/TST: Fix investigation_type setter

### DIFF
--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -1144,6 +1144,10 @@ class PrepTemplate(MetadataTemplate):
     str_cols_handlers = {'emp_status_id': get_emp_status(key='emp_status_id')}
     _sample_cls = PrepSample
 
+    def __init__(self, id_):
+        super(PrepTemplate, self).__init__(id_)
+        self._investigation_type_ontology = 'ENA'
+
     @classmethod
     def create(cls, md_template, raw_data, study, data_type,
                investigation_type=None, investigation_type_ontology='ENA'):

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -1345,6 +1345,23 @@ class TestPrepTemplate(TestCase):
         with self.assertRaises(QiitaDBColumnError):
             pt.investigation_type = "should fail"
 
+    def test_investigation_type_ontology(self):
+        pt = PrepTemplate(1)
+        self.assertEqual(pt._investigation_type_ontology, 'ENA')
+
+    def test_investigation_type_ontology_fails(self):
+        # this should fail because ENA is not valid in the test environments
+        pt = PrepTemplate(1)
+        with self.assertRaises(IncompetentQiitaDeveloperError):
+            pt.investigation_type = 'RNASeq'
+
+    def test_investigation_type_instance_setter(self):
+        pt = PrepTemplate(1)
+        # we need to check against the ontology test table
+        pt._investigation_type_ontology = 'ENA_test'
+        pt.investigation_type = 'RNASeq'
+        self.assertEqual(pt.investigation_type, 'RNASeq')
+
 
 EXP_SAMPLE_TEMPLATE = (
     "sample_name\tcollection_timestamp\tdescription\thas_extracted_data\t"


### PR DESCRIPTION
The investigation_type setter was not working in the PrepTemplate class 
because the `_investigation_type_ontology` value was missing when this object
was being instantiated.

I have added 3 tests to exercise this attribute of the class.

Fixes #594
