### PR TITLE
Queues for adding templates

### DIFF
--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -1479,6 +1479,8 @@ class PrepTemplate(MetadataTemplate):
 
         # Get a connection handler
         conn_handler = SQLConnectionHandler()
+        queue_name = "CREATE_PREP_TEMPLATE_%d" % raw_data.id
+        conn_handler.create_queue(queue_name)
 
         # Check if the data_type is the id or the string
         if isinstance(data_type, (int, long)):
@@ -1516,6 +1518,8 @@ class PrepTemplate(MetadataTemplate):
                                      % ', '.join(missing))
 
         # Insert the metadata template
+        # We need the prep_id for multiple calls below, which currently is not
+        # supported by the queue system. Thus, executing this outside the queue
         prep_id = conn_handler.execute_fetchone(
             "INSERT INTO qiita.prep_template (data_type_id, raw_data_id, "
             "investigation_type) VALUES (%s, %s, %s) RETURNING "
@@ -1527,12 +1531,13 @@ class PrepTemplate(MetadataTemplate):
         values.insert(0, sample_ids)
         values.insert(0, [prep_id] * num_samples)
         values = [v for v in zip(*values)]
-        conn_handler.executemany(
+        conn_handler.add_to_queue(
+            queue_name,
             "INSERT INTO qiita.{0} ({1}, sample_id, {2}) "
             "VALUES (%s, %s, {3})".format(
                 cls._table, cls._id_column, ', '.join(db_cols),
                 ', '.join(['%s'] * len(db_cols))),
-            values)
+            values, many=True)
 
         # Insert rows on *_columns table
         headers = list(set(headers).difference(db_cols))
@@ -1543,16 +1548,18 @@ class PrepTemplate(MetadataTemplate):
         # to create the list of tuples that psycopg2 requires.
         values = [
             v for v in zip([prep_id] * len(headers), headers, datatypes)]
-        conn_handler.executemany(
+        conn_handler.add_to_queue(
+            queue_name,
             "INSERT INTO qiita.{0} ({1}, column_name, column_type) "
             "VALUES (%s, %s, %s)".format(cls._column_table, cls._id_column),
-            values)
+            values, many=True)
 
         # Create table with custom columns
         table_name = cls._table_name(prep_id)
         column_datatype = ["%s %s" % (col, dtype)
                            for col, dtype in zip(headers, datatypes)]
-        conn_handler.execute(
+        conn_handler.add_to_queue(
+            queue_name,
             "CREATE TABLE qiita.{0} (sample_id varchar, "
             "{1})".format(table_name, ', '.join(column_datatype)))
 
@@ -1560,11 +1567,21 @@ class PrepTemplate(MetadataTemplate):
         values = _as_python_types(md_template, headers)
         values.insert(0, sample_ids)
         values = [v for v in zip(*values)]
-        conn_handler.executemany(
+        conn_handler.add_to_queue(
+            queue_name,
             "INSERT INTO qiita.{0} (sample_id, {1}) "
             "VALUES (%s, {2})".format(table_name, ", ".join(headers),
                                       ', '.join(["%s"] * len(headers))),
-            values)
+            values, many=True)
+
+        try:
+            conn_handler.execute_queue(queue_name)
+        except Exception:
+            # Clean up row from qiita.prep_template
+            conn_handler.execute(
+                "DELETE FROM qiita.prep_template where "
+                "{0} = %s".format(cls._id_column), (prep_id,))
+            raise
 
         # figuring out the filepath of the backup
         _id, fp = get_mountpoint('templates')[0]

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -30,7 +30,8 @@ from qiita_db.exceptions import (QiitaDBDuplicateError, QiitaDBUnknownIDError,
 from qiita_db.study import Study, StudyPerson
 from qiita_db.user import User
 from qiita_db.data import RawData
-from qiita_db.util import exists_table, get_db_files_base_dir, get_mountpoint
+from qiita_db.util import (exists_table, get_db_files_base_dir, get_mountpoint,
+                           get_count)
 from qiita_db.metadata_template import (
     _get_datatypes, _as_python_types, MetadataTemplate, SampleTemplate,
     PrepTemplate, BaseSample, PrepSample, Sample, _prefix_sample_names_with_id,
@@ -610,6 +611,42 @@ class TestSampleTemplate(TestCase):
         with self.assertRaises(QiitaDBColumnError):
             SampleTemplate.create(self.metadata, self.new_study)
 
+    def test_create_error_cleanup(self):
+        """Create does not modify the database if an error happens"""
+        metadata_dict = {
+            'Sample1': {'physical_location': 'location1',
+                        'has_physical_specimen': True,
+                        'has_extracted_data': True,
+                        'sample_type': 'type1',
+                        'required_sample_info_status': 'received',
+                        'collection_timestamp':
+                        datetime(2014, 5, 29, 12, 24, 51),
+                        'host_subject_id': 'NotIdentified',
+                        'Description': 'Test Sample 1',
+                        'group': 'Forcing the creation to fail',
+                        'latitude': 42.42,
+                        'longitude': 41.41}
+            }
+        metadata = pd.DataFrame.from_dict(metadata_dict, orient='index')
+        with self.assertRaises(QiitaDBExecutionError):
+            SampleTemplate.create(metadata, self.new_study)
+
+        sql = """SELECT EXISTS(
+                    SELECT * FROM qiita.required_sample_info
+                    WHERE sample_id=%s)"""
+        sample_id = "%d.Sample1" % self.new_study.id
+        self.assertFalse(
+            self.conn_handler.execute_fetchone(sql, (sample_id,))[0])
+
+        sql = """SELECT EXISTS(
+                    SELECT * FROM qiita.study_sample_columns
+                    WHERE study_id=%s)"""
+        self.assertFalse(
+            self.conn_handler.execute_fetchone(sql, (self.new_study.id,))[0])
+
+        self.assertFalse(
+            exists_table("sample_%d" % self.new_study.id, self.conn_handler))
+
     def test_create(self):
         """Creates a new SampleTemplate"""
         st = SampleTemplate.create(self.metadata, self.new_study)
@@ -1035,6 +1072,68 @@ class TestPrepTemplate(TestCase):
         with self.assertRaises(QiitaDBColumnError):
             PrepTemplate.create(self.metadata, self.new_raw_data,
                                 self.test_study, self.data_type)
+
+    def test_create_error_cleanup(self):
+        """Create does not modify the database if an error happens"""
+        metadata_dict = {
+            'SKB8.640193': {'center_name': 'ANL',
+                            'center_project_name': 'Test Project',
+                            'ebi_submission_accession': None,
+                            'EMP_status': 'EMP',
+                            'group': 2,
+                            'linkerprimersequence': 'GTGCCAGCMGCCGCGGTAA',
+                            'barcodesequence': 'GTCCGCAAGTTA',
+                            'run_prefix': "s_G1_L001_sequences",
+                            'platform': 'ILLUMINA',
+                            'library_construction_protocol': 'AAAA',
+                            'experiment_design_description': 'BBBB'},
+            'SKD8.640184': {'center_name': 'ANL',
+                            'center_project_name': 'Test Project',
+                            'ebi_submission_accession': None,
+                            'EMP_status': 'EMP',
+                            'group': 1,
+                            'linkerprimersequence': 'GTGCCAGCMGCCGCGGTAA',
+                            'barcodesequence': 'CGTAGAGCTCTC',
+                            'run_prefix': "s_G1_L001_sequences",
+                            'platform': 'ILLUMINA',
+                            'library_construction_protocol': 'AAAA',
+                            'experiment_design_description': 'BBBB'},
+            'SKB7.640196': {'center_name': 'ANL',
+                            'center_project_name': 'Test Project',
+                            'ebi_submission_accession': None,
+                            'EMP_status': 'EMP',
+                            'group': 'Value for sample 3',
+                            'linkerprimersequence': 'GTGCCAGCMGCCGCGGTAA',
+                            'barcodesequence': 'CCTCTGAGAGCT',
+                            'run_prefix': "s_G1_L002_sequences",
+                            'platform': 'ILLUMINA',
+                            'library_construction_protocol': 'AAAA',
+                            'experiment_design_description': 'BBBB'}
+            }
+        metadata = pd.DataFrame.from_dict(metadata_dict, orient='index')
+
+        exp_id = get_count("qiita.prep_template") + 1
+
+        with self.assertRaises(QiitaDBExecutionError):
+            PrepTemplate.create(metadata, self.new_raw_data,
+                                self.test_study, self.data_type)
+
+        sql = """SELECT EXISTS(
+                    SELECT * FROM qiita.prep_template
+                    WHERE prep_template_id=%s)"""
+        self.assertFalse(self.conn_handler.execute_fetchone(sql, (exp_id,))[0])
+
+        sql = """SELECT EXISTS(
+                    SELECT * FROM qiita.common_prep_info
+                    WHERE prep_template_id=%s)"""
+        self.assertFalse(self.conn_handler.execute_fetchone(sql, (exp_id,))[0])
+
+        sql = """SELECT EXISTS(
+                    SELECT * FROM qiita.prep_columns
+                    WHERE prep_template_id=%s)"""
+        self.assertFalse(self.conn_handler.execute_fetchone(sql, (exp_id,))[0])
+
+        self.assertFalse(exists_table("prep_%d" % exp_id, self.conn_handler))
 
     def test_create(self):
         """Creates a new PrepTemplate"""


### PR DESCRIPTION
Modifies the insertion of the templates to use the queue system. This will help to avoid the problem in which "floating" samples are added and cannot be automatically removed.