### PR TITLE
Force debug=False for testing. - URGENT MERGE NEEDED

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 env:
   - PYTHON_VERSION=2.7
 before_install:
+  - redis-server --version
   - wget http://repo.continuum.io/miniconda/Miniconda3-3.7.3-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b

--- a/qiita_pet/test/tornado_test_base.py
+++ b/qiita_pet/test/tornado_test_base.py
@@ -20,6 +20,7 @@ class TestHandlerBase(AsyncHTTPTestCase):
 
     def get_app(self):
         BaseHandler.get_current_user = Mock(return_value=User("test@foo.bar"))
+        self.app.settings['debug'] = False
         return self.app
 
     def setUp(self):


### PR DESCRIPTION
This turns debug off for tests. Essentially what was happening is, because of the debug setting, a filecheck was added to ioloop to check files every 500ms. Since each test opened an ioloop, this file check started to get io bound and cause the stochastic failures.