### PR TITLE
Fixes #790

### DIFF
--- a/qiita_db/exceptions.py
+++ b/qiita_db/exceptions.py
@@ -7,6 +7,8 @@
 # -----------------------------------------------------------------------------
 
 from __future__ import division
+import warnings
+
 from qiita_core.exceptions import QiitaError
 
 
@@ -71,3 +73,10 @@ class QiitaDBIncompatibleDatatypeError(QiitaDBError):
         super(QiitaDBIncompatibleDatatypeError, self).__init__()
         self.args = ("The %s operator is not for use with data of type %s" %
                      (operator, str(argument_type)))
+
+
+class QiitaDBWarning(UserWarning):
+    """Warning specific for the QiitaDB domain"""
+    pass
+
+warnings.simplefilter('always', QiitaDBWarning)

--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -48,6 +48,7 @@ from functools import partial
 import pandas as pd
 import numpy as np
 import warnings
+warnings.simplefilter('always', UserWarning)
 
 from qiita_core.exceptions import IncompetentQiitaDeveloperError
 from .exceptions import (QiitaDBDuplicateError, QiitaDBColumnError,
@@ -145,13 +146,14 @@ def _prefix_sample_names_with_id(md_template, study):
         The study to which the metadata belongs to
     """
     # Get all the prefixes of the index, defined as any string before a '.'
-    prefixes = {idx.split('.')[0] for idx in md_template.index}
+    prefixes = {idx.split('.', 1)[0] for idx in md_template.index}
     # If the samples have been already prefixed with the study id, the prefixes
     # set will contain only one element and it will be the str representation
     # of the study id
     if len(prefixes) == 1 and prefixes.pop() == str(study.id):
         # The samples were already prefixed with the study id
-        warnings.warn("Sample names were already prefixed with the study id.")
+        warnings.warn("Sample names were already prefixed with the study id.",
+                      UserWarning)
     else:
         # Create a new pandas series in which all the values are the study_id
         # and it is indexed as the metadata template

--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -144,20 +144,30 @@ def _prefix_sample_names_with_id(md_template, study):
     study : Study
         The study to which the metadata belongs to
     """
-    # Create a new pandas series in which all the values are the study_id and
-    # it is indexed as the metadata template
-    study_ids = pd.Series([str(study.id)] * len(md_template.index),
-                          index=md_template.index)
-    # Create a new column on the metadata template that includes the metadata
-    # template indexes prefixed with the study id
-    md_template['sample_name_with_id'] = study_ids + '.' + md_template.index
-    # Assign the new previously created column as the new index
-    md_template.index = md_template.sample_name_with_id
-    # Delete the previously created column
-    del md_template['sample_name_with_id']
-    # The original metadata template had the index column unnamed - remove
-    # the name of the index
-    md_template.index.name = None
+    # Before we prefix the sample names with the study id, we should check if
+    # they have already prefixed with it
+    # Get all the prefixes of the index, defined as any string before a '.'
+    prefixes = set([idx.split('.')[0] for idx in md_template.index])
+    # If the samples have been already prefixed with the study id, the prefixes
+    # set will contain only one element and it will be the str representation
+    # of the study id
+    if not (len(prefixes) == 1 and prefixes.pop() == str(study.id)):
+        # The sample have not been prefixed, so prefix them with the study_id
+        # Create a new pandas series in which all the values are the study_id
+        # and it is indexed as the metadata template
+        study_ids = pd.Series([str(study.id)] * len(md_template.index),
+                              index=md_template.index)
+        # Create a new column on the metadata template that includes the
+        # metadata template indexes prefixed with the study id
+        md_template['sample_name_with_id'] = (study_ids + '.' +
+                                              md_template.index)
+        # Assign the new previously created column as the new index
+        md_template.index = md_template.sample_name_with_id
+        # Delete the previously created column
+        del md_template['sample_name_with_id']
+        # The original metadata template had the index column unnamed - remove
+        # the name of the index
+        md_template.index.name = None
 
 
 class BaseSample(QiitaObject):

--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -152,7 +152,9 @@ def _prefix_sample_names_with_id(md_template, study):
     # set will contain only one element and it will be the str representation
     # of the study id
     if not (len(prefixes) == 1 and prefixes.pop() == str(study.id)):
-        # The sample have not been prefixed, so prefix them with the study_id
+        warnings.warn("Sample names where not prefixed with the study id. "
+                      "Adding the study id as prefix")
+        # The samples have not been prefixed, so prefix them with the study_id
         # Create a new pandas series in which all the values are the study_id
         # and it is indexed as the metadata template
         study_ids = pd.Series([str(study.id)] * len(md_template.index),

--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -48,12 +48,12 @@ from functools import partial
 import pandas as pd
 import numpy as np
 import warnings
-warnings.simplefilter('always', UserWarning)
 
 from qiita_core.exceptions import IncompetentQiitaDeveloperError
 from .exceptions import (QiitaDBDuplicateError, QiitaDBColumnError,
                          QiitaDBUnknownIDError, QiitaDBNotImplementedError,
-                         QiitaDBDuplicateHeaderError, QiitaDBError)
+                         QiitaDBDuplicateHeaderError, QiitaDBError,
+                         QiitaDBWarning)
 from .base import QiitaObject
 from .sql_connection import SQLConnectionHandler
 from .ontology import Ontology
@@ -153,7 +153,7 @@ def _prefix_sample_names_with_id(md_template, study):
     if len(prefixes) == 1 and prefixes.pop() == str(study.id):
         # The samples were already prefixed with the study id
         warnings.warn("Sample names were already prefixed with the study id.",
-                      UserWarning)
+                      QiitaDBWarning)
     else:
         # Create a new pandas series in which all the values are the study_id
         # and it is indexed as the metadata template
