### PR TITLE
BUG: Add warning when removing empty columns

### DIFF
--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -47,6 +47,7 @@ from functools import partial
 
 import pandas as pd
 import numpy as np
+import warnings
 
 from qiita_core.exceptions import IncompetentQiitaDeveloperError
 from .exceptions import (QiitaDBDuplicateError, QiitaDBColumnError,
@@ -1728,6 +1729,11 @@ def load_template_to_dataframe(fn):
     DataFrame
         Pandas dataframe with the loaded information
 
+    Raises
+    ------
+    UserWarning
+        When columns are dropped because they have no content for any sample.
+
     Notes
     -----
     The index attribute of the DataFrame will be forced to be 'sample_name'
@@ -1738,6 +1744,12 @@ def load_template_to_dataframe(fn):
 
     # index_col:
     #   is set as False, otherwise it is casted as a float and we want a string
+    # keep_default:
+    #   is set as False, to avoid inferring empty/NA values with the defaults
+    #   that Pandas has.
+    # na_values:
+    #   the values that should be considered as empty, in this case only empty
+    #   strings.
     # converters:
     #   ensure that sample names are not converted into any other types but
     #   strings and remove any trailing spaces.
@@ -1745,9 +1757,12 @@ def load_template_to_dataframe(fn):
     #   using the tab character as "comment" we remove rows that are
     #   constituted only by delimiters i. e. empty rows.
     template = pd.read_csv(fn, sep='\t', infer_datetime_format=True,
+                           keep_default_na=False, na_values=[''],
                            parse_dates=True, index_col=False, comment='\t',
                            mangle_dupe_cols=False, converters={
                                'sample_name': lambda x: str(x).strip()})
+
+    initial_columns = set(template.columns)
 
     # remove rows that have no sample identifier but that may have other data
     # in the rest of the columns
@@ -1758,5 +1773,12 @@ def load_template_to_dataframe(fn):
 
     # it is not uncommon to find templates that have empty columns
     template.dropna(how='all', axis=1, inplace=True)
+
+    initial_columns.remove('sample_name')
+    dropped_cols = initial_columns - set(template.columns)
+    if dropped_cols:
+        warnings.warn('The following column(s) were removed from the template '
+                      'because all their values are empty: '
+                      '%s' % ', '.join(dropped_cols), UserWarning)
 
     return template

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -16,6 +16,7 @@ from os import close, remove
 from os.path import join, basename
 from collections import Iterable
 
+import numpy.testing as npt
 import pandas as pd
 from pandas.util.testing import assert_frame_equal
 
@@ -1445,8 +1446,8 @@ class TestUtilities(TestCase):
         assert_frame_equal(obs, exp)
 
     def test_load_template_to_dataframe_empty_columns(self):
-        obs = load_template_to_dataframe(
-            StringIO(EXP_SAMPLE_TEMPLATE_SPACES_EMPTY_COLUMN))
+        obs = npt.assert_warns(UserWarning, load_template_to_dataframe,
+                               StringIO(EXP_ST_SPACES_EMPTY_COLUMN))
         exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_DICT_FORM)
         exp.index.name = 'sample_name'
         assert_frame_equal(obs, exp)
@@ -1478,6 +1479,21 @@ class TestUtilities(TestCase):
         obs = load_template_to_dataframe(
             StringIO(SAMPLE_TEMPLATE_NO_SAMPLE_NAMES_SOME_SPACES))
         exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_DICT_FORM)
+        exp.index.name = 'sample_name'
+        assert_frame_equal(obs, exp)
+
+    def test_load_template_to_dataframe_empty_column(self):
+
+            obs = npt.assert_warns(UserWarning, load_template_to_dataframe,
+                                   StringIO(SAMPLE_TEMPLATE_EMPTY_COLUMN))
+            exp = pd.DataFrame.from_dict(ST_EMPTY_COLUMN_DICT_FORM)
+            exp.index.name = 'sample_name'
+            assert_frame_equal(obs, exp)
+
+    def test_load_template_to_dataframe_column_with_nas(self):
+        obs = load_template_to_dataframe(
+            StringIO(SAMPLE_TEMPLATE_COLUMN_WITH_NAS))
+        exp = pd.DataFrame.from_dict(ST_COLUMN_WITH_NAS_DICT_FORM)
         exp.index.name = 'sample_name'
         assert_frame_equal(obs, exp)
 
