### PR TITLE
deletes raw data

### DIFF
--- a/qiita_db/data.py
+++ b/qiita_db/data.py
@@ -85,7 +85,7 @@ from qiita_core.exceptions import IncompetentQiitaDeveloperError
 from .base import QiitaObject
 from .logger import LogEntry
 from .sql_connection import SQLConnectionHandler
-from .exceptions import QiitaDBError
+from .exceptions import QiitaDBError, QiitaDBUnknownIDError
 from .util import (exists_dynamic_table, insert_filepaths, convert_to_id,
                    convert_from_id, purge_filepaths, get_filepath_id,
                    get_mountpoint, move_filepaths_to_upload_folder)
@@ -255,7 +255,7 @@ class BaseData(QiitaObject):
         Returns
         -------
         bool
-            True if already exists. False otherwise.
+            True if exists, false otherwise.
         """
         conn_handler = SQLConnectionHandler()
 
@@ -342,8 +342,9 @@ class RawData(BaseData):
 
         Raises
         ------
-        ValueError
+        QiitaDBUnknownIDError
             If the raw data id doesn't exist
+        QiitaDBError
             If the raw data is not linked to that study_id
             If the raw data has prep templates associated
         """
@@ -351,26 +352,41 @@ class RawData(BaseData):
 
         # check if the raw data exist
         if not cls.exists(raw_data_id):
-            raise ValueError("Raw data: %s doesn't exist." % str(raw_data_id))
+            raise QiitaDBUnknownIDError(raw_data_id, "raw data")
 
         study_raw_data_exists = conn_handler.execute_fetchone(
             "SELECT EXISTS(SELECT * FROM qiita.study_raw_data WHERE "
             "study_id = {0} AND raw_data_id = {1})".format(study_id,
                                                            raw_data_id))[0]
         if not study_raw_data_exists:
-            raise ValueError(
-                "Raw data %s is not linked to study %s" % (raw_data_id,
-                                                           study_id))
+            raise QiitaDBError(
+                "Raw data %d is not linked to study %d or the study "
+                "doesn't exist" % (raw_data_id, study_id))
 
-        # check if there are any prep templates
+        # check if there are any prep templates for this study
         prep_template_count = conn_handler.execute_fetchone(
-            "SELECT COUNT(*) FROM qiita.prep_template WHERE "
-            "raw_data_id = {0}".format(raw_data_id))[0]
+            """SELECT COUNT(*) FROM qiita.prep_template AS pt
+            LEFT JOIN qiita.common_prep_info AS cpi ON
+                (pt.prep_template_id=cpi.prep_template_id)
+            LEFT JOIN qiita.required_sample_info AS rsi ON
+                (cpi.sample_id=rsi.sample_id)
+            WHERE raw_data_id = {0} and study_id = {1}""".format(raw_data_id,
+                                                                 study_id))[0]
 
         if (prep_template_count > 0):
-            raise ValueError("Raw data: %s, has %d prep templates associated "
-                             "so it can't be erased." % (str(raw_data_id),
-                                                         prep_template_count))
+            raise QiitaDBError(
+                "Raw data %d has prep template(s) associated so it can't be "
+                "erased." % raw_data_id)
+
+        # check if how many raw data are left, if last one, check that there
+        # are no linked files
+        raw_data_count = conn_handler.execute_fetchone(
+            "SELECT COUNT(*) FROM qiita.study_raw_data WHERE "
+            "raw_data_id = {0}".format(raw_data_id))[0]
+        if raw_data_count == 1 and RawData(raw_data_id).get_filepath_ids():
+            raise QiitaDBError(
+                "Raw data (%d) can't be remove because it has linked files. "
+                "To remove it, first unlink files." % raw_data_id)
 
         # delete
         conn_handler.execute("DELETE FROM qiita.study_raw_data WHERE "

--- a/qiita_db/test/test_data.py
+++ b/qiita_db/test/test_data.py
@@ -261,6 +261,28 @@ class RawDataTests(TestCase):
         with self.assertRaises(QiitaDBError):
             RawData(2).remove_filepath(fp)
 
+    def test_exists(self):
+        self.assertTrue(RawData.exists(1))
+        self.assertFalse(RawData.exists(1000))
+
+    def test_delete(self):
+        # the raw data doesn't exist
+        with self.assertRaises(ValueError):
+            RawData.delete(1000, 1)
+
+        # the raw data and the study id are not linked
+        with self.assertRaises(ValueError):
+            RawData.delete(1, 1000)
+
+        # the raw data has prep templates
+        with self.assertRaises(ValueError):
+            RawData.delete(1, 1)
+
+        # delete raw data
+        self.assertTrue(RawData.exists(2))
+        RawData.delete(2, 1)
+        self.assertFalse(RawData.exists(2))
+
 
 @qiita_test_checker()
 class PreprocessedDataTests(TestCase):
@@ -607,6 +629,10 @@ class PreprocessedDataTests(TestCase):
                                       data_type="18S")
         with self.assertRaises(ValueError):
             ppd.processing_status = 'not a valid state'
