### PR TITLE
BUG: Improve message when sample_name isn't found

### DIFF
--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -1895,6 +1895,8 @@ def load_template_to_dataframe(fn):
 
     Raises
     ------
+    QiitaDBColumnError
+        If the sample_name column is not present in the template.
     UserWarning
         When columns are dropped because they have no content for any sample.
 
@@ -1927,6 +1929,10 @@ def load_template_to_dataframe(fn):
                                'sample_name': lambda x: str(x).strip()})
 
     initial_columns = set(template.columns)
+
+    if 'sample_name' not in template.columns:
+        raise QiitaDBColumnError("The 'sample_name' column is missing from "
+                                 "your template, this file cannot be parsed.")
 
     # remove rows that have no sample identifier but that may have other data
     # in the rest of the columns

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -1588,6 +1588,14 @@ class TestUtilities(TestCase):
         exp.index.name = 'sample_name'
         assert_frame_equal(obs, exp)
 
+    def test_load_template_to_dataframe_exception(self):
+        with self.assertRaises(QiitaDBColumnError):
+            x = load_template_to_dataframe(
+                StringIO(SAMPLE_TEMPLATE_NO_SAMPLE_NAME))
+
+            # prevent flake8 from complaining
+            x.strip()
+
     def test_get_invalid_sample_names(self):
         all_valid = ['2.sample.1', 'foo.bar.baz', 'roses', 'are', 'red',
                      'v10l3t5', '4r3', '81u3']
@@ -1777,6 +1785,21 @@ SAMPLE_TEMPLATE_EMPTY_COLUMN = (
 
 SAMPLE_TEMPLATE_COLUMN_WITH_NAS = (
     "sample_name\tcollection_timestamp\tdescription\thas_extracted_data\t"
+    "has_physical_specimen\thost_subject_id\tlatitude\tlongitude\t"
+    "physical_location\trequired_sample_info_status\tsample_type\t"
+    "str_column\n"
+    "2.Sample1\t2014-05-29 12:24:51\tTest Sample 1\tTrue\tTrue\t"
+    "NotIdentified\t42.42\t41.41\tlocation1\treceived\ttype1\t"
+    "NA\n"
+    "2.Sample2\t2014-05-29 12:24:51\t"
+    "Test Sample 2\tTrue\tTrue\tNotIdentified\t4.2\t1.1\tlocation1\treceived\t"
+    "type1\tNA\n"
+    "2.Sample3\t2014-05-29 12:24:51\tTest Sample 3\tTrue\t"
+    "True\tNotIdentified\t4.8\t4.41\tlocation1\treceived\ttype1\t"
+    "NA\n")
+
+SAMPLE_TEMPLATE_NO_SAMPLE_NAME = (
+    ":L}={\tcollection_timestamp\tdescription\thas_extracted_data\t"
     "has_physical_specimen\thost_subject_id\tlatitude\tlongitude\t"
     "physical_location\trequired_sample_info_status\tsample_type\t"
     "str_column\n"


### PR DESCRIPTION
Raise a more appropriate exception when the sample_name column is not found in
the template.

Fixes #713