### PR TITLE
Use single ioloop for coroutine tests. Fix #950

### DIFF
--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -1,6 +1,8 @@
 from unittest import main
 from collections import namedtuple
 
+from tornado.ioloop import IOLoop
+
 from qiita_pet.test.tornado_test_base import TestHandlerBase
 from qiita_db.study import StudyPerson, Study
 from qiita_db.util import get_count, check_count
@@ -101,6 +103,9 @@ class TestPublicStudiesHandler(TestHandlerBase):
 
 
 class TestStudyDescriptionHandler(TestHandlerBase):
+    def get_new_ioloop(self):
+        return IOLoop.instance()
+
     def test_get_exists(self):
         response = self.get('/study/description/1')
         self.assertEqual(response.code, 200)


### PR DESCRIPTION
From http://stackoverflow.com/q/14688042
"What is happening is the AsyncHTTPClient in your RequestHandler is running on a different IOLoop, which is never started."

This makes it so a single IOLoop is used for all coroutine tests.