@@ -1913,7 +1913,7 @@ def load_template_to_dataframe(fn):
     ------
     QiitaDBColumnError
         If the sample_name column is not present in the template.
-    UserWarning
+    QiitaDBWarning
         When columns are dropped because they have no content for any sample.
 
     Notes
@@ -1965,7 +1965,7 @@ def load_template_to_dataframe(fn):
     if dropped_cols:
         warnings.warn('The following column(s) were removed from the template '
                       'because all their values are empty: '
-                      '%s' % ', '.join(dropped_cols), UserWarning)
+                      '%s' % ', '.join(dropped_cols), QiitaDBWarning)
 
     return template
 

--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -144,17 +144,15 @@ def _prefix_sample_names_with_id(md_template, study):
     study : Study
         The study to which the metadata belongs to
     """
-    # Before we prefix the sample names with the study id, we should check if
-    # they have already prefixed with it
     # Get all the prefixes of the index, defined as any string before a '.'
-    prefixes = set([idx.split('.')[0] for idx in md_template.index])
+    prefixes = {idx.split('.')[0] for idx in md_template.index}
     # If the samples have been already prefixed with the study id, the prefixes
     # set will contain only one element and it will be the str representation
     # of the study id
     if len(prefixes) == 1 and prefixes.pop() == str(study.id):
+        # The samples were already prefixed with the study id
         warnings.warn("Sample names were already prefixed with the study id.")
     else:
-        # The samples have not been prefixed, so prefix them with the study_id
         # Create a new pandas series in which all the values are the study_id
         # and it is indexed as the metadata template
         study_ids = pd.Series([str(study.id)] * len(md_template.index),
@@ -163,12 +161,10 @@ def _prefix_sample_names_with_id(md_template, study):
         # metadata template indexes prefixed with the study id
         md_template['sample_name_with_id'] = (study_ids + '.' +
                                               md_template.index)
-        # Assign the new previously created column as the new index
         md_template.index = md_template.sample_name_with_id
-        # Delete the previously created column
         del md_template['sample_name_with_id']
         # The original metadata template had the index column unnamed - remove
-        # the name of the index
+        # the name of the index for consistency
         md_template.index.name = None
 
 

--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -151,9 +151,9 @@ def _prefix_sample_names_with_id(md_template, study):
     # If the samples have been already prefixed with the study id, the prefixes
     # set will contain only one element and it will be the str representation
     # of the study id
-    if not (len(prefixes) == 1 and prefixes.pop() == str(study.id)):
-        warnings.warn("Sample names where not prefixed with the study id. "
-                      "Adding the study id as prefix")
+    if len(prefixes) == 1 and prefixes.pop() == str(study.id):
+        warnings.warn("Sample names were already prefixed with the study id.")
+    else:
         # The samples have not been prefixed, so prefix them with the study_id
         # Create a new pandas series in which all the values are the study_id
         # and it is indexed as the metadata template

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -26,7 +26,8 @@ from qiita_db.exceptions import (QiitaDBDuplicateError, QiitaDBUnknownIDError,
                                  QiitaDBNotImplementedError,
                                  QiitaDBDuplicateHeaderError,
                                  QiitaDBExecutionError,
-                                 QiitaDBColumnError, QiitaDBError)
+                                 QiitaDBColumnError, QiitaDBError,
+                                 QiitaDBWarning)
 from qiita_db.study import Study, StudyPerson
 from qiita_db.user import User
 from qiita_db.data import RawData
@@ -861,7 +862,7 @@ class TestSampleTemplate(TestCase):
 
     def test_create_already_prefixed_samples(self):
         """Creates a new SampleTemplate with the samples already prefixed"""
-        st = npt.assert_warns(UserWarning, SampleTemplate.create,
+        st = npt.assert_warns(QiitaDBWarning, SampleTemplate.create,
                               self.metadata_prefixed, self.new_study)
         # The returned object has the correct id
         self.assertEqual(st.id, 2)
@@ -1390,7 +1391,7 @@ class TestPrepTemplate(TestCase):
 
     def test_create_already_prefixed_samples(self):
         """Creates a new PrepTemplate"""
-        pt = npt.assert_warns(UserWarning, PrepTemplate.create,
+        pt = npt.assert_warns(QiitaDBWarning, PrepTemplate.create,
                               self.metadata_prefixed, self.new_raw_data,
                               self.test_study, self.data_type)
         # The returned object has the correct id
@@ -1891,7 +1892,7 @@ class TestUtilities(TestCase):
         assert_frame_equal(obs, exp)
 
     def test_load_template_to_dataframe_empty_columns(self):
-        obs = npt.assert_warns(UserWarning, load_template_to_dataframe,
+        obs = npt.assert_warns(QiitaDBWarning, load_template_to_dataframe,
                                StringIO(EXP_ST_SPACES_EMPTY_COLUMN))
         exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_DICT_FORM)
         exp.index.name = 'sample_name'
@@ -1928,7 +1929,7 @@ class TestUtilities(TestCase):
         assert_frame_equal(obs, exp)
 
     def test_load_template_to_dataframe_empty_column(self):
-        obs = npt.assert_warns(UserWarning, load_template_to_dataframe,
+        obs = npt.assert_warns(QiitaDBWarning, load_template_to_dataframe,
                                StringIO(SAMPLE_TEMPLATE_EMPTY_COLUMN))
         exp = pd.DataFrame.from_dict(ST_EMPTY_COLUMN_DICT_FORM)
         exp.index.name = 'sample_name'

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -861,7 +861,8 @@ class TestSampleTemplate(TestCase):
 
     def test_create_already_prefixed_samples(self):
         """Creates a new SampleTemplate with the samples already prefixed"""
-        st = SampleTemplate.create(self.metadata_prefixed, self.new_study)
+        st = npt.assert_warns(UserWarning, SampleTemplate.create,
+                              self.metadata_prefixed, self.new_study)
         # The returned object has the correct id
         self.assertEqual(st.id, 2)
 
@@ -1389,8 +1390,9 @@ class TestPrepTemplate(TestCase):
 
     def test_create_already_prefixed_samples(self):
         """Creates a new PrepTemplate"""
-        pt = PrepTemplate.create(self.metadata_prefixed, self.new_raw_data,
-                                 self.test_study, self.data_type)
+        pt = npt.assert_warns(UserWarning, PrepTemplate.create,
+                              self.metadata_prefixed, self.new_raw_data,
+                              self.test_study, self.data_type)
         # The returned object has the correct id
         self.assertEqual(pt.id, 2)
 


### PR DESCRIPTION
Checks that the samples have not been already prefixed with the study. If they are, it does not prefix them again. If not, it prefixes them with the study id.