### PR TITLE
ENH: change default webserver port

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Scripts in Qiita are located inside the scripts directory, their actions will re
 * `qiita_env drop` will delete the environment (as specified by the Qiita config file).
 * `qiita_env start_cluster qiita_general`, starts an IPython cluster named ‘qiita_general’. Normally you’ll want to wait a few seconds for the engines to start and become responsive (30-40 seconds depending on your system).
 * `qiita_env stop_cluster qiita_general`, terminates a cluster named ‘qiita_general’.
-* `qiita webserver start`, will start the Qiita web-application running on port 8888, you can change this using the `--port` flag, for example `--port=7532`.
+* `qiita webserver start`, will start the Qiita web-application running on port 21174, you can change this using the `--port` flag, for example `--port=7532`.
 
 ##Making Database Changes
 After the initial production release of Qiita, changes to the database schema will require patches; the database can no longer be dropped and recreated using the most recent schema because all the data would be lost! Therefore, patches must be applied instead.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,7 +65,7 @@ qiita webserver start
 
 ```
 
-If all the above commands executed correctly, you should be able to go to http://localhost:8888 in your browser, to login use `demo@microbio.me` and `password` as the credentials.
+If all the above commands executed correctly, you should be able to go to http://localhost:21174 in your browser, to login use `demo@microbio.me` and `password` as the credentials.
 
 
 ## If using other operating systems that are not Ubuntu

--- a/qiita_pet/nginx_example.conf
+++ b/qiita_pet/nginx_example.conf
@@ -23,9 +23,9 @@ http {
             alias ;
         }
 
-        # general redirect from 80 to 8888 for tornado
+        # general redirect from 80 to 21174 for tornado
         location / {
-            proxy_pass http://127.0.0.1:8888;
+            proxy_pass http://127.0.0.1:21174;
             proxy_redirect     off;
             proxy_set_header   Host             $host;
             proxy_set_header   X-Real-IP        $remote_addr;

--- a/scripts/qiita
+++ b/scripts/qiita
@@ -8,6 +8,9 @@
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
 
+import errno
+import socket
+
 import click
 import tornado.httpserver
 import tornado.ioloop
@@ -342,7 +345,8 @@ def status():
 
 @webserver.command()
 @click.option('--port', required=False, type=int, help='Port where the '
-              'webserver will start', default=8888)
+              'webserver will start', default=21174)
+# (cursive Q)iita = 21174 in 1337sp34k
 def start(port):
     # in order to use this command you need to have an IPython cluster running,
     # for now this makes it so that you can use other sub-commands without
@@ -351,7 +355,17 @@ def start(port):
     from qiita_pet.webserver import Application
 
     http_server = tornado.httpserver.HTTPServer(Application())
-    http_server.listen(port)
+
+    try:
+        http_server.listen(port)
+    except socket.error as e:
+        if e.errno == errno.EADDRINUSE:
+            raise ValueError(
+                "Port %d is already in use. Please choose another port with "
+                "--port." % port)
+        else:
+            raise
+
     click.echo("Qiita started on port %d" % port)
     tornado.ioloop.IOLoop.instance().start()
 


### PR DESCRIPTION
Changed default port from 8888 to 21174, which is (cursive Q)iita in 1337sp34k. This port is unlikely to conflict with other services (e.g., IPython). If it does, a descriptive error message is raised.

Fixes #914.

Thanks to @ebolyen and @ElDeveloper for the input on this!