### PR TITLE
BUG: Fix incorrect rendering of public studies

### DIFF
--- a/qiita_pet/templates/public_studies.html
+++ b/qiita_pet/templates/public_studies.html
@@ -30,8 +30,8 @@ $(document).ready(function() {
             {% for s in public_studies %}
             <tr>
                 <td><a href="/study/description/{{ s.id }}">{{ s.title }}</a></td>
-                {% if s.meta_complete %}
                 <td>{% raw s.owner %}</td>
+                {% if s.meta_complete %}
                 <td><span class="glyphicon glyphicon-ok"></span></td>
                 {% else %}
                 <td><span class="glyphicon glyphicon-remove"></span></td>


### PR DESCRIPTION
The page was being rendered incorrectly because of a small confusion in the
tornado template.

Fixes #623
