### PR TITLE
Raise error for disallowed columns

### DIFF
--- a/qiita_db/metadata_template.py
+++ b/qiita_db/metadata_template.py
@@ -750,7 +750,7 @@ class MetadataTemplate(QiitaObject):
 
     @classmethod
     def _check_special_columns(cls, md_template, obj):
-        r"""Checks for special columns based on obj type
+        r"""Checks for special columns based on obj type, and invalid col names
 
         Parameters
         ----------
@@ -760,6 +760,13 @@ class MetadataTemplate(QiitaObject):
             The obj to which the metadata template belongs to. Study in case
             of SampleTemplate and RawData in case of PrepTemplate
         """
+        # Check disallowed col names
+        disallowed = {'study_id', 'processed_data_id'}
+        invalid = disallowed.intersection(md_template.columns)
+        if len(invalid) > 0:
+            raise QiitaDBColumnError("Disallowed column names found! "
+                                     "Please change these column names: %s" %
+                                     ", ".join(invalid))
         # Check required columns
         missing = set(cls.translate_cols_dict.values()).difference(md_template)
         if not missing:

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -1101,6 +1101,13 @@ class TestSampleTemplate(TestCase):
                ['2.Sample3', "Value for sample 3"]]
         self.assertEqual(obs, exp)
 
+    def test_create_disallowed_column(self):
+        for key in self.metadata_dict:
+            self.metadata_dict[key].update({"study_id": "NOOOOOOOOO"})
+        df = pd.DataFrame.from_dict(self.metadata_dict, orient='index')
+        with self.assertRaises(QiitaDBColumnError):
+            SampleTemplate.create(df, self.new_study)
+
     def test_delete(self):
         """Deletes Sample template 1"""
         SampleTemplate.create(self.metadata, self.new_study)
@@ -1713,6 +1720,14 @@ class TestPrepTemplate(TestCase):
         with self.assertRaises(QiitaDBColumnError):
             PrepTemplate.create(self.metadata, self.new_raw_data,
                                 self.test_study, self.data_type)
+
+    def test_create_disallowed_column(self):
+        for key in self.metadata_dict:
+            self.metadata_dict[key].update({"study_id": "NOOOOOOOOO"})
+        df = pd.DataFrame.from_dict(self.metadata_dict, orient='index')
+        with self.assertRaises(QiitaDBColumnError):
+            PrepTemplate.create(df, self.new_raw_data,
+                               self.test_study, self.data_type)
 
     def test_create_unknown_sample_names(self):
         # set two real and one fake sample name

--- a/qiita_db/test/test_metadata_template.py
+++ b/qiita_db/test/test_metadata_template.py
@@ -1727,7 +1727,7 @@ class TestPrepTemplate(TestCase):
         df = pd.DataFrame.from_dict(self.metadata_dict, orient='index')
         with self.assertRaises(QiitaDBColumnError):
             PrepTemplate.create(df, self.new_raw_data,
-                               self.test_study, self.data_type)
+                                self.test_study, self.data_type)
 
     def test_create_unknown_sample_names(self):
         # set two real and one fake sample name


### PR DESCRIPTION
While working on the search object overhaul, I realized that we are not disallowing the specialized column names from being in the templates. This checks for the existence of the specific columns needed for study searches, and if they do exist in a given sample or prep template, raises a QiitaDBColumnError. These columns are parts of known tables, so they should never be passed in as a part of a template and become a column on the dynamic tables. 