### PR TITLE
BUG:Remove rows without sample name & improve docs

### DIFF
--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -1732,14 +1732,26 @@ def load_template_to_dataframe(fn):
     -----
     The index attribute of the DataFrame will be forced to be 'sample_name'
     and will be casted to a string. Additionally rows that start with a '\t'
-    character will be ignored and columns that are empty will be removed.
+    character will be ignored and columns that are empty will be removed. Empty
+    sample names will be removed from the DataFrame.
     """
 
-    # index_col=False, otherwise it is casted as a float and we want a string
+    # index_col:
+    #   is set as False, otherwise it is casted as a float and we want a string
+    # converters:
+    #   ensure that sample names are not converted into any other types but
+    #   strings and remove any trailing spaces.
+    # comment:
+    #   using the tab character as "comment" we remove rows that are
+    #   constituted only by delimiters i. e. empty rows.
     template = pd.read_csv(fn, sep='\t', infer_datetime_format=True,
                            parse_dates=True, index_col=False, comment='\t',
                            converters={
                                'sample_name': lambda x: str(x).strip()})
+
+    # remove rows that have no sample identifier but that may have other data
+    # in the rest of the columns
+    template.dropna(subset=['sample_name'], how='all', inplace=True)
 
     # set the sample name as the index
     template.set_index('sample_name', inplace=True)

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -1458,6 +1458,19 @@ class TestUtilities(TestCase):
         exp.sort_index(inplace=True)
         assert_frame_equal(obs, exp)
 
+    def test_load_template_to_dataframe_empty_sample_names(self):
+        obs = load_template_to_dataframe(
+            StringIO(SAMPLE_TEMPLATE_NO_SAMPLE_NAMES))
+        exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_DICT_FORM)
+        exp.index.name = 'sample_name'
+        assert_frame_equal(obs, exp)
+
+        obs = load_template_to_dataframe(
+            StringIO(SAMPLE_TEMPLATE_NO_SAMPLE_NAMES_SOME_SPACES))
+        exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_DICT_FORM)
+        exp.index.name = 'sample_name'
+        assert_frame_equal(obs, exp)
+
 
 EXP_SAMPLE_TEMPLATE = (
     "sample_name\tcollection_timestamp\tdescription\thas_extracted_data\t"
@@ -1547,6 +1560,44 @@ EXP_SAMPLE_TEMPLATE_NUMBER_SAMPLE_NAMES = (
     "0.12121\t2014-05-29 12:24:51\tTest Sample 3\tTrue\t"
     "True\tNotIdentified\t4.8\t4.41\tlocation1\treceived\ttype1\t"
     "Value for sample 3\n")
+
+SAMPLE_TEMPLATE_NO_SAMPLE_NAMES = (
+    "sample_name\tcollection_timestamp\tdescription\thas_extracted_data\t"
+    "has_physical_specimen\thost_subject_id\tlatitude\tlongitude\t"
+    "physical_location\trequired_sample_info_status\tsample_type\t"
+    "str_column\n"
+    "2.Sample1\t2014-05-29 12:24:51\tTest Sample 1\tTrue\tTrue\t"
+    "NotIdentified\t42.42\t41.41\tlocation1\treceived\ttype1\t"
+    "Value for sample 1\n"
+    "2.Sample2\t2014-05-29 12:24:51\t"
+    "Test Sample 2\tTrue\tTrue\tNotIdentified\t4.2\t1.1\tlocation1\treceived\t"
+    "type1\tValue for sample 2\n"
+    "2.Sample3\t2014-05-29 12:24:51\tTest Sample 3\tTrue\t"
+    "True\tNotIdentified\t4.8\t4.41\tlocation1\treceived\ttype1\t"
+    "Value for sample 3\n"
+    "\t2014-05-29 12:24:51\tTest Sample 3\tTrue\t"
+    "True\tNotIdentified\t4.8\t4.41\tlocation1\treceived\ttype1\t"
+    "Value for sample 3\n"
+    "\t\t\t\t\t\t\t\t\t\t\t\n"
+    )
+
+SAMPLE_TEMPLATE_NO_SAMPLE_NAMES_SOME_SPACES = (
+    "sample_name\tcollection_timestamp\tdescription\thas_extracted_data\t"
+    "has_physical_specimen\thost_subject_id\tlatitude\tlongitude\t"
+    "physical_location\trequired_sample_info_status\tsample_type\t"
+    "str_column\n"
+    "2.Sample1\t2014-05-29 12:24:51\tTest Sample 1\tTrue\tTrue\t"
+    "NotIdentified\t42.42\t41.41\tlocation1\treceived\ttype1\t"
+    "Value for sample 1\n"
+    "2.Sample2\t2014-05-29 12:24:51\t"
+    "Test Sample 2\tTrue\tTrue\tNotIdentified\t4.2\t1.1\tlocation1\treceived\t"
+    "type1\tValue for sample 2\n"
+    "2.Sample3\t2014-05-29 12:24:51\tTest Sample 3\tTrue\t"
+    "True\tNotIdentified\t4.8\t4.41\tlocation1\treceived\ttype1\t"
+    "Value for sample 3\n"
+    "\t\t\t\t\t \t\t\t\t \t\t\n"
+    )
+
 
 SAMPLE_TEMPLATE_DICT_FORM = {
     'collection_timestamp': {'2.Sample1': '2014-05-29 12:24:51',


### PR DESCRIPTION
Rows with empty sample names are now removed from the dataframe, note that
these rows could include relevant data in other columns but since we have no
sample name, they are useless.

The documentation for read_csv was lacking a bit, so I expanded on the reason
why the arguments are being passed the way they are.

Fixes #746