### PR TITLE
More informative reset password messages. Fix #788

### DIFF
--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -141,6 +141,8 @@ class ConfigurationManager(object):
         self.base_data_dir = config.get('main', 'BASE_DATA_DIR') or \
             default_base_data_dir
 
+        self.base_url = config.get('main', 'BASE_URL')
+
         if not isdir(self.base_data_dir):
             raise ValueError("The BASE_DATA_DIR (%s) folder doesn't exist" %
                              self.base_data_dir)

--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -28,6 +28,8 @@ class ConfigurationManager(object):
     ----------
     test_environment : bool
         If true, we are in a test environment.
+    base_url: str
+        base URL for the website, in the form http://SOMETHING.com
     base_data_dir : str
         Path to the base directorys where all data file are stored
     working_dir : str

--- a/qiita_core/support_files/config_test.txt
+++ b/qiita_core/support_files/config_test.txt
@@ -18,6 +18,9 @@ TEST_ENVIRONMENT = TRUE
 # Whether studies require admin approval to be made available
 REQUIRE_APPROVAL = True
 
+# Base URL: DO NOT ADD TRAILING SLASH
+BASE_URL = http://localhost
+
 # Download path files
 UPLOAD_DATA_DIR = /tmp/
 

--- a/qiita_pet/handlers/auth_handlers.py
+++ b/qiita_pet/handlers/auth_handlers.py
@@ -6,6 +6,7 @@ from tornado.web import HTTPError
 from moi import r_client
 
 from qiita_pet.handlers.base_handlers import BaseHandler
+from qiita_core.qiita_settings import qiita_config
 from qiita_core.util import send_email
 from qiita_core.exceptions import (IncorrectPasswordError, IncorrectEmailError,
                                    UnverifiedEmailError)
@@ -45,8 +46,9 @@ class AuthCreateHandler(BaseHandler):
             try:
                 send_email(username, "QIITA: Verify Email Address", "Please "
                            "click the following link to verify email address: "
-                           "http://qiita.colorado.edu/auth/verify/%s?email=%s"
-                           % (info['user_verify_code'], url_escape(username)))
+                           "%s/auth/verify/%s?email=%s"
+                           % (qiita_config.base_url, info['user_verify_code'],
+                              url_escape(username)))
             except:
                 msg = ("Unable to send verification email. Please contact the "
                        "qiita developers at <a href='mailto:qiita-help"

--- a/qiita_pet/handlers/user_handlers.py
+++ b/qiita_pet/handlers/user_handlers.py
@@ -7,6 +7,7 @@ from qiita_db.user import User
 from qiita_db.logger import LogEntry
 from qiita_db.exceptions import QiitaDBUnknownIDError
 from qiita_core.util import send_email
+from qiita_core.qiita_settings import qiita_config
 
 
 class UserProfile(Form):
@@ -94,11 +95,11 @@ class ForgotPasswordHandler(BaseHandler):
             try:
                 send_email(user.id, "Qiita: Password Reset", "Please go to "
                            "the following URL to reset your password: \n"
-                           "http://qiita.colorado.edu/auth/reset/%s  \nYou "
+                           "%s/auth/reset/%s  \nYou "
                            "have 30 minutes from the time you requested a "
                            "reset to change your password. After this period, "
                            "you will have to request another reset." %
-                           info["pass_reset_code"])
+                           (qiita_config.base_url, info["pass_reset_code"]))
                 message = ("Check your email for the reset code.")
                 level = "success"
                 page = "index.html"

--- a/qiita_pet/handlers/user_handlers.py
+++ b/qiita_pet/handlers/user_handlers.py
@@ -93,8 +93,11 @@ class ForgotPasswordHandler(BaseHandler):
             info = user.info
             try:
                 send_email(user.id, "Qiita: Password Reset", "Please go to "
-                           "the following URL to reset your password: "
-                           "http://qiita.colorado.edu/auth/reset/%s" %
+                           "the following URL to reset your password: \n"
+                           "http://qiita.colorado.edu/auth/reset/%s  \nYou "
+                           "have 30 minutes from the time you requested a "
+                           "reset to change your password. After this period, "
+                           "you will have to request another reset." %
                            info["pass_reset_code"])
                 message = ("Check your email for the reset code.")
                 level = "success"
@@ -137,7 +140,9 @@ class ChangeForgotPasswordHandler(BaseHandler):
                 level = "success"
                 page = "index.html"
             else:
-                message = "Unable to reset password"
+                message = ("Unable to reset password. Most likely your email "
+                           "is incorrect or your reset window has timed out.")
+
                 level = "danger"
 
         self.render(page, user=user, message=message, level=level, code=code)


### PR DESCRIPTION
This adds the 30 minute timeout information to the email sent and a more informative message when the user's password is not reset.