### PR TITLE
Cleaner error when prep template contains non-sample template IDs

### DIFF
--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -1596,17 +1596,13 @@ class PrepTemplate(MetadataTemplate):
                    "study_id = %s")
             # Get list of study sample IDs, prep template study IDs,
             # and their intersection
-            study_samples = set(s[0] for s in conn_handler.execute_fetchall(
-                sql, [study.id]))
             prep_samples = set(md_template.index.values)
-            both_samples = study_samples.intersection(prep_samples)
-            # filter prep template to just samples available in the study
-            md_template = md_template.loc[both_samples]
-            if len(both_samples) != len(prep_samples):
-                prep_samples.difference_update(both_samples)
+            unknown_samples = prep_samples.difference(
+                s[0] for s in conn_handler.execute_fetchall(sql, [study.id]))
+            if unknown_samples:
                 raise QiitaDBExecutionError(
                     'Samples found in prep template but not sample template: '
-                    '%s' % ', '.join(prep_samples))
+                    '%s' % ', '.join(unknown_samples))
 
             # some other error we haven't seen before so raise it
             raise

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -1371,12 +1371,15 @@ class TestPrepTemplate(TestCase):
         self.metadata = pd.DataFrame.from_dict(self.metadata_dict,
                                                orient='index')
         # Test error raised and correct error given
-        with self.assertRaises(QiitaDBExecutionError) as er:
+        # Try/Except used so can test the text of the error raised
+        try:
             PrepTemplate.create(self.metadata, self.new_raw_data,
                                 self.test_study, self.data_type)
+        except Exception as e:
+            self.assertIsInstance(e, QiitaDBExecutionError)
             self.assertEqual(
-                er.exception, 'QiitaDBExecutionError: Samples found in prep '
-                'template but not sample template: 1.NOTREAL')
+                str(e), 'Samples found in prep template but not sample '
+                'template: 1.NOTREAL')
 
     def test_create_shorter_prep_template(self):
         # remove one sample so not all samples in the prep template

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -1220,7 +1220,7 @@ class TestPrepTemplate(TestCase):
     """Tests the PrepTemplate class"""
 
     def setUp(self):
-        metadata_dict = {
+        self.metadata_dict = {
             'SKB8.640193': {'center_name': 'ANL',
                             'center_project_name': 'Test Project',
                             'ebi_submission_accession': None,
@@ -1255,7 +1255,7 @@ class TestPrepTemplate(TestCase):
                             'library_construction_protocol': 'AAAA',
                             'experiment_design_description': 'BBBB'}
             }
-        self.metadata = pd.DataFrame.from_dict(metadata_dict, orient='index')
+        self.metadata = pd.DataFrame.from_dict(self.metadata_dict, orient='index')
 
         metadata_prefixed_dict = {
             '1.SKB8.640193': {'center_name': 'ANL',
@@ -1365,16 +1365,21 @@ class TestPrepTemplate(TestCase):
 
     def test_create_filter_sample_names(self):
         # set two real and one fake sample name
-        self.metadata.index = ['SKB9.640200', 'NOTREAL', 'SKB1.640202']
-        pt = npt.assert_warns(QiitaDBWarning, PrepTemplate.create,
-                              self.metadata_prefixed, self.new_raw_data,
-                              self.test_study, self.data_type)
+        self.metadata_dict['NOTREAL'] = self.metadata_dict['SKB7.640196']
+        del self.metadata_dict['SKB7.640196']
+        self.metadata = pd.DataFrame.from_dict(self.metadata_dict,
+                                               orient='index')
+        with self.assertWarns(QiitaDBWarning) as warn:
+            print warn
+            PrepTemplate.create(self.metadata, self.new_raw_data,
+                                self.test_study, self.data_type)
 
         # make sure the two samples were added correctly
-        self.assertEqual(pt.id, 2)
+        PrepTemplate(2)
         obs = obs = self.conn_handler.execute_fetchall(
             "SELECT sample_id FROM qiita.prep_2")
-        exp = [['1.SKB9.640200'], ['1.SKB1.640202']]
+        exp = [['1.SKB8.640193'], ['1.SKD8.640184']]
+        self.assertEqual(obs, exp)
 
     def test_create_error_cleanup(self):
         """Create does not modify the database if an error happens"""

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -1326,6 +1326,13 @@ class TestPrepTemplate(TestCase):
             PrepTemplate.create(self.metadata, self.new_raw_data,
                                 self.test_study, self.data_type)
 
+    def test_create_filter_sample_names(self):
+        # set a horrible list of sample names
+        self.metadata.index = ['SKB9.640200', 'NOTREAL', 'SKB1.640202']
+        with self.assertRaises(QiitaDBWarning):
+            PrepTemplate.create(self.metadata, self.new_raw_data,
+                                self.test_study, self.data_type)
+
     def test_create(self):
         """Creates a new PrepTemplate"""
         pt = PrepTemplate.create(self.metadata, self.new_raw_data,

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -1371,19 +1371,12 @@ class TestPrepTemplate(TestCase):
         self.metadata = pd.DataFrame.from_dict(self.metadata_dict,
                                                orient='index')
         # Test error raised and correct error given
-        with self.assertRaises(QiitaDBExecutionError):
+        with self.assertRaises(QiitaDBExecutionError) as err:
             PrepTemplate.create(self.metadata, self.new_raw_data,
                                 self.test_study, self.data_type)
-
-        # Try/Except used so can test the text of the error raised
-        try:
-            PrepTemplate.create(self.metadata, self.new_raw_data,
-                                self.test_study, self.data_type)
-        except Exception as e:
-            self.assertIsInstance(e, QiitaDBExecutionError)
-            self.assertEqual(
-                str(e), 'Samples found in prep template but not sample '
-                'template: 1.NOTREAL')
+        self.assertEqual(
+            str(err.exception), 'Samples found in prep template but not sample'
+            ' template: 1.NOTREAL')
 
     def test_create_shorter_prep_template(self):
         # remove one sample so not all samples in the prep template

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -1370,7 +1370,7 @@ class TestPrepTemplate(TestCase):
         del self.metadata_dict['SKB7.640196']
         self.metadata = pd.DataFrame.from_dict(self.metadata_dict,
                                                orient='index')
-        # Test warning raised and correct warning given
+        # Test error raised and correct error given
         with self.assertRaises(QiitaDBExecutionError) as er:
             PrepTemplate.create(self.metadata, self.new_raw_data,
                                 self.test_study, self.data_type)

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -1371,6 +1371,10 @@ class TestPrepTemplate(TestCase):
         self.metadata = pd.DataFrame.from_dict(self.metadata_dict,
                                                orient='index')
         # Test error raised and correct error given
+        with self.assertRaises(QiitaDBExecutionError):
+            PrepTemplate.create(self.metadata, self.new_raw_data,
+                                self.test_study, self.data_type)
+
         # Try/Except used so can test the text of the error raised
         try:
             PrepTemplate.create(self.metadata, self.new_raw_data,


### PR DESCRIPTION
This pull request adds a check and filter to the prep template addition. It makes sure the samples in the prep template exist in the sample template, and whichever don't are removed and raised as a warning. 

This allows us to support a prep template with samples from multiple studies on it, which is frequently the case.