### PR TITLE
BUG: Fix error raised when editing a public study

### DIFF
--- a/qiita_pet/handlers/study_handlers/edit_handlers.py
+++ b/qiita_pet/handlers/study_handlers/edit_handlers.py
@@ -265,7 +265,7 @@ class StudyEditHandler(BaseHandler):
                    (the_study.id, form_data.data['study_title'][0]))
 
         # Add the environmental packages, this attribute can only be edited
-        # if the study is public, otherwise this cannot be changed
+        # if the study is not public, otherwise this cannot be changed
         if isinstance(form_data, StudyEditorExtendedForm):
             the_study.environmental_packages = form_data.data[
                 'environmental_packages']

--- a/qiita_pet/handlers/study_handlers/edit_handlers.py
+++ b/qiita_pet/handlers/study_handlers/edit_handlers.py
@@ -264,9 +264,11 @@ class StudyEditHandler(BaseHandler):
                    'successfully created' %
                    (the_study.id, form_data.data['study_title'][0]))
 
-        # Add the environmental packages
-        the_study.environmental_packages = form_data.data[
-            'environmental_packages']
+        # Add the environmental packages, this attribute can only be edited
+        # if the study is public, otherwise this cannot be changed
+        if isinstance(form_data, StudyEditorExtendedForm):
+            the_study.environmental_packages = form_data.data[
+                'environmental_packages']
 
         pubmed_ids = form_data.data['pubmed_id'][0]
         if pubmed_ids:


### PR DESCRIPTION
If a public study was to be edited, a KeyError would be raised as the 
environmental_packages attribute is non-editable once the study is viewable by
everyone.

Fixes #816