+
+    def test_exists(self):
+        self.assertTrue(PreprocessedData.exists(1))
+        self.assertFalse(PreprocessedData.exists(1000))
 
 
 @qiita_test_checker()

--- a/qiita_db/test/test_data.py
+++ b/qiita_db/test/test_data.py
@@ -284,8 +284,8 @@ class RawDataTests(TestCase):
             RawData.delete(3, 1)
 
         # the raw data is linked to a study that has not prep templates
-        Study(2).add_raw_data([RawData(3)])
-        RawData.delete(3, 2)
+        Study(2).add_raw_data([RawData(1)])
+        RawData.delete(1, 2)
 
         # delete raw data
         self.assertTrue(RawData.exists(2))

--- a/qiita_pet/handlers/study_handlers/description_handlers.py
+++ b/qiita_pet/handlers/study_handlers/description_handlers.py
@@ -609,7 +609,7 @@ class StudyDescriptionHandler(BaseHandler):
             msg_level = "danger"
             tab = 'raw_data_tab'
             tab_id = raw_data_id
-            
+
         callback((msg, msg_level, tab, tab_id, None))
 
     @authenticated

--- a/qiita_pet/handlers/study_handlers/description_handlers.py
+++ b/qiita_pet/handlers/study_handlers/description_handlers.py
@@ -595,19 +595,22 @@ class StudyDescriptionHandler(BaseHandler):
             The callback function to call with the results once the processing
             is done
         """
-        raw_data_id = self.get_argument('raw_data_id')
+        raw_data_id = int(self.get_argument('raw_data_id'))
 
         try:
             RawData.delete(raw_data_id, study.id)
-            msg = ("Raw data %s has been deleted from study: "
-                   "<b><i>%s</i></b>" % (str(raw_data_id), study.title))
+            msg = ("Raw data %d has been deleted from study: "
+                   "<b><i>%s</i></b>" % (raw_data_id, study.title))
             msg_level = "success"
+            tab = 'study_information_tab'
+            tab_id = None
         except Exception as e:
-            msg = "Couldn't remove %s raw data: %s" % (str(raw_data_id),
-                                                       str(e))
+            msg = "Couldn't remove %d raw data: %s" % (raw_data_id, str(e))
             msg_level = "danger"
-
-        callback((msg, msg_level, 'study_information_tab', None, None))
+            tab = 'raw_data_tab'
+            tab_id = raw_data_id
+            
+        callback((msg, msg_level, tab, tab_id, None))
 
     @authenticated
     def get(self, study_id):

--- a/qiita_pet/handlers/study_handlers/description_handlers.py
+++ b/qiita_pet/handlers/study_handlers/description_handlers.py
@@ -582,6 +582,33 @@ class StudyDescriptionHandler(BaseHandler):
                     sub_tab=sub_tab,
                     prep_tab=prep_tab)
 
+    def delete_raw_data(self, study, user, callback):
+        """Delete the selected raw data
+
+        Parameters
+        ----------
+        study : Study
+            The current study object
+        user : User
+            The current user object
+        callback : function
+            The callback function to call with the results once the processing
+            is done
+        """
+        raw_data_id = self.get_argument('raw_data_id')
+
+        try:
+            RawData.delete(raw_data_id, study.id)
+            msg = ("Raw data %s has been deleted from study: "
+                   "<b><i>%s</i></b>" % (str(raw_data_id), study.title))
+            msg_level = "success"
+        except Exception as e:
+            msg = "Couldn't remove %s raw data: %s" % (str(raw_data_id),
+                                                       str(e))
+            msg_level = "danger"
+
+        callback((msg, msg_level, 'study_information_tab', None, None))
+
     @authenticated
     def get(self, study_id):
         study, user = self._get_sudy_and_check_access(study_id)
@@ -608,7 +635,8 @@ class StudyDescriptionHandler(BaseHandler):
             approve_study=self.approve_study,
             request_approval=self.request_approval,
             make_sandbox=self.make_sandbox,
-            update_investigation_type=self.update_investigation_type)
+            update_investigation_type=self.update_investigation_type,
+            delete_raw_data=self.delete_raw_data)
 
         # Get the action that we need to perform
         action = self.get_argument("action", None)

--- a/qiita_pet/templates/study_description.html
+++ b/qiita_pet/templates/study_description.html
@@ -153,8 +153,8 @@ function add_prep_template(raw_data_id) {
 }
 
 
-function delete_raw_data(raw_data_id) {
-  if (confirm("Are you sure you want to delete raw data " + raw_data_id + "?")) {
+function delete_raw_data(raw_data_filetype, raw_data_id) {
+  if (confirm('Are you sure you want to delete raw data: ' + raw_data_filetype + ' (ID: ' + raw_data_id + ')?')) {
     var form = $("<form>")
     .attr("action", window.location.href)
     .attr("method", "post")

--- a/qiita_pet/templates/study_description.html
+++ b/qiita_pet/templates/study_description.html
@@ -154,7 +154,7 @@ function add_prep_template(raw_data_id) {
 
 
 function delete_raw_data(raw_data_id) {
-  if (confirm("Are you sure you want to delete this raw data?")) {
+  if (confirm("Are you sure you want to delete raw data " + raw_data_id + "?")) {
     var form = $("<form>")
     .attr("action", window.location.href)
     .attr("method", "post")

--- a/qiita_pet/templates/study_description.html
+++ b/qiita_pet/templates/study_description.html
@@ -152,6 +152,25 @@ function add_prep_template(raw_data_id) {
   }
 }
 
+
+function delete_raw_data(raw_data_id) {
+  if (confirm("Are you sure you want to delete this raw data?")) {
+    var form = $("<form>")
+    .attr("action", window.location.href)
+    .attr("method", "post")
+    .append($("<input>")
+    .attr("type", "hidden")
+    .attr("name", "raw_data_id")
+    .attr("value", raw_data_id))
+    .append($("<input>")
+    .attr("type", "hidden")
+    .attr("name", "action")
+    .attr("value", "delete_raw_data"));
+    $("body").append(form);
+    form.submit();
+  }
+}
+
 function make_public() {
   if (confirm("Are you sure you want to make this study public?")) {
     var form = $("<form>")

--- a/qiita_pet/templates/study_description_templates/raw_data_editor_tab.html
+++ b/qiita_pet/templates/study_description_templates/raw_data_editor_tab.html
@@ -60,7 +60,19 @@
           </li>
         </ol>
         <br/>
-        <a class="btn btn-primary" onclick="add_prep_template({{raw_data_id}});">Add prep template</a>
+        <table border="0">
+          <tr>
+            <td>
+              <a class="btn btn-primary" onclick="add_prep_template({{raw_data_id}});">Add prep template</a>
+            </td>
+            <td>&nbsp; &nbsp;</td>
+            <td>
+              <a class="btn btn-danger" onclick="if ({{len(available_prep_templates)}} > 0) { alert('This raw data can\'t be erased. First remove the attached prep templates') } else { delete_raw_data({{raw_data_id}}) }">
+                <span class="glyphicon glyphicon-trash"></span> Delete raw data
+              </a>
+            </td>
+          </tr>
+        </table>
         <br/>
         <hr/>
       {% end %}

--- a/qiita_pet/templates/study_description_templates/raw_data_editor_tab.html
+++ b/qiita_pet/templates/study_description_templates/raw_data_editor_tab.html
@@ -60,19 +60,7 @@
           </li>
         </ol>
         <br/>
-        <table border="0">
-          <tr>
-            <td>
-              <a class="btn btn-primary" onclick="add_prep_template({{raw_data_id}});">Add prep template</a>
-            </td>
-            <td>&nbsp; &nbsp;</td>
-            <td>
-              <a class="btn btn-danger" onclick="if ({{len(available_prep_templates)}} > 0) { alert('This raw data can\'t be erased. First remove the attached prep templates') } else { delete_raw_data({{raw_data_id}}) }">
-                <span class="glyphicon glyphicon-trash"></span> Delete raw data
-              </a>
-            </td>
-          </tr>
-        </table>
+        <a class="btn btn-primary" onclick="add_prep_template({{raw_data_id}});">Add prep template</a>
         <br/>
         <hr/>
       {% end %}

--- a/qiita_pet/templates/study_description_templates/raw_data_tab.html
+++ b/qiita_pet/templates/study_description_templates/raw_data_tab.html
@@ -5,7 +5,10 @@
     <li class="active"><a href="#add_raw_data_tab" role="tab" data-toggle="tab">Add raw data</a></li>
     <!-- Nav tabs: one for each raw data available -->
   {% for rd_id, rd_filetype, _ in available_raw_data %}
-    <li><a href="#raw_data_info_{{rd_id}}" role="tab" data-toggle="tab">{{rd_filetype}} (ID: {{rd_id}})</a></li>
+    <li><a href="#raw_data_info_{{rd_id}}" role="tab" data-toggle="tab">
+      {{rd_filetype}} (ID: {{rd_id}})
+      <button class="close" title="Remove this raw data" type="button" onclick="delete_raw_data({{rd_id}})">&nbsp; ×</button> 
+    </a></li>
   {% end %}
   </ul>
 

--- a/qiita_pet/templates/study_description_templates/raw_data_tab.html
+++ b/qiita_pet/templates/study_description_templates/raw_data_tab.html
@@ -7,7 +7,7 @@
   {% for rd_id, rd_filetype, _ in available_raw_data %}
     <li><a href="#raw_data_info_{{rd_id}}" role="tab" data-toggle="tab">
       {{rd_filetype}} (ID: {{rd_id}})
-      <button class="close" title="Remove this raw data" type="button" onclick="delete_raw_data({{rd_id}})">&nbsp; ×</button> 
+      <button class="close" title="Remove this raw data" type="button" onclick="delete_raw_data('{{rd_filetype}}', {{rd_id}})">&nbsp; ×</button> 
     </a></li>
   {% end %}
   </ul>


### PR DESCRIPTION
Add the possibility of removing raw data. Raw data can only be removed if there are not prep templates added, this functionality will be in another PR. There are 2 delete levels: if there is more studies link to the raw data, only the study_raw_data connection is removed, and if the raw data is the last one, it will remove all connections.

This also adds the exists method at the BaseData level. 