### PR TITLE
BUG: Enforce QIIME sample name naming conventions

### DIFF
--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -68,7 +68,6 @@ else:
     from string import letters, digits
 
 
-
 TARGET_GENE_DATA_TYPES = ['16S', '18S', 'ITS']
 REQUIRED_TARGET_GENE_COLS = {'barcodesequence', 'linkerprimersequence',
                              'run_prefix', 'library_construction_protocol',
@@ -1129,6 +1128,13 @@ class SampleTemplate(MetadataTemplate):
         if cls.exists(study.id):
             raise QiitaDBDuplicateError(cls.__name__, 'id: %d' % study.id)
 
+        invalid_ids = get_invalid_sample_names(md_template.index)
+        if invalid_ids:
+            raise QiitaDBColumnError("The following sample names in the sample"
+                                     " template contain invalid characters "
+                                     "(only alphanumeric characters or periods"
+                                     " are allowed): %s." %
+                                     ", ".join(invalid_ids))
         # We are going to modify the md_template. We create a copy so
         # we don't modify the user one
         md_template = deepcopy(md_template)
@@ -1290,6 +1296,14 @@ class PrepTemplate(MetadataTemplate):
         # the recognized investigation types
         if investigation_type is not None:
             cls.validate_investigation_type(investigation_type)
+
+        invalid_ids = get_invalid_sample_names(md_template.index)
+        if invalid_ids:
+            raise QiitaDBColumnError("The following sample names in the prep"
+                                     " template contain invalid characters "
+                                     "(only alphanumeric characters or periods"
+                                     " are allowed): %s." %
+                                     ", ".join(invalid_ids))
 
         # We are going to modify the md_template. We create a copy so
         # we don't modify the user one

--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -39,7 +39,7 @@ Methods
 
 from __future__ import division
 from future.builtins import zip
-from future.utils import viewitems
+from future.utils import viewitems, PY3
 from copy import deepcopy
 from os.path import join
 from time import strftime
@@ -61,6 +61,12 @@ from .util import (exists_table, get_table_cols, get_emp_status,
                    convert_from_id, find_repeated, get_mountpoint,
                    insert_filepaths)
 from .logger import LogEntry
+
+if PY3:
+    from string import ascii_letters as letters, digits
+else:
+    from string import letters, digits
+
 
 
 TARGET_GENE_DATA_TYPES = ['16S', '18S', 'ITS']
@@ -1782,3 +1788,33 @@ def load_template_to_dataframe(fn):
                       '%s' % ', '.join(dropped_cols), UserWarning)
 
     return template
+
+
+def get_invalid_sample_names(sample_names):
+    """Get a list of sample names that are not QIIME compliant
+
+    Parameters
+    ----------
+    sample_names : iterable
+        Iterable containing the sample names to check.
+
+    Returns
+    -------
+    list
+        List of str objects where each object is an invalid sample name.
+
+    References
+    ----------
+    .. [1] QIIME File Types documentaiton:
+    http://qiime.org/documentation/file_formats.html#mapping-file-overview.
+    """
+
+    # from the QIIME mapping file documentation
+    valid = set(letters+digits+'.')
+    inv = []
+
+    for s in sample_names:
+        if set(s) - valid:
+            inv.append(s)
+
+    return inv

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -601,6 +601,13 @@ class TestSampleTemplate(TestCase):
         with self.assertRaises(QiitaDBDuplicateHeaderError):
             SampleTemplate.create(self.metadata, self.new_study)
 
+    def test_create_bad_sample_names(self):
+        """Create raises an error when duplicate headers are present"""
+        # set a horrible list of sample names
+        self.metadata.index = ['o()xxxx[{::::::::>', 'sample.1', 'sample.3']
+        with self.assertRaises(QiitaDBColumnError):
+            SampleTemplate.create(self.metadata, self.new_study)
+
     def test_create(self):
         """Creates a new SampleTemplate"""
         st = SampleTemplate.create(self.metadata, self.new_study)
@@ -941,6 +948,13 @@ class TestPrepTemplate(TestCase):
         self.metadata['STR_COLUMN'] = pd.Series(['', '', ''],
                                                 index=self.metadata.index)
         with self.assertRaises(QiitaDBDuplicateHeaderError):
+            PrepTemplate.create(self.metadata, self.new_raw_data,
+                                self.test_study, self.data_type)
+
+    def test_create_bad_sample_names(self):
+        # set a horrible list of sample names
+        self.metadata.index = ['o()xxxx[{::::::::>', 'sample.1', 'sample.3']
+        with self.assertRaises(QiitaDBColumnError):
             PrepTemplate.create(self.metadata, self.new_raw_data,
                                 self.test_study, self.data_type)
 


### PR DESCRIPTION
Sample and prep templates are now checked to ensure there are not invalid
characters in any sample name.

Fixes #792