### PR TITLE
Add tsv to default acceptable upload extensiosn

### DIFF
--- a/qiita_core/support_files/config_test.txt
+++ b/qiita_core/support_files/config_test.txt
@@ -34,7 +34,7 @@ MAX_UPLOAD_SIZE = 100
 BASE_DATA_DIR =
 
 # Valid upload extension, comma separated. Empty for no uploads
-VALID_UPLOAD_EXTENSION = fastq,fastq.gz,txt,sff,fna,qual
+VALID_UPLOAD_EXTENSION = fastq,fastq.gz,txt,tsv,sff,fna,qual
 
 # ----------------------------- SMTP settings -----------------------------
 [smtp]


### PR DESCRIPTION
This is the extension that is added to tab-separated value files when exported
from google docs.

Fix #939