@@ -1556,7 +1572,7 @@ EXP_SAMPLE_TEMPLATE_SPACES_EMPTY_ROW = (
     "\t\t\t\t\t\t\t\t\t\t\t\n"
     "\t\t\t\t\t\t\t\t\t\t\t\n")
 
-EXP_SAMPLE_TEMPLATE_SPACES_EMPTY_COLUMN = (
+EXP_ST_SPACES_EMPTY_COLUMN = (
     "sample_name\tcollection_timestamp\tdescription\thas_extracted_data\t"
     "has_physical_specimen\thost_subject_id\tlatitude\tlongitude\t"
     "physical_location\trequired_sample_info_status\tsample_type\t"
@@ -1623,6 +1639,35 @@ SAMPLE_TEMPLATE_NO_SAMPLE_NAMES_SOME_SPACES = (
     "\t\t\t\t\t \t\t\t\t \t\t\n"
     )
 
+SAMPLE_TEMPLATE_EMPTY_COLUMN = (
+    "sample_name\tcollection_timestamp\tdescription\thas_extracted_data\t"
+    "has_physical_specimen\thost_subject_id\tlatitude\tlongitude\t"
+    "physical_location\trequired_sample_info_status\tsample_type\t"
+    "str_column\n"
+    "2.Sample1\t2014-05-29 12:24:51\tTest Sample 1\tTrue\tTrue\t"
+    "NotIdentified\t42.42\t41.41\tlocation1\treceived\ttype1\t"
+    "\n"
+    "2.Sample2\t2014-05-29 12:24:51\t"
+    "Test Sample 2\tTrue\tTrue\tNotIdentified\t4.2\t1.1\tlocation1\treceived\t"
+    "type1\t\n"
+    "2.Sample3\t2014-05-29 12:24:51\tTest Sample 3\tTrue\t"
+    "True\tNotIdentified\t4.8\t4.41\tlocation1\treceived\ttype1\t"
+    "\n")
+
+SAMPLE_TEMPLATE_COLUMN_WITH_NAS = (
+    "sample_name\tcollection_timestamp\tdescription\thas_extracted_data\t"
+    "has_physical_specimen\thost_subject_id\tlatitude\tlongitude\t"
+    "physical_location\trequired_sample_info_status\tsample_type\t"
+    "str_column\n"
+    "2.Sample1\t2014-05-29 12:24:51\tTest Sample 1\tTrue\tTrue\t"
+    "NotIdentified\t42.42\t41.41\tlocation1\treceived\ttype1\t"
+    "NA\n"
+    "2.Sample2\t2014-05-29 12:24:51\t"
+    "Test Sample 2\tTrue\tTrue\tNotIdentified\t4.2\t1.1\tlocation1\treceived\t"
+    "type1\tNA\n"
+    "2.Sample3\t2014-05-29 12:24:51\tTest Sample 3\tTrue\t"
+    "True\tNotIdentified\t4.8\t4.41\tlocation1\treceived\ttype1\t"
+    "NA\n")
 
 SAMPLE_TEMPLATE_DICT_FORM = {
     'collection_timestamp': {'2.Sample1': '2014-05-29 12:24:51',
@@ -1693,6 +1738,71 @@ SAMPLE_TEMPLATE_NUMBER_SAMPLE_NAMES_DICT_FORM = {
     'str_column': {'002.000': 'Value for sample 1',
                    '1.11111': 'Value for sample 2',
                    '0.12121': 'Value for sample 3'}}
+
+ST_EMPTY_COLUMN_DICT_FORM = \
+    {'collection_timestamp': {'2.Sample1': '2014-05-29 12:24:51',
+                              '2.Sample2': '2014-05-29 12:24:51',
+                              '2.Sample3': '2014-05-29 12:24:51'},
+     'description': {'2.Sample1': 'Test Sample 1',
+                     '2.Sample2': 'Test Sample 2',
+                     '2.Sample3': 'Test Sample 3'},
+     'has_extracted_data': {'2.Sample1': True,
+                            '2.Sample2': True,
+                            '2.Sample3': True},
+     'has_physical_specimen': {'2.Sample1': True,
+                               '2.Sample2': True,
+                               '2.Sample3': True},
+     'host_subject_id': {'2.Sample1': 'NotIdentified',
+                         '2.Sample2': 'NotIdentified',
+                         '2.Sample3': 'NotIdentified'},
+     'latitude': {'2.Sample1': 42.420000000000002,
+                  '2.Sample2': 4.2000000000000002,
+                  '2.Sample3': 4.7999999999999998},
+     'longitude': {'2.Sample1': 41.409999999999997,
+                   '2.Sample2': 1.1000000000000001,
+                   '2.Sample3': 4.4100000000000001},
+     'physical_location': {'2.Sample1': 'location1',
+                           '2.Sample2': 'location1',
+                           '2.Sample3': 'location1'},
+     'required_sample_info_status': {'2.Sample1': 'received',
+                                     '2.Sample2': 'received',
+                                     '2.Sample3': 'received'},
+     'sample_type': {'2.Sample1': 'type1',
+                     '2.Sample2': 'type1',
+                     '2.Sample3': 'type1'}}
+
+ST_COLUMN_WITH_NAS_DICT_FORM = \
+    {'collection_timestamp': {'2.Sample1': '2014-05-29 12:24:51',
+                              '2.Sample2': '2014-05-29 12:24:51',
+                              '2.Sample3': '2014-05-29 12:24:51'},
+     'description': {'2.Sample1': 'Test Sample 1',
+                     '2.Sample2': 'Test Sample 2',
+                     '2.Sample3': 'Test Sample 3'},
+     'has_extracted_data': {'2.Sample1': True,
+                            '2.Sample2': True,
+                            '2.Sample3': True},
+     'has_physical_specimen': {'2.Sample1': True,
+                               '2.Sample2': True,
+                               '2.Sample3': True},
+     'host_subject_id': {'2.Sample1': 'NotIdentified',
+                         '2.Sample2': 'NotIdentified',
+                         '2.Sample3': 'NotIdentified'},
+     'latitude': {'2.Sample1': 42.420000000000002,
+                  '2.Sample2': 4.2000000000000002,
+                  '2.Sample3': 4.7999999999999998},
+     'longitude': {'2.Sample1': 41.409999999999997,
+                   '2.Sample2': 1.1000000000000001,
+                   '2.Sample3': 4.4100000000000001},
+     'physical_location': {'2.Sample1': 'location1',
+                           '2.Sample2': 'location1',
+                           '2.Sample3': 'location1'},
+     'required_sample_info_status': {'2.Sample1': 'received',
+                                     '2.Sample2': 'received',
+                                     '2.Sample3': 'received'},
+     'sample_type': {'2.Sample1': 'type1',
+                     '2.Sample2': 'type1',
+                     '2.Sample3': 'type1'},
+     'str_column': {'2.Sample1': 'NA', '2.Sample2': 'NA', '2.Sample3': 'NA'}}
 
 EXP_PREP_TEMPLATE = (
     'sample_name\tbarcodesequence\tcenter_name\tcenter_project_name\t'

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -1483,12 +1483,11 @@ class TestUtilities(TestCase):
         assert_frame_equal(obs, exp)
 
     def test_load_template_to_dataframe_empty_column(self):
-
-            obs = npt.assert_warns(UserWarning, load_template_to_dataframe,
-                                   StringIO(SAMPLE_TEMPLATE_EMPTY_COLUMN))
-            exp = pd.DataFrame.from_dict(ST_EMPTY_COLUMN_DICT_FORM)
-            exp.index.name = 'sample_name'
-            assert_frame_equal(obs, exp)
+        obs = npt.assert_warns(UserWarning, load_template_to_dataframe,
+                               StringIO(SAMPLE_TEMPLATE_EMPTY_COLUMN))
+        exp = pd.DataFrame.from_dict(ST_EMPTY_COLUMN_DICT_FORM)
+        exp.index.name = 'sample_name'
+        assert_frame_equal(obs, exp)
 
     def test_load_template_to_dataframe_column_with_nas(self):
         obs = load_template_to_dataframe(

--- a/qiita_pet/handlers/study_handlers/description_handlers.py
+++ b/qiita_pet/handlers/study_handlers/description_handlers.py
@@ -6,6 +6,9 @@
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
 from __future__ import division
+
+import warnings
+
 from os import remove
 from os.path import exists, join, basename
 from future.utils import viewvalues
@@ -170,8 +173,20 @@ class StudyDescriptionHandler(BaseHandler):
             raise HTTPError(400, "This file doesn't exist: %s" % fp_rsp)
 
         try:
-            # deleting previous uploads and inserting new one
-            self.remove_add_study_template(study.raw_data, study.id, fp_rsp)
+            with warnings.catch_warnings(record=True) as warns:
+                # force all warnings to always be triggered
+                warnings.simplefilter("always")
+
+                # deleting previous uploads and inserting new one
+                self.remove_add_study_template(study.raw_data, study.id,
+                                              fp_rsp)
+
+                # join all the warning messages into one. Note that this info
+                # will be ignored if an exception is raised
+                if warns:
+                    msg = '; '.join([str(w.message) for w in warns])
+                    msg_level = 'warning'
+
         except (TypeError, QiitaDBColumnError, QiitaDBExecutionError,
                 QiitaDBDuplicateError, IOError, ValueError, KeyError,
                 CParserError, QiitaDBDuplicateHeaderError) as e:
@@ -280,9 +295,20 @@ class StudyDescriptionHandler(BaseHandler):
             raise HTTPError(400, "This file doesn't exist: %s" % fp_rpt)
 
         try:
-            pt_id = self.remove_add_prep_template(fp_rpt, raw_data_id, study,
-                                                  data_type_id,
-                                                  investigation_type)
+            with warnings.catch_warnings(record=True) as warns:
+                # force all warnings to always be triggered
+                warnings.simplefilter("always")
+
+                # deleting previous uploads and inserting new one
+                pt_id = self.remove_add_prep_template(fp_rpt, raw_data_id,
+                                                      study, data_type_id,
+                                                      investigation_type)
+
+                # join all the warning messages into one. Note that this info
+                # will be ignored if an exception is raised
+                if warns:
+                    msg = '; '.join([str(w.message) for w in warns])
+                    msg_level = 'danger'
         except (TypeError, QiitaDBColumnError, QiitaDBExecutionError,
                 QiitaDBDuplicateError, IOError, ValueError,
                 CParserError) as e:

--- a/qiita_pet/handlers/study_handlers/description_handlers.py
+++ b/qiita_pet/handlers/study_handlers/description_handlers.py
@@ -184,8 +184,8 @@ class StudyDescriptionHandler(BaseHandler):
                 # join all the warning messages into one. Note that this info
                 # will be ignored if an exception is raised
                 if warns:
-                    msg_level = 'warning'
                     msg = '; '.join([str(w.message) for w in warns])
+                    msg_level = 'warning'
 
         except (TypeError, QiitaDBColumnError, QiitaDBExecutionError,
                 QiitaDBDuplicateError, IOError, ValueError, KeyError,
@@ -308,7 +308,7 @@ class StudyDescriptionHandler(BaseHandler):
                 # will be ignored if an exception is raised
                 if warns:
                     msg = '; '.join([str(w.message) for w in warns])
-                    msg_level = 'danger'
+                    msg_level = 'warning'
         except (TypeError, QiitaDBColumnError, QiitaDBExecutionError,
                 QiitaDBDuplicateError, IOError, ValueError,
                 CParserError) as e:

--- a/qiita_pet/handlers/study_handlers/description_handlers.py
+++ b/qiita_pet/handlers/study_handlers/description_handlers.py
@@ -179,13 +179,13 @@ class StudyDescriptionHandler(BaseHandler):
 
                 # deleting previous uploads and inserting new one
                 self.remove_add_study_template(study.raw_data, study.id,
-                                              fp_rsp)
+                                               fp_rsp)
 
                 # join all the warning messages into one. Note that this info
                 # will be ignored if an exception is raised
                 if warns:
-                    msg = '; '.join([str(w.message) for w in warns])
                     msg_level = 'warning'
+                    msg = '; '.join([str(w.message) for w in warns])
 
         except (TypeError, QiitaDBColumnError, QiitaDBExecutionError,
                 QiitaDBDuplicateError, IOError, ValueError, KeyError,

--- a/qiita_pet/templates/sitebase.html
+++ b/qiita_pet/templates/sitebase.html
@@ -97,7 +97,7 @@
     {% set message = sysmessage + "<br />" + str(message) %}
   {% end %}
   {% if message != '' %}
-      {% if level not in {'danger', 'success', 'info'} %}
+      {% if level not in {'danger', 'success', 'info', 'warning'} %}
           {% set level = 'info' %}
       {% end %}
       <div class="alert alert-{{ level }} alert-dismissable">


### PR DESCRIPTION
A UserWarning is now raised whenever load_template_to_dataframe drops a column
if it is empty. This message is shown on the interface as well.

Fixes #740