### PR TITLE
Fix trying to render without dropped samples

### DIFF
--- a/qiita_pet/handlers/analysis_handlers.py
+++ b/qiita_pet/handlers/analysis_handlers.py
@@ -303,11 +303,13 @@ class AnalysisResultsHandler(BaseHandler):
                                              jobject.results))
 
         dropped = {}
-        for proc_data_id, samples in viewitems(analysis.dropped_samples):
-            proc_data = ProcessedData(proc_data_id)
-            key = "Data type %s, Study: %s" % (proc_data.data_type(),
-                                               proc_data.study)
-            dropped[key] = samples
+        dropped_samples = analysis.dropped_samples
+        if dropped_samples:
+            for proc_data_id, samples in viewitems(dropped_samples):
+                proc_data = ProcessedData(proc_data_id)
+                key = "Data type %s, Study: %s" % (proc_data.data_type(),
+                                                   proc_data.study)
+                dropped[key] = samples
 
         self.render("analysis_results.html", user=self.current_user,
                     jobres=jobres, aname=analysis.name, dropped=dropped,


### PR DESCRIPTION
This makes sure we don't loop over a None when doing viewitems.