### PR TITLE
ENH/API: methods to update sample metadata

### DIFF
--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -1372,7 +1372,7 @@ class SampleTemplate(MetadataTemplate):
             NOT NULL DEFAULT '{3}'""".format(table_name, category, dtype,
                                              default))
 
-        self[column] = values
+        self[category] = values
 
 
 class PrepTemplate(MetadataTemplate):

--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -579,6 +579,40 @@ class Sample(BaseSample):
         if not isinstance(md_template, SampleTemplate):
             raise IncompetentQiitaDeveloperError()
 
+    def __setitem__(self, column, value):
+        r"""Sets the metadata value for the category `column`
+
+        Parameters
+        ----------
+        column : str
+            The column to update
+        value : str
+            The value to set. This is expected to be a str on the assumption
+            that psycopg2 will cast as necessary when updating.
+
+        Raises
+        ------
+        QiitaDBColumnError
+            If the column does not exist in the table
+        """
+        conn_handler = SQLConnectionHandler()
+
+        exists = conn_handler.execute_fetchone("""
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_name='{0}'
+                AND column_name='{1}'""".format(self._dynamic_table, column))
+
+        if exists is None:
+            raise QiitaDBColumnError("Column %s does not exist in %s" %
+                                     (column, self._dynamic_table))
+
+        conn_handler.execute("""
+            UPDATE qiita.{0}
+            SET {1}={2}
+            WHERE sample_id='{3}'""".format(self._dynamic_table, column, value,
+                                            self._id))
+
 
 class MetadataTemplate(QiitaObject):
     r"""Metadata map object that accesses the db to get the sample/prep
@@ -1051,6 +1085,27 @@ class MetadataTemplate(QiitaObject):
 
         return [(fpid, base_fp(fp)) for fpid, fp in filepath_ids]
 
+    def categories(self):
+        """Get the categories associated with self
+
+        Returns
+        -------
+        set
+            The set of categories associated with self
+        """
+        conn_handler = SQLConnectionHandler()
+        table_name = self._table_name(self.study_id)
+
+        raw = conn_handler.execute_fetchall("""
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_name='{0}'""".format(table_name))
+
+        categories = {c[0] for c in raw}
+        categories.remove('sample_id')
+
+        return categories
+
 
 class SampleTemplate(MetadataTemplate):
     r"""Represent the SampleTemplate of a study. Provides access to the
@@ -1231,6 +1286,93 @@ class SampleTemplate(MetadataTemplate):
             The ID of the study with which this sample template is associated
         """
         return self._id
+
+    def __delitem__(self, column):
+        """Remove a column from the sample template
+
+        Parameters
+        ----------
+        column : str
+            The column to remove
+
+        Raises
+        ------
+        QiitaDBColumnError
+            If the column does not exist in the table
+        """
+        table_name = self._table_name(self.study_id)
+        conn_handler = SQLConnectionHandler()
+
+        if column not in self.categories():
+            raise QiitaDBColumnError("Column %s does not exist in %s" %
+                                     (column, table_name))
+
+        # This operation may invalidate another user's perspective on the
+        # table
+        conn_handler.execute("""
+            ALTER TABLE qiita.{0} DROP COLUMN {1}""".format(table_name,
+                                                            column))
+
+    def __setitem__(self, column, values):
+        """Update an existing column
+
+        Parameters
+        ----------
+        column : str
+            The column to add or update
+        values : dict
+            A mapping of {sample_id: value}
+
+        Raises
+        ------
+        QiitaDBUnknownIDError
+            If a sample_id is included in values that is not in the template
+        QiitaDBColumnError
+            If the column does not exist in the table. This is implicit, and
+            can be thrown by the contained Samples.
+        """
+        if not set(self.keys()).issuperset(values):
+            missing = set(self.keys()) - set(values)
+            table_name = self._table_name(self.study_id)
+            raise QiitaDBUnknownIDError(missing, table_name)
+
+        for k, v in viewitems(values):
+            sample = self[k]
+            sample[column] = v
+
+    def add_category(self, column, values, dtype, default):
+        """Add a metadata category
+
+        Parameters
+        ----------
+        column : str
+            The column to add
+        values : dict
+            A mapping of {sample_id: value}
+        dtype : str
+            The datatype of the column
+        default : object
+            The default value associated with the column. This must be
+            specified as these columns are added "not null".
+
+        Raises
+        ------
+        QiitaDBDuplicateError
+            If the column already exists
+        """
+        table_name = self._table_name(self.study_id)
+        conn_handler = SQLConnectionHandler()
+
+        if column in self.categories():
+            raise QiitaDBDuplicateError(column, "N/A")
+
+        conn_handler.execute("""
+            ALTER TABLE qiita.{0}
+            ADD COLUMN {1} {2}
+            NOT NULL DEFAULT '{3}'""".format(table_name, column, dtype,
+                                             default))
+
+        self[column] = values
 
 
 class PrepTemplate(MetadataTemplate):

