### PR TITLE
Redirect to mainpage if login from auth pages. Fix #697

### DIFF
--- a/qiita_pet/handlers/auth_handlers.py
+++ b/qiita_pet/handlers/auth_handlers.py
@@ -82,7 +82,7 @@ class AuthLoginHandler(BaseHandler):
         passwd = self.get_argument("password", "")
         nextpage = self.get_argument("next", None)
         if nextpage is None:
-            if "auth" not in self.request.headers['Referer']:
+            if "auth/" not in self.request.headers['Referer']:
                 nextpage = self.request.headers['Referer']
             else:
                 nextpage = "/"


### PR DESCRIPTION
This makes it so any login with "auth" in the URL is ignored when doing the redirect to the page you were trying to access. This stops issues we were having logging in from the create user and forgot password pages.
