### PR TITLE
Only split twice when getting PI information

### DIFF
--- a/qiita_db/commands.py
+++ b/qiita_db/commands.py
@@ -78,7 +78,7 @@ def load_study_from_cmd(owner, title, info):
                                                        lab_affiliation.strip())
 
     pi_name_email = infodict.pop('principal_investigator')
-    pi_name, pi_email, pi_affiliation = pi_name_email.split(',')
+    pi_name, pi_email, pi_affiliation = pi_name_email.split(',', 2)
     infodict['principal_investigator_id'] = StudyPerson.create(
         pi_name.strip(), pi_email.strip(), pi_affiliation.strip())
 


### PR DESCRIPTION
Some of the PI's affiliations have commas in them.  Probably, these should be three separate fields (or minimally the delimiter should be changed to something less common), but in the interest of finishing loading the EMP studies, this will do for now.
