### PR TITLE
Stop mangling duplicate columns. Fix #736

### DIFF
--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -1738,7 +1738,7 @@ def load_template_to_dataframe(fn):
     # index_col=False, otherwise it is casted as a float and we want a string
     template = pd.read_csv(fn, sep='\t', infer_datetime_format=True,
                            parse_dates=True, index_col=False, comment='\t',
-                           converters={
+                           mangle_dupe_cols=False, converters={
                                'sample_name': lambda x: str(x).strip()})
 
     # set the sample name as the index

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -1427,6 +1427,16 @@ class TestUtilities(TestCase):
         exp.index.name = 'sample_name'
         assert_frame_equal(obs, exp)
 
+    def test_load_template_to_dataframe_duplicate_cols(self):
+        obs = load_template_to_dataframe(
+            StringIO(EXP_SAMPLE_TEMPLATE_DUPE_COLS))
+        obs = list(obs.columns)
+        exp = ['collection_timestamp', 'description', 'has_extracted_data',
+               'has_physical_specimen', 'host_subject_id', 'latitude',
+               'longitude', 'physical_location', 'required_sample_info_status',
+               'sample_type', 'str_column', 'str_column']
+        assert obs == exp
+
     def test_load_template_to_dataframe_scrubbing(self):
         obs = load_template_to_dataframe(StringIO(EXP_SAMPLE_TEMPLATE_SPACES))
         exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_DICT_FORM)
@@ -1472,6 +1482,21 @@ EXP_SAMPLE_TEMPLATE = (
     "2.Sample3\t2014-05-29 12:24:51\tTest Sample 3\tTrue\t"
     "True\tNotIdentified\t4.8\t4.41\tlocation1\treceived\ttype1\t"
     "Value for sample 3\n")
+
+EXP_SAMPLE_TEMPLATE_DUPE_COLS = (
+    "sample_name\tcollection_timestamp\tdescription\thas_extracted_data\t"
+    "has_physical_specimen\thost_subject_id\tlatitude\tlongitude\t"
+    "physical_location\trequired_sample_info_status\tsample_type\t"
+    "str_column\tstr_column\n"
+    "2.Sample1\t2014-05-29 12:24:51\tTest Sample 1\tTrue\tTrue\t"
+    "NotIdentified\t42.42\t41.41\tlocation1\treceived\ttype1\t"
+    "Value for sample 1\tValue for sample 1\n"
+    "2.Sample2\t2014-05-29 12:24:51\t"
+    "Test Sample 2\tTrue\tTrue\tNotIdentified\t4.2\t1.1\tlocation1\treceived\t"
+    "type1\tValue for sample 2\tValue for sample 2\n"
+    "2.Sample3\t2014-05-29 12:24:51\tTest Sample 3\tTrue\t"
+    "True\tNotIdentified\t4.8\t4.41\tlocation1\treceived\ttype1\t"
+    "Value for sample 3\tValue for sample 3\n")
 
 EXP_SAMPLE_TEMPLATE_FEWER_SAMPLES = (
     "sample_name\tcollection_timestamp\tdescription\thas_extracted_data\t"

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -1435,7 +1435,7 @@ class TestUtilities(TestCase):
                'has_physical_specimen', 'host_subject_id', 'latitude',
                'longitude', 'physical_location', 'required_sample_info_status',
                'sample_type', 'str_column', 'str_column']
-        assert obs == exp
+        self.assertEqual(obs, exp)
 
     def test_load_template_to_dataframe_scrubbing(self):
         obs = load_template_to_dataframe(StringIO(EXP_SAMPLE_TEMPLATE_SPACES))


### PR DESCRIPTION
This makes it so pandas no longer mangles duplicate columns, allowing for proper duplicate column checks.