### PR TITLE
BUG: Prevent pandas from inferring data types

### DIFF
--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -119,7 +119,7 @@ def _as_python_types(metadata_map, headers):
     Returns
     -------
     list of lists
-        The values of the columns in metadata_map pointed by headers casted to
+        The values of the columns in metadata_map pointed by headers cast to
         python types.
     """
     values = []
@@ -1936,7 +1936,7 @@ def load_template_to_dataframe(fn):
     ------
     QiitaDBColumnError
         If the sample_name column is not present in the template.
-        If there's a value in one of the reserved columns that cannot be casted
+        If there's a value in one of the reserved columns that cannot be cast
         to the needed type.
     QiitaDBWarning
         When columns are dropped because they have no content for any sample.
@@ -1944,7 +1944,7 @@ def load_template_to_dataframe(fn):
     Notes
     -----
     The index attribute of the DataFrame will be forced to be 'sample_name'
-    and will be casted to a string. Additionally rows that start with a '\t'
+    and will be cast to a string. Additionally rows that start with a '\t'
     character will be ignored and columns that are empty will be removed. Empty
     sample names will be removed from the DataFrame.
 
@@ -1975,7 +1975,7 @@ def load_template_to_dataframe(fn):
     """
 
     # index_col:
-    #   is set as False, otherwise it is casted as a float and we want a string
+    #   is set as False, otherwise it is cast as a float and we want a string
     # keep_default:
     #   is set as False, to avoid inferring empty/NA values with the defaults
     #   that Pandas has.
@@ -2014,7 +2014,7 @@ def load_template_to_dataframe(fn):
             if n in template.columns and not np.issubdtype(template[n].dtype,
                                                            c_dtype):
                 raise QiitaDBColumnError("The '%s' column includes values that"
-                                         " cannot be casted into a %s "
+                                         " cannot be cast into a %s "
                                          "type." % (n, c_dtype))
 
     initial_columns = set(template.columns)

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -2079,6 +2079,20 @@ class TestUtilities(TestCase):
         obs = get_invalid_sample_names(one_invalid)
         self.assertItemsEqual(obs, [' ', ' ', ' '])
 
+    def test_invalid_lat_long(self):
+
+        with self.assertRaises(QiitaDBColumnError):
+            obs = load_template_to_dataframe(
+                StringIO(SAMPLE_TEMPLATE_INVALID_LATITUDE_COLUMNS))
+            # prevent flake8 from complaining
+            str(obs)
+
+        with self.assertRaises(QiitaDBColumnError):
+            obs = load_template_to_dataframe(
+                StringIO(SAMPLE_TEMPLATE_INVALID_LONGITUDE_COLUMNS))
+            # prevent flake8 from complaining
+            str(obs)
+
 
 EXP_SAMPLE_TEMPLATE = (
     "sample_name\tcollection_timestamp\tdescription\thas_extracted_data\t"
@@ -2265,6 +2279,37 @@ SAMPLE_TEMPLATE_NO_SAMPLE_NAME = (
     "2.Sample3\t2014-05-29 12:24:51\tTest Sample 3\tTrue\t"
     "True\tNotIdentified\t4.8\t4.41\tlocation1\treceived\ttype1\t"
     "NA\n")
+
+SAMPLE_TEMPLATE_INVALID_LATITUDE_COLUMNS = (
+    "sample_name\tcollection_timestamp\tdescription\thas_extracted_data\t"
+    "has_physical_specimen\thost_subject_id\tlatitude\tlongitude\t"
+    "physical_location\trequired_sample_info_status\tsample_type\t"
+    "str_column\n"
+    "2.Sample1\t2014-05-29 12:24:51\tTest Sample 1\tTrue\tTrue\t"
+    "1\t42\t41.41\tlocation1\treceived\ttype1\t"
+    "Value for sample 1\n"
+    "2.Sample2\t2014-05-29 12:24:51\t"
+    "Test Sample 2\tTrue\tTrue\1\t4.2\t1.1\tlocation1\treceived\t"
+    "type1\tValue for sample 2\n"
+    "2.Sample3\t2014-05-29 12:24:51\tTest Sample 3\tTrue\t"
+    "True\1\tXXXXX4.8\t4.41\tlocation1\treceived\ttype1\t"
+    "Value for sample 3\n")
+
+SAMPLE_TEMPLATE_INVALID_LONGITUDE_COLUMNS = (
+    "sample_name\tcollection_timestamp\tdescription\thas_extracted_data\t"
+    "has_physical_specimen\thost_subject_id\tlatitude\tlongitude\t"
+    "physical_location\trequired_sample_info_status\tsample_type\t"
+    "str_column\n"
+    "2.Sample1\t2014-05-29 12:24:51\tTest Sample 1\tTrue\tTrue\t"
+    "1\t11.42\t41.41\tlocation1\treceived\ttype1\t"
+    "Value for sample 1\n"
+    "2.Sample2\t2014-05-29 12:24:51\t"
+    "Test Sample 2\tTrue\tTrue\1\t4.2\tXXX\tlocation1\treceived\t"
+    "type1\tValue for sample 2\n"
+    "2.Sample3\t2014-05-29 12:24:51\tTest Sample 3\tTrue\t"
+    "True\1\t4.8\t4.XXXXX41\tlocation1\treceived\ttype1\t"
+    "Value for sample 3\n")
+
 
 SAMPLE_TEMPLATE_DICT_FORM = {
     'collection_timestamp': {'2.Sample1': '2014-05-29 12:24:51',


### PR DESCRIPTION
This was causing some required columns were being casted into unusable types.
For example if the values in HOST_SUBJECT_ID were all int-looking
(00011, 0011.2, etc), these were being casted into integers which later caused
troubles with the pipeline.

We now restrict pandas from casting certain columns into undesirable types and
enforce other types where possible.

Fixes #872