### PR TITLE
Add reference name and version to selection for processing

### DIFF
--- a/qiita_db/reference.py
+++ b/qiita_db/reference.py
@@ -139,7 +139,6 @@ class Reference(QiitaObject):
             "reference_id = %s".format(self._table), (self._id,))[0]
         _, basefp = get_mountpoint('reference', conn_handler=conn_handler)[0]
 
-
     @property
     def sequence_fp(self):
         conn_handler = SQLConnectionHandler()

--- a/qiita_db/reference.py
+++ b/qiita_db/reference.py
@@ -124,6 +124,23 @@ class Reference(QiitaObject):
             (name, version))[0]
 
     @property
+    def name(self):
+        conn_handler = SQLConnectionHandler()
+        return conn_handler.execute_fetchone(
+            "SELECT reference_name FROM qiita.{0} WHERE "
+            "reference_id = %s".format(self._table), (self._id,))[0]
+        _, basefp = get_mountpoint('reference', conn_handler=conn_handler)[0]
+
+    @property
+    def version(self):
+        conn_handler = SQLConnectionHandler()
+        return conn_handler.execute_fetchone(
+            "SELECT reference_version FROM qiita.{0} WHERE "
+            "reference_id = %s".format(self._table), (self._id,))[0]
+        _, basefp = get_mountpoint('reference', conn_handler=conn_handler)[0]
+
+
+    @property
     def sequence_fp(self):
         conn_handler = SQLConnectionHandler()
         rel_path = conn_handler.execute_fetchone(

--- a/qiita_pet/test/test_util.py
+++ b/qiita_pet/test/test_util.py
@@ -20,10 +20,10 @@ class TestUtil(TestCase):
     def test_generate_param_str(self):
         params = ProcessedSortmernaParams(1)
         obs = generate_param_str(params)
-        exp = ("<b>similarity:</b> 0.97<br/>"
+        exp = ("<b>Reference:</b> Greengenes 13_8<br/>"
+               "<b>similarity:</b> 0.97<br/>"
                "<b>sortmerna_e_value:</b> 1.0<br/>"
                "<b>sortmerna_max_pos:</b> 10000<br/>"
-               "<b>reference_id:</b> 1<br/>"
                "<b>threads:</b> 1<br/>"
                "<b>sortmerna_coverage:</b> 0.97")
         self.assertEqual(obs, exp)

--- a/qiita_pet/util.py
+++ b/qiita_pet/util.py
@@ -23,6 +23,7 @@ Methods
 # -----------------------------------------------------------------------------
 from qiita_db.reference import Reference
 
+
 def linkify(link_template, item):
     """Formats a strings into a URL using string replacement
 

--- a/qiita_pet/util.py
+++ b/qiita_pet/util.py
@@ -21,7 +21,7 @@ Methods
 #
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
-
+from qiita_db.reference import Reference
 
 def linkify(link_template, item):
     """Formats a strings into a URL using string replacement
@@ -65,6 +65,8 @@ def generate_param_str(param):
     str
         The html string with the parameter set values
     """
-    result = ["<b>%s:</b> %s" % (name, value)
-              for name, value in param.values.items()]
+    ref = Reference(param.reference)
+    result = ["<b>Reference:</b> %s %s" % (ref.name, ref.version)]
+    result.extend("<b>%s:</b> %s" % (name, value)
+                  for name, value in param.values.items())
     return "<br/>".join(result)

--- a/qiita_pet/util.py
+++ b/qiita_pet/util.py
@@ -68,5 +68,6 @@ def generate_param_str(param):
     ref = Reference(param.reference)
     result = ["<b>Reference:</b> %s %s" % (ref.name, ref.version)]
     result.extend("<b>%s:</b> %s" % (name, value)
-                  for name, value in param.values.items())
+                  for name, value in param.values.items()
+                  if name != 'reference_id')
     return "<br/>".join(result)

--- a/qiita_pet/util.py
+++ b/qiita_pet/util.py
@@ -21,6 +21,8 @@ Methods
 #
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
+from future.utils import viewitems
+
 from qiita_db.reference import Reference
 
 
@@ -69,6 +71,6 @@ def generate_param_str(param):
     ref = Reference(param.reference)
     result = ["<b>Reference:</b> %s %s" % (ref.name, ref.version)]
     result.extend("<b>%s:</b> %s" % (name, value)
-                  for name, value in param.values.items()
+                  for name, value in viewitems(param.values)
                   if name != 'reference_id')
     return "<br/>".join(result)


### PR DESCRIPTION
The current setup is pretty much already set for reference changes, so this adds that information to the params displayed.

To be clear: If the reference is added to the reference table, then used in a params row, it will show up as a new parameter because it is in that row.