--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -1340,14 +1340,14 @@ class SampleTemplate(MetadataTemplate):
             sample = self[k]
             sample[category] = v
 
-    def add_category(self, category, values, dtype, default):
+    def add_category(self, category, samples_and_values, dtype, default):
         """Add a metadata category
 
         Parameters
         ----------
         category : str
             The category to add
-        values : dict
+        samples_and_values : dict
             A mapping of {sample_id: value}
         dtype : str
             The datatype of the column
@@ -1372,7 +1372,7 @@ class SampleTemplate(MetadataTemplate):
             NOT NULL DEFAULT '{3}'""".format(table_name, category, dtype,
                                              default))
 
-        self[category] = values
+        self.update_category(category, samples_and_values)
 
 
 class PrepTemplate(MetadataTemplate):

--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -1364,7 +1364,7 @@ class SampleTemplate(MetadataTemplate):
         conn_handler = SQLConnectionHandler()
 
         if category in self.categories():
-            raise QiitaDBDuplicateError(column, "N/A")
+            raise QiitaDBDuplicateError(category, "N/A")
 
         conn_handler.execute("""
             ALTER TABLE qiita.{0}

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -190,9 +190,11 @@ class TestSample(TestCase):
             self.tester['Not_a_Category']
 
     def test_setitem(self):
-        """setitem raises an error (currently not allowed)"""
-        with self.assertRaises(QiitaDBNotImplementedError):
-            self.tester['DEPTH'] = 0.30
+        with self.assertRaises(QiitaDBColumnError):
+            self.tester['column that does not exist'] = 0.30
+        self.assertEqual(self.tester['tot_nitro'], 1.41)
+        self.tester['tot_nitro'] = '1234.5'
+        self.assertEqual(self.tester['tot_nitro'], 1234.5)
 
     def test_delitem(self):
         """delitem raises an error (currently not allowed)"""
@@ -693,13 +695,88 @@ class TestSampleTemplate(TestCase):
 
     def test_setitem(self):
         """setitem raises an error (currently not allowed)"""
-        with self.assertRaises(QiitaDBNotImplementedError):
-            self.tester['1.SKM7.640188'] = Sample('1.SKM7.640188', self.tester)
+        with self.assertRaises(QiitaDBUnknownIDError):
+            self.tester['country'] = {"foo": "bar"}
+
+        with self.assertRaises(QiitaDBColumnError):
+            self.tester['missing column'] = {'1.SKM7.640188': 'stuff'}
+
+        negtest = self.tester['1.SKM7.640188']['country']
+
+        mapping = {'1.SKB1.640202': "1",
+                   '1.SKB5.640181': "2",
+                   '1.SKD6.640190': "3"}
+
+        self.tester['country'] = mapping
+
+        self.assertEqual(self.tester['1.SKB1.640202']['country'], "1")
+        self.assertEqual(self.tester['1.SKB5.640181']['country'], "2")
+        self.assertEqual(self.tester['1.SKD6.640190']['country'], "3")
+        self.assertEqual(self.tester['1.SKM7.640188']['country'], negtest)
+
+    def test_add_category(self):
+        column = "new_column"
+        dtype = "varchar"
+        default = "stuff"
+        mapping = {'1.SKB1.640202': "1",
+                   '1.SKB5.640181': "2",
+                   '1.SKD6.640190': "3"}
+
+        exp = {
+            '1.SKB1.640202': "1",
+            '1.SKB2.640194': "stuff",
+            '1.SKB3.640195': "stuff",
+            '1.SKB4.640189': "stuff",
+            '1.SKB5.640181': "2",
+            '1.SKB6.640176': "stuff",
+            '1.SKB7.640196': "stuff",
+            '1.SKB8.640193': "stuff",
+            '1.SKB9.640200': "stuff",
+            '1.SKD1.640179': "stuff",
+            '1.SKD2.640178': "stuff",
+            '1.SKD3.640198': "stuff",
+            '1.SKD4.640185': "stuff",
+            '1.SKD5.640186': "stuff",
+            '1.SKD6.640190': "3",
+            '1.SKD7.640191': "stuff",
+            '1.SKD8.640184': "stuff",
+            '1.SKD9.640182': "stuff",
+            '1.SKM1.640183': "stuff",
+            '1.SKM2.640199': "stuff",
+            '1.SKM3.640197': "stuff",
+            '1.SKM4.640180': "stuff",
+            '1.SKM5.640177': "stuff",
+            '1.SKM6.640187': "stuff",
+            '1.SKM7.640188': "stuff",
+            '1.SKM8.640201': "stuff",
+            '1.SKM9.640192': "stuff"}
+
+        self.tester.add_category(column, mapping, dtype, default)
+
+        obs = {k: v['new_column'] for k, v in self.tester.items()}
+        self.assertEqual(obs, exp)
+
+    def test_categories(self):
+        exp = {'season_environment',
+               'assigned_from_geo', 'texture', 'taxon_id', 'depth',
+               'host_taxid', 'common_name', 'water_content_soil', 'elevation',
+               'temp', 'tot_nitro', 'samp_salinity', 'altitude', 'env_biome',
+               'country', 'ph', 'anonymized_name', 'tot_org_carb',
+               'description_duplicate', 'env_feature'}
+        obs = self.tester.categories()
+        self.assertEqual(obs, exp)
 
     def test_delitem(self):
-        """delitem raises an error (currently not allowed)"""
-        with self.assertRaises(QiitaDBNotImplementedError):
+        with self.assertRaises(QiitaDBColumnError):
             del self.tester['1.SKM7.640188']
+
+        for v in self.tester.values():
+            self.assertIn('elevation', v)
+
+        del self.tester['elevation']
+
+        for v in self.tester.values():
+            self.assertNotIn('elevation', v)
 
     def test_iter(self):
         """iter returns an iterator over the sample ids"""

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -693,13 +693,14 @@ class TestSampleTemplate(TestCase):
         with self.assertRaises(KeyError):
             self.tester['Not_a_Sample']
 
-    def test_setitem(self):
+    def test_update_category(self):
         """setitem raises an error (currently not allowed)"""
         with self.assertRaises(QiitaDBUnknownIDError):
-            self.tester['country'] = {"foo": "bar"}
+            self.tester.update_category('country', {"foo": "bar"})
 
         with self.assertRaises(QiitaDBColumnError):
-            self.tester['missing column'] = {'1.SKM7.640188': 'stuff'}
+            self.tester.update_category('missing column',
+                                        {'1.SKM7.640188': 'stuff'})
 
         negtest = self.tester['1.SKM7.640188']['country']
 
@@ -707,7 +708,7 @@ class TestSampleTemplate(TestCase):
                    '1.SKB5.640181': "2",
                    '1.SKD6.640190': "3"}
 
-        self.tester['country'] = mapping
+        self.tester.update_category('country', mapping)
 
         self.assertEqual(self.tester['1.SKB1.640202']['country'], "1")
         self.assertEqual(self.tester['1.SKB5.640181']['country'], "2")
@@ -766,14 +767,14 @@ class TestSampleTemplate(TestCase):
         obs = self.tester.categories()
         self.assertEqual(obs, exp)
 
-    def test_delitem(self):
+    def test_remove_category(self):
         with self.assertRaises(QiitaDBColumnError):
-            del self.tester['1.SKM7.640188']
+            self.tester.remove_category('does not exist')
 
         for v in self.tester.values():
             self.assertIn('elevation', v)
 
-        del self.tester['elevation']
+        self.tester.remove_category('elevation')
 
         for v in self.tester.values():
             self.assertNotIn('elevation', v)


### PR DESCRIPTION
Partially addresses #822. These changes include:

* updating of existing sample metadata
* adding new columns
* removing columns

Right now, this is limited to the SampleTemplate, and support is not in
for the PrepTemplate. This would be easy to change, but put it in place
this way based on the email traffic I saw regarding the issue.

The API for get/set/del at the template level is not consistent yet. Pushing
in now to exercise full tests, and will issue follow up commits to resolve the
inconsistencies.