### PR TITLE
ENH: Change exception being raised on prep.remove

### DIFF
--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -1931,7 +1931,7 @@ class PrepTemplate(MetadataTemplate):
 
         Raises
         ------
-        QiitaDBError
+        QiitaDBExecutionError
             If the prep template already has a preprocessed data
         QiitaDBUnknownIDError
             If no prep template with id = id_ exists
@@ -1942,15 +1942,14 @@ class PrepTemplate(MetadataTemplate):
         if not cls.exists(id_):
             raise QiitaDBUnknownIDError(id_, cls.__name__)
 
-        # TODO: Should we cascade to preprocessed data? See issue #537
         preprocessed_data_exists = conn_handler.execute_fetchone(
             "SELECT EXISTS(SELECT * FROM qiita.prep_template_preprocessed_data"
             " WHERE prep_template_id=%s)", (id_,))[0]
 
         if preprocessed_data_exists:
-            raise QiitaDBError("Cannot remove prep template %d because a "
-                               "preprocessed data has been already generated "
-                               "using it." % id_)
+            raise QiitaDBExecutionError("Cannot remove prep template %d "
+                                        "because a preprocessed data has been"
+                                        " already generated using it." % id_)
 
         # Delete the prep template filepaths
         conn_handler.execute(

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -2044,7 +2044,7 @@ class TestPrepTemplate(TestCase):
 
     def test_delete_error(self):
         """Try to delete a prep template that already has preprocessed data"""
-        with self.assertRaises(QiitaDBError):
+        with self.assertRaises(QiitaDBExecutionError):
             PrepTemplate.delete(1)
 
     def test_delete_unkonwn_id_error(self):


### PR DESCRIPTION
When removing a prep template that already had processed data, the
remove method would raise an exception that was not caught by the
handler. The solution was to change the QiitaDBError (which is a base
class and I think is to generic) to a QiitaDBExecutionError.

Fixes #909