### PR TITLE
Speedup metadata tests

### DIFF
--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -431,7 +431,6 @@ class MetadataTemplate(QiitaObject):
 
     Methods
     -------
-    create
     exists
     __len__
     __getitem__

--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -824,8 +824,6 @@ class MetadataTemplate(QiitaObject):
         pandas DataFrame
             The metadata in the template,indexed on sample id
         """
-        # Check that we are not instantiating the base class
-        self._check_subclass()
         conn_handler = SQLConnectionHandler()
         cols = get_table_cols(self._table, conn_handler)
         if 'study_id' in cols:

--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -532,6 +532,7 @@ class MetadataTemplate(QiitaObject):
         QiitaDBUnknownIDError
             If no metadata_template with id id_ exists
         """
+        cls._check_subclass()
         if not cls.exists(id_):
             raise QiitaDBUnknownIDError(id_, cls.__name__)
 

--- a/qiita_db/metadata_template/test/test_base_metadata_template.py
+++ b/qiita_db/metadata_template/test/test_base_metadata_template.py
@@ -31,8 +31,7 @@ class TestBaseSample(TestCase):
             BaseSample.exists('SKM7.640188', SampleTemplate(1))
 
 
-@qiita_test_checker()
-class TestMetadataTemplate(TestCase):
+class TestMetadataTemplateReadOnly(TestCase):
     """Tests the MetadataTemplate base class"""
     def setUp(self):
         self.study = Study(1)
@@ -53,6 +52,9 @@ class TestMetadataTemplate(TestCase):
         with self.assertRaises(IncompetentQiitaDeveloperError):
             MetadataTemplate._table_name(self.study)
 
+
+@qiita_test_checker()
+class TestMetadataTemplateReadWrite(TestCase):
     def test_delete(self):
         """delete raises an error because it's not called from a subclass"""
         with self.assertRaises(IncompetentQiitaDeveloperError):

--- a/qiita_db/metadata_template/test/test_base_metadata_template.py
+++ b/qiita_db/metadata_template/test/test_base_metadata_template.py
@@ -17,7 +17,6 @@ from qiita_db.metadata_template.base_metadata_template import (
 from qiita_db.metadata_template.sample_template import SampleTemplate
 
 
-@qiita_test_checker()
 class TestBaseSample(TestCase):
     """Tests the BaseSample class"""
 

--- a/qiita_db/metadata_template/test/test_base_metadata_template.py
+++ b/qiita_db/metadata_template/test/test_base_metadata_template.py
@@ -43,11 +43,6 @@ class TestMetadataTemplate(TestCase):
         with self.assertRaises(IncompetentQiitaDeveloperError):
             MetadataTemplate(1)
 
-    def test_create(self):
-        """Create raises an error because it's not called from a subclass"""
-        with self.assertRaises(QiitaDBNotImplementedError):
-            MetadataTemplate.create()
-
     def test_exist(self):
         """Exists raises an error because it's not called from a subclass"""
         with self.assertRaises(IncompetentQiitaDeveloperError):

--- a/qiita_db/metadata_template/test/test_base_metadata_template.py
+++ b/qiita_db/metadata_template/test/test_base_metadata_template.py
@@ -53,11 +53,5 @@ class TestMetadataTemplate(TestCase):
         with self.assertRaises(IncompetentQiitaDeveloperError):
             MetadataTemplate._table_name(self.study)
 
-    def test_to_dataframe(self):
-        """to dataframeraises an error because it's not called from a subclass
-        """
-        with self.assertRaises(TypeError):
-            MetadataTemplate.to_dataframe()
-
 if __name__ == '__main__':
     main()

--- a/qiita_db/metadata_template/test/test_base_metadata_template.py
+++ b/qiita_db/metadata_template/test/test_base_metadata_template.py
@@ -53,5 +53,10 @@ class TestMetadataTemplate(TestCase):
         with self.assertRaises(IncompetentQiitaDeveloperError):
             MetadataTemplate._table_name(self.study)
 
+    def test_delete(self):
+        """delete raises an error because it's not called from a subclass"""
+        with self.assertRaises(IncompetentQiitaDeveloperError):
+            MetadataTemplate.delete(1)
+
 if __name__ == '__main__':
     main()

--- a/qiita_db/metadata_template/test/test_base_metadata_template.py
+++ b/qiita_db/metadata_template/test/test_base_metadata_template.py
@@ -10,7 +10,6 @@ from unittest import TestCase, main
 
 from qiita_core.util import qiita_test_checker
 from qiita_core.exceptions import IncompetentQiitaDeveloperError
-from qiita_db.exceptions import QiitaDBNotImplementedError
 from qiita_db.study import Study
 from qiita_db.metadata_template.base_metadata_template import (
     MetadataTemplate, BaseSample)

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -35,7 +35,7 @@ from qiita_db.metadata_template.prep_template import PrepTemplate, PrepSample
 from qiita_db.metadata_template.sample_template import SampleTemplate, Sample
 
 
-class SetUpTestPrepSample(TestCase):
+class BaseTestPrepSample(TestCase):
     def setUp(self):
         self.prep_template = PrepTemplate(1)
         self.sample_id = '1.SKB8.640193'
@@ -52,7 +52,7 @@ class SetUpTestPrepSample(TestCase):
                                'sample_center', 'pcr_primers', 'study_center'}
 
 
-class TestPrepSampleReadOnly(SetUpTestPrepSample):
+class TestPrepSampleReadOnly(BaseTestPrepSample):
     def test_init_unknown_error(self):
         """Init errors if the PrepSample id is not found in the template"""
         with self.assertRaises(QiitaDBUnknownIDError):
@@ -217,7 +217,7 @@ class TestPrepSampleReadOnly(SetUpTestPrepSample):
 
 
 @qiita_test_checker()
-class TestPrepSampleReadWrite(SetUpTestPrepSample):
+class TestPrepSampleReadWrite(BaseTestPrepSample):
     """Tests the PrepSample class"""
     def test_setitem(self):
         """setitem raises an error (currently not allowed)"""
@@ -230,7 +230,7 @@ class TestPrepSampleReadWrite(SetUpTestPrepSample):
             del self.tester['pcr_primers']
 
 
-class SetUpTestPrepTemplate(TestCase):
+class BaseTestPrepTemplate(TestCase):
     def _set_up(self):
         self.metadata_dict = {
             'SKB8.640193': {'center_name': 'ANL',
@@ -330,7 +330,7 @@ class SetUpTestPrepTemplate(TestCase):
             remove(f)
 
 
-class TestPrepTemplateReadOnly(SetUpTestPrepTemplate):
+class TestPrepTemplateReadOnly(BaseTestPrepTemplate):
     def setUp(self):
         self._set_up()
 
@@ -535,7 +535,7 @@ class TestPrepTemplateReadOnly(SetUpTestPrepTemplate):
 
 
 @qiita_test_checker()
-class TestPrepTemplateReadWrite(SetUpTestPrepTemplate):
+class TestPrepTemplateReadWrite(BaseTestPrepTemplate):
     """Tests the PrepTemplate class"""
 
     def setUp(self):

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -230,11 +230,8 @@ class TestPrepSampleReadWrite(SetUpTestPrepSample):
             del self.tester['pcr_primers']
 
 
-@qiita_test_checker()
-class TestPrepTemplate(TestCase):
-    """Tests the PrepTemplate class"""
-
-    def setUp(self):
+class SetUpTestPrepTemplate(TestCase):
+    def _set_up(self):
         self.metadata_dict = {
             'SKB8.640193': {'center_name': 'ANL',
                             'center_project_name': 'Test Project',
@@ -316,21 +313,6 @@ class TestPrepTemplate(TestCase):
         self.data_type = "18S"
         self.data_type_id = 2
 
-        fd, seqs_fp = mkstemp(suffix='_seqs.fastq')
-        close(fd)
-        fd, barcodes_fp = mkstemp(suffix='_barcodes.fastq')
-        close(fd)
-        filepaths = [(seqs_fp, 1), (barcodes_fp, 2)]
-        with open(seqs_fp, "w") as f:
-            f.write("\n")
-        with open(barcodes_fp, "w") as f:
-            f.write("\n")
-        self.new_raw_data = RawData.create(2, [Study(1)], filepaths=filepaths)
-        db_test_raw_dir = join(get_db_files_base_dir(), 'raw_data')
-        db_seqs_fp = join(db_test_raw_dir, "5_%s" % basename(seqs_fp))
-        db_barcodes_fp = join(db_test_raw_dir, "5_%s" % basename(barcodes_fp))
-        self._clean_up_files = [db_seqs_fp, db_barcodes_fp]
-
         self.tester = PrepTemplate(1)
         self.exp_sample_ids = {
             '1.SKB1.640202', '1.SKB2.640194', '1.SKB3.640195', '1.SKB4.640189',
@@ -341,9 +323,16 @@ class TestPrepTemplate(TestCase):
             '1.SKM3.640197', '1.SKM4.640180', '1.SKM5.640177', '1.SKM6.640187',
             '1.SKM7.640188', '1.SKM8.640201', '1.SKM9.640192'}
 
+        self._clean_up_files = []
+
     def tearDown(self):
         for f in self._clean_up_files:
             remove(f)
+
+
+class TestPrepTemplateReadOnly(SetUpTestPrepTemplate):
+    def setUp(self):
+        self._set_up()
 
     def test_study_id(self):
         """Ensure that the correct study ID is returned"""
@@ -363,6 +352,209 @@ class TestPrepTemplate(TestCase):
         """Table name return the correct string"""
         obs = PrepTemplate._table_name(1)
         self.assertEqual(obs, "prep_1")
+
+    def test_exists_true(self):
+        """Exists returns true when the PrepTemplate already exists"""
+        self.assertTrue(PrepTemplate.exists(1))
+
+    def test_exists_false(self):
+        """Exists returns false when the PrepTemplate does not exists"""
+        self.assertFalse(PrepTemplate.exists(2))
+
+    def test_get_sample_ids(self):
+        """get_sample_ids returns the correct set of sample ids"""
+        conn_handler = SQLConnectionHandler()
+        obs = self.tester._get_sample_ids(conn_handler)
+        self.assertEqual(obs, self.exp_sample_ids)
+
+    def test_len(self):
+        """Len returns the correct number of sample ids"""
+        self.assertEqual(len(self.tester), 27)
+
+    def test_getitem(self):
+        """Get item returns the correct sample object"""
+        obs = self.tester['1.SKM7.640188']
+        exp = PrepSample('1.SKM7.640188', self.tester)
+        self.assertEqual(obs, exp)
+
+    def test_getitem_error(self):
+        """Get item raises an error if key does not exists"""
+        with self.assertRaises(KeyError):
+            self.tester['Not_a_Sample']
+
+    def test_iter(self):
+        """iter returns an iterator over the sample ids"""
+        obs = self.tester.__iter__()
+        self.assertTrue(isinstance(obs, Iterable))
+        self.assertEqual(set(obs), self.exp_sample_ids)
+
+    def test_contains_true(self):
+        """contains returns true if the sample id exists"""
+        self.assertTrue('1.SKM7.640188' in self.tester)
+
+    def test_contains_false(self):
+        """contains returns false if the sample id does not exists"""
+        self.assertFalse('Not_a_Sample' in self.tester)
+
+    def test_keys(self):
+        """keys returns an iterator over the sample ids"""
+        obs = self.tester.keys()
+        self.assertTrue(isinstance(obs, Iterable))
+        self.assertEqual(set(obs), self.exp_sample_ids)
+
+    def test_values(self):
+        """values returns an iterator over the values"""
+        obs = self.tester.values()
+        self.assertTrue(isinstance(obs, Iterable))
+        exp = {PrepSample('1.SKB1.640202', self.tester),
+               PrepSample('1.SKB2.640194', self.tester),
+               PrepSample('1.SKB3.640195', self.tester),
+               PrepSample('1.SKB4.640189', self.tester),
+               PrepSample('1.SKB5.640181', self.tester),
+               PrepSample('1.SKB6.640176', self.tester),
+               PrepSample('1.SKB7.640196', self.tester),
+               PrepSample('1.SKB8.640193', self.tester),
+               PrepSample('1.SKB9.640200', self.tester),
+               PrepSample('1.SKD1.640179', self.tester),
+               PrepSample('1.SKD2.640178', self.tester),
+               PrepSample('1.SKD3.640198', self.tester),
+               PrepSample('1.SKD4.640185', self.tester),
+               PrepSample('1.SKD5.640186', self.tester),
+               PrepSample('1.SKD6.640190', self.tester),
+               PrepSample('1.SKD7.640191', self.tester),
+               PrepSample('1.SKD8.640184', self.tester),
+               PrepSample('1.SKD9.640182', self.tester),
+               PrepSample('1.SKM1.640183', self.tester),
+               PrepSample('1.SKM2.640199', self.tester),
+               PrepSample('1.SKM3.640197', self.tester),
+               PrepSample('1.SKM4.640180', self.tester),
+               PrepSample('1.SKM5.640177', self.tester),
+               PrepSample('1.SKM6.640187', self.tester),
+               PrepSample('1.SKM7.640188', self.tester),
+               PrepSample('1.SKM8.640201', self.tester),
+               PrepSample('1.SKM9.640192', self.tester)}
+        # Creating a list and looping over it since unittest does not call
+        # the __eq__ function on the objects
+        for o, e in zip(sorted(list(obs), key=lambda x: x.id),
+                        sorted(exp, key=lambda x: x.id)):
+            self.assertEqual(o, e)
+
+    def test_items(self):
+        """items returns an iterator over the (key, value) tuples"""
+        obs = self.tester.items()
+        self.assertTrue(isinstance(obs, Iterable))
+        exp = [('1.SKB1.640202', PrepSample('1.SKB1.640202', self.tester)),
+               ('1.SKB2.640194', PrepSample('1.SKB2.640194', self.tester)),
+               ('1.SKB3.640195', PrepSample('1.SKB3.640195', self.tester)),
+               ('1.SKB4.640189', PrepSample('1.SKB4.640189', self.tester)),
+               ('1.SKB5.640181', PrepSample('1.SKB5.640181', self.tester)),
+               ('1.SKB6.640176', PrepSample('1.SKB6.640176', self.tester)),
+               ('1.SKB7.640196', PrepSample('1.SKB7.640196', self.tester)),
+               ('1.SKB8.640193', PrepSample('1.SKB8.640193', self.tester)),
+               ('1.SKB9.640200', PrepSample('1.SKB9.640200', self.tester)),
+               ('1.SKD1.640179', PrepSample('1.SKD1.640179', self.tester)),
+               ('1.SKD2.640178', PrepSample('1.SKD2.640178', self.tester)),
+               ('1.SKD3.640198', PrepSample('1.SKD3.640198', self.tester)),
+               ('1.SKD4.640185', PrepSample('1.SKD4.640185', self.tester)),
+               ('1.SKD5.640186', PrepSample('1.SKD5.640186', self.tester)),
+               ('1.SKD6.640190', PrepSample('1.SKD6.640190', self.tester)),
+               ('1.SKD7.640191', PrepSample('1.SKD7.640191', self.tester)),
+               ('1.SKD8.640184', PrepSample('1.SKD8.640184', self.tester)),
+               ('1.SKD9.640182', PrepSample('1.SKD9.640182', self.tester)),
+               ('1.SKM1.640183', PrepSample('1.SKM1.640183', self.tester)),
+               ('1.SKM2.640199', PrepSample('1.SKM2.640199', self.tester)),
+               ('1.SKM3.640197', PrepSample('1.SKM3.640197', self.tester)),
+               ('1.SKM4.640180', PrepSample('1.SKM4.640180', self.tester)),
+               ('1.SKM5.640177', PrepSample('1.SKM5.640177', self.tester)),
+               ('1.SKM6.640187', PrepSample('1.SKM6.640187', self.tester)),
+               ('1.SKM7.640188', PrepSample('1.SKM7.640188', self.tester)),
+               ('1.SKM8.640201', PrepSample('1.SKM8.640201', self.tester)),
+               ('1.SKM9.640192', PrepSample('1.SKM9.640192', self.tester))]
+        # Creating a list and looping over it since unittest does not call
+        # the __eq__ function on the objects
+        for o, e in zip(sorted(list(obs)), sorted(exp)):
+            self.assertEqual(o, e)
+
+    def test_get(self):
+        """get returns the correct PrepSample object"""
+        obs = self.tester.get('1.SKM7.640188')
+        exp = PrepSample('1.SKM7.640188', self.tester)
+        self.assertEqual(obs, exp)
+
+    def test_get_none(self):
+        """get returns none if the sample id is not present"""
+        self.assertTrue(self.tester.get('Not_a_Sample') is None)
+
+    def test_data_type(self):
+        """data_type returns the string with the data_type"""
+        self.assertTrue(self.tester.data_type(), "18S")
+
+    def test_data_type_id(self):
+        """data_type returns the int with the data_type_id"""
+        self.assertTrue(self.tester.data_type(ret_id=True), 2)
+
+    def test_raw_data(self):
+        """Returns the raw_data associated with the prep template"""
+        self.assertEqual(self.tester.raw_data, 1)
+
+    def test_preprocessed_data(self):
+        """Returns the preprocessed data list generated from this template"""
+        self.assertEqual(self.tester.preprocessed_data, [1, 2])
+
+    def test_investigation_type(self):
+        """investigation_type works correctly"""
+        self.assertEqual(self.tester.investigation_type, "Metagenomics")
+
+    def test_to_dataframe(self):
+        obs = self.tester.to_dataframe()
+        # We don't test the specific values as this would blow up the size
+        # of this file as the amount of lines would go to ~1000
+
+        # 27 samples
+        self.assertEqual(len(obs), 27)
+        self.assertEqual(set(obs.index), {
+            u'1.SKB1.640202', u'1.SKB2.640194', u'1.SKB3.640195',
+            u'1.SKB4.640189', u'1.SKB5.640181', u'1.SKB6.640176',
+            u'1.SKB7.640196', u'1.SKB8.640193', u'1.SKB9.640200',
+            u'1.SKD1.640179', u'1.SKD2.640178', u'1.SKD3.640198',
+            u'1.SKD4.640185', u'1.SKD5.640186', u'1.SKD6.640190',
+            u'1.SKD7.640191', u'1.SKD8.640184', u'1.SKD9.640182',
+            u'1.SKM1.640183', u'1.SKM2.640199', u'1.SKM3.640197',
+            u'1.SKM4.640180', u'1.SKM5.640177', u'1.SKM6.640187',
+            u'1.SKM7.640188', u'1.SKM8.640201', u'1.SKM9.640192'})
+
+        self.assertEqual(set(obs.columns), {
+            u'prep_template_id', u'center_name', u'center_project_name',
+            u'emp_status', u'barcodesequence',
+            u'library_construction_protocol', u'linkerprimersequence',
+            u'target_subfragment', u'target_gene', u'run_center',
+            u'run_prefix', u'run_date', u'experiment_center',
+            u'experiment_design_description', u'experiment_title', u'platform',
+            u'samp_size', u'sequencing_meth', u'illumina_technology',
+            u'sample_center', u'pcr_primers', u'study_center'})
+
+
+@qiita_test_checker()
+class TestPrepTemplateReadWrite(SetUpTestPrepTemplate):
+    """Tests the PrepTemplate class"""
+
+    def setUp(self):
+        self._set_up()
+        fd, seqs_fp = mkstemp(suffix='_seqs.fastq')
+        close(fd)
+        fd, barcodes_fp = mkstemp(suffix='_barcodes.fastq')
+        close(fd)
+        filepaths = [(seqs_fp, 1), (barcodes_fp, 2)]
+        with open(seqs_fp, "w") as f:
+            f.write("\n")
+        with open(barcodes_fp, "w") as f:
+            f.write("\n")
+        self.new_raw_data = RawData.create(2, [Study(1)], filepaths=filepaths)
+
+        db_test_raw_dir = join(get_db_files_base_dir(), 'raw_data')
+        db_seqs_fp = join(db_test_raw_dir, "5_%s" % basename(seqs_fp))
+        db_barcodes_fp = join(db_test_raw_dir, "5_%s" % basename(barcodes_fp))
+        self._clean_up_files = [db_seqs_fp, db_barcodes_fp]
 
     def test_create_duplicate_header(self):
         """Create raises an error when duplicate headers are present"""
@@ -786,34 +978,6 @@ class TestPrepTemplate(TestCase):
             self.conn_handler.execute_fetchall(
                 "SELECT * FROM qiita.prep_2")
 
-    def test_exists_true(self):
-        """Exists returns true when the PrepTemplate already exists"""
-        self.assertTrue(PrepTemplate.exists(1))
-
-    def test_exists_false(self):
-        """Exists returns false when the PrepTemplate does not exists"""
-        self.assertFalse(PrepTemplate.exists(2))
-
-    def test_get_sample_ids(self):
-        """get_sample_ids returns the correct set of sample ids"""
-        obs = self.tester._get_sample_ids(self.conn_handler)
-        self.assertEqual(obs, self.exp_sample_ids)
-
-    def test_len(self):
-        """Len returns the correct number of sample ids"""
-        self.assertEqual(len(self.tester), 27)
-
-    def test_getitem(self):
-        """Get item returns the correct sample object"""
-        obs = self.tester['1.SKM7.640188']
-        exp = PrepSample('1.SKM7.640188', self.tester)
-        self.assertEqual(obs, exp)
-
-    def test_getitem_error(self):
-        """Get item raises an error if key does not exists"""
-        with self.assertRaises(KeyError):
-            self.tester['Not_a_Sample']
-
     def test_setitem(self):
         """setitem raises an error (currently not allowed)"""
         with self.assertRaises(QiitaDBNotImplementedError):
@@ -824,109 +988,6 @@ class TestPrepTemplate(TestCase):
         """delitem raises an error (currently not allowed)"""
         with self.assertRaises(QiitaDBNotImplementedError):
             del self.tester['1.SKM7.640188']
-
-    def test_iter(self):
-        """iter returns an iterator over the sample ids"""
-        obs = self.tester.__iter__()
-        self.assertTrue(isinstance(obs, Iterable))
-        self.assertEqual(set(obs), self.exp_sample_ids)
-
-    def test_contains_true(self):
-        """contains returns true if the sample id exists"""
-        self.assertTrue('1.SKM7.640188' in self.tester)
-
-    def test_contains_false(self):
-        """contains returns false if the sample id does not exists"""
-        self.assertFalse('Not_a_Sample' in self.tester)
-
-    def test_keys(self):
-        """keys returns an iterator over the sample ids"""
-        obs = self.tester.keys()
-        self.assertTrue(isinstance(obs, Iterable))
-        self.assertEqual(set(obs), self.exp_sample_ids)
-
-    def test_values(self):
-        """values returns an iterator over the values"""
-        obs = self.tester.values()
-        self.assertTrue(isinstance(obs, Iterable))
-        exp = {PrepSample('1.SKB1.640202', self.tester),
-               PrepSample('1.SKB2.640194', self.tester),
-               PrepSample('1.SKB3.640195', self.tester),
-               PrepSample('1.SKB4.640189', self.tester),
-               PrepSample('1.SKB5.640181', self.tester),
-               PrepSample('1.SKB6.640176', self.tester),
-               PrepSample('1.SKB7.640196', self.tester),
-               PrepSample('1.SKB8.640193', self.tester),
-               PrepSample('1.SKB9.640200', self.tester),
-               PrepSample('1.SKD1.640179', self.tester),
-               PrepSample('1.SKD2.640178', self.tester),
-               PrepSample('1.SKD3.640198', self.tester),
-               PrepSample('1.SKD4.640185', self.tester),
-               PrepSample('1.SKD5.640186', self.tester),
-               PrepSample('1.SKD6.640190', self.tester),
-               PrepSample('1.SKD7.640191', self.tester),
-               PrepSample('1.SKD8.640184', self.tester),
-               PrepSample('1.SKD9.640182', self.tester),
-               PrepSample('1.SKM1.640183', self.tester),
-               PrepSample('1.SKM2.640199', self.tester),
-               PrepSample('1.SKM3.640197', self.tester),
-               PrepSample('1.SKM4.640180', self.tester),
-               PrepSample('1.SKM5.640177', self.tester),
-               PrepSample('1.SKM6.640187', self.tester),
-               PrepSample('1.SKM7.640188', self.tester),
-               PrepSample('1.SKM8.640201', self.tester),
-               PrepSample('1.SKM9.640192', self.tester)}
-        # Creating a list and looping over it since unittest does not call
-        # the __eq__ function on the objects
-        for o, e in zip(sorted(list(obs), key=lambda x: x.id),
-                        sorted(exp, key=lambda x: x.id)):
-            self.assertEqual(o, e)
-
-    def test_items(self):
-        """items returns an iterator over the (key, value) tuples"""
-        obs = self.tester.items()
-        self.assertTrue(isinstance(obs, Iterable))
-        exp = [('1.SKB1.640202', PrepSample('1.SKB1.640202', self.tester)),
-               ('1.SKB2.640194', PrepSample('1.SKB2.640194', self.tester)),
-               ('1.SKB3.640195', PrepSample('1.SKB3.640195', self.tester)),
-               ('1.SKB4.640189', PrepSample('1.SKB4.640189', self.tester)),
-               ('1.SKB5.640181', PrepSample('1.SKB5.640181', self.tester)),
-               ('1.SKB6.640176', PrepSample('1.SKB6.640176', self.tester)),
-               ('1.SKB7.640196', PrepSample('1.SKB7.640196', self.tester)),
-               ('1.SKB8.640193', PrepSample('1.SKB8.640193', self.tester)),
-               ('1.SKB9.640200', PrepSample('1.SKB9.640200', self.tester)),
-               ('1.SKD1.640179', PrepSample('1.SKD1.640179', self.tester)),
-               ('1.SKD2.640178', PrepSample('1.SKD2.640178', self.tester)),
-               ('1.SKD3.640198', PrepSample('1.SKD3.640198', self.tester)),
-               ('1.SKD4.640185', PrepSample('1.SKD4.640185', self.tester)),
-               ('1.SKD5.640186', PrepSample('1.SKD5.640186', self.tester)),
-               ('1.SKD6.640190', PrepSample('1.SKD6.640190', self.tester)),
-               ('1.SKD7.640191', PrepSample('1.SKD7.640191', self.tester)),
-               ('1.SKD8.640184', PrepSample('1.SKD8.640184', self.tester)),
-               ('1.SKD9.640182', PrepSample('1.SKD9.640182', self.tester)),
-               ('1.SKM1.640183', PrepSample('1.SKM1.640183', self.tester)),
-               ('1.SKM2.640199', PrepSample('1.SKM2.640199', self.tester)),
-               ('1.SKM3.640197', PrepSample('1.SKM3.640197', self.tester)),
-               ('1.SKM4.640180', PrepSample('1.SKM4.640180', self.tester)),
-               ('1.SKM5.640177', PrepSample('1.SKM5.640177', self.tester)),
-               ('1.SKM6.640187', PrepSample('1.SKM6.640187', self.tester)),
-               ('1.SKM7.640188', PrepSample('1.SKM7.640188', self.tester)),
-               ('1.SKM8.640201', PrepSample('1.SKM8.640201', self.tester)),
-               ('1.SKM9.640192', PrepSample('1.SKM9.640192', self.tester))]
-        # Creating a list and looping over it since unittest does not call
-        # the __eq__ function on the objects
-        for o, e in zip(sorted(list(obs)), sorted(exp)):
-            self.assertEqual(o, e)
-
-    def test_get(self):
-        """get returns the correct PrepSample object"""
-        obs = self.tester.get('1.SKM7.640188')
-        exp = PrepSample('1.SKM7.640188', self.tester)
-        self.assertEqual(obs, exp)
-
-    def test_get_none(self):
-        """get returns none if the sample id is not present"""
-        self.assertTrue(self.tester.get('Not_a_Sample') is None)
 
     def test_to_file(self):
         """to file writes a tab delimited file with all the metadata"""
@@ -939,22 +1000,6 @@ class TestPrepTemplate(TestCase):
         with open(fp, 'U') as f:
             obs = f.read()
         self.assertEqual(obs, EXP_PREP_TEMPLATE)
-
-    def test_data_type(self):
-        """data_type returns the string with the data_type"""
-        self.assertTrue(self.tester.data_type(), "18S")
-
-    def test_data_type_id(self):
-        """data_type returns the int with the data_type_id"""
-        self.assertTrue(self.tester.data_type(ret_id=True), 2)
-
-    def test_raw_data(self):
-        """Returns the raw_data associated with the prep template"""
-        self.assertEqual(self.tester.raw_data, 1)
-
-    def test_preprocessed_data(self):
-        """Returns the preprocessed data list generated from this template"""
-        self.assertEqual(self.tester.preprocessed_data, [1, 2])
 
     def test_preprocessing_status(self):
         """preprocessing_status works correctly"""
@@ -991,10 +1036,6 @@ class TestPrepTemplate(TestCase):
         with self.assertRaises(ValueError):
             self.tester.preprocessing_status = 'not a valid state'
 
-    def test_investigation_type(self):
-        """investigation_type works correctly"""
-        self.assertEqual(self.tester.investigation_type, "Metagenomics")
-
     def test_investigation_type_setter(self):
         """Able to update the investigation type"""
         pt = PrepTemplate.create(self.metadata, self.new_raw_data,
@@ -1025,34 +1066,6 @@ class TestPrepTemplate(TestCase):
         pt = PrepTemplate.create(self.metadata, self.new_raw_data,
                                  self.test_study, self.data_type_id)
         self.assertEqual(pt.status, 'sandbox')
-
-    def test_to_dataframe(self):
-        obs = self.tester.to_dataframe()
-        # We don't test the specific values as this would blow up the size
-        # of this file as the amount of lines would go to ~1000
-
-        # 27 samples
-        self.assertEqual(len(obs), 27)
-        self.assertEqual(set(obs.index), {
-            u'1.SKB1.640202', u'1.SKB2.640194', u'1.SKB3.640195',
-            u'1.SKB4.640189', u'1.SKB5.640181', u'1.SKB6.640176',
-            u'1.SKB7.640196', u'1.SKB8.640193', u'1.SKB9.640200',
-            u'1.SKD1.640179', u'1.SKD2.640178', u'1.SKD3.640198',
-            u'1.SKD4.640185', u'1.SKD5.640186', u'1.SKD6.640190',
-            u'1.SKD7.640191', u'1.SKD8.640184', u'1.SKD9.640182',
-            u'1.SKM1.640183', u'1.SKM2.640199', u'1.SKM3.640197',
-            u'1.SKM4.640180', u'1.SKM5.640177', u'1.SKM6.640187',
-            u'1.SKM7.640188', u'1.SKM8.640201', u'1.SKM9.640192'})
-
-        self.assertEqual(set(obs.columns), {
-            u'prep_template_id', u'center_name', u'center_project_name',
-            u'emp_status', u'barcodesequence',
-            u'library_construction_protocol', u'linkerprimersequence',
-            u'target_subfragment', u'target_gene', u'run_center',
-            u'run_prefix', u'run_date', u'experiment_center',
-            u'experiment_design_description', u'experiment_title', u'platform',
-            u'samp_size', u'sequencing_meth', u'illumina_technology',
-            u'sample_center', u'pcr_primers', u'study_center'})
 
 
 EXP_PREP_TEMPLATE = (

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -32,7 +32,7 @@ from qiita_db.metadata_template.sample_template import SampleTemplate, Sample
 from qiita_db.metadata_template.prep_template import PrepTemplate, PrepSample
 
 
-class SetUpTestSample(TestCase):
+class BaseTestSample(TestCase):
     def setUp(self):
         self.sample_template = SampleTemplate(1)
         self.sample_id = '1.SKB8.640193'
@@ -51,7 +51,7 @@ class SetUpTestSample(TestCase):
                                'env_feature', 'latitude', 'longitude'}
 
 
-class TestSampleReadOnly(SetUpTestSample):
+class TestSampleReadOnly(BaseTestSample):
     def test_init_unknown_error(self):
         """Init raises an error if the sample id is not found in the template
         """
@@ -204,7 +204,7 @@ class TestSampleReadOnly(SetUpTestSample):
 
 
 @qiita_test_checker()
-class TestSampleReadWrite(SetUpTestSample):
+class TestSampleReadWrite(BaseTestSample):
     def test_setitem(self):
         with self.assertRaises(QiitaDBColumnError):
             self.tester['column that does not exist'] = 0.30
@@ -218,7 +218,7 @@ class TestSampleReadWrite(SetUpTestSample):
             del self.tester['DEPTH']
 
 
-class SetUpTestSampleTemplate(TestCase):
+class BaseTestSampleTemplate(TestCase):
     def _set_up(self):
         self.metadata_dict = {
             'Sample1': {'physical_location': 'location1',
@@ -552,7 +552,7 @@ class SetUpTestSampleTemplate(TestCase):
             remove(f)
 
 
-class TestSampleTemplateReadOnly(SetUpTestSampleTemplate):
+class TestSampleTemplateReadOnly(BaseTestSampleTemplate):
     def setUp(self):
         self._set_up()
 
@@ -750,7 +750,7 @@ class TestSampleTemplateReadOnly(SetUpTestSampleTemplate):
 
 
 @qiita_test_checker()
-class TestSampleTemplateReadWrite(SetUpTestSampleTemplate):
+class TestSampleTemplateReadWrite(BaseTestSampleTemplate):
     """Tests the SampleTemplate class"""
 
     def setUp(self):

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -218,11 +218,8 @@ class TestSampleReadWrite(SetUpTestSample):
             del self.tester['DEPTH']
 
 
-@qiita_test_checker()
-class TestSampleTemplate(TestCase):
-    """Tests the SampleTemplate class"""
-
-    def setUp(self):
+class SetUpTestSampleTemplate(TestCase):
+    def _set_up(self):
         self.metadata_dict = {
             'Sample1': {'physical_location': 'location1',
                         'has_physical_specimen': True,
@@ -391,24 +388,6 @@ class TestSampleTemplate(TestCase):
             metadata_prefixed_dict, orient='index')
 
         self.test_study = Study(1)
-        info = {
-            "timeseries_type_id": 1,
-            "metadata_complete": True,
-            "mixs_compliant": True,
-            "number_samples_collected": 25,
-            "number_samples_promised": 28,
-            "portal_type_id": 3,
-            "study_alias": "FCM",
-            "study_description": "Microbiome of people who eat nothing but "
-                                 "fried chicken",
-            "study_abstract": "Exploring how a high fat diet changes the "
-                              "gut microbiome",
-            "emp_person_id": StudyPerson(2),
-            "principal_investigator_id": StudyPerson(3),
-            "lab_person_id": StudyPerson(1)
-        }
-        self.new_study = Study.create(User('test@foo.bar'),
-                                      "Fried Chicken Microbiome", [1], info)
         self.tester = SampleTemplate(1)
         self.exp_sample_ids = {
             '1.SKB1.640202', '1.SKB2.640194', '1.SKB3.640195', '1.SKB4.640189',
@@ -572,6 +551,11 @@ class TestSampleTemplate(TestCase):
         for f in self._clean_up_files:
             remove(f)
 
+
+class TestSampleTemplateReadOnly(SetUpTestSampleTemplate):
+    def setUp(self):
+        self._set_up()
+
     def test_study_id(self):
         """Ensure that the correct study ID is returned"""
         self.assertEqual(self.tester.study_id, 1)
@@ -590,6 +574,205 @@ class TestSampleTemplate(TestCase):
         """Table name return the correct string"""
         obs = SampleTemplate._table_name(self.test_study.id)
         self.assertEqual(obs, "sample_1")
+
+    def test_exists_true(self):
+        """Exists returns true when the SampleTemplate already exists"""
+        self.assertTrue(SampleTemplate.exists(self.test_study.id))
+
+    def test_get_sample_ids(self):
+        """get_sample_ids returns the correct set of sample ids"""
+        conn_handler = SQLConnectionHandler()
+        obs = self.tester._get_sample_ids(conn_handler)
+        self.assertEqual(obs, self.exp_sample_ids)
+
+    def test_len(self):
+        """Len returns the correct number of sample ids"""
+        self.assertEqual(len(self.tester), 27)
+
+    def test_getitem(self):
+        """Get item returns the correct sample object"""
+        obs = self.tester['1.SKM7.640188']
+        exp = Sample('1.SKM7.640188', self.tester)
+        self.assertEqual(obs, exp)
+
+    def test_getitem_error(self):
+        """Get item raises an error if key does not exists"""
+        with self.assertRaises(KeyError):
+            self.tester['Not_a_Sample']
+
+    def test_to_dataframe(self):
+        obs = self.tester.to_dataframe()
+        # We don't test the specific values as this would blow up the size
+        # of this file as the amount of lines would go to ~1000
+
+        # 27 samples
+        self.assertEqual(len(obs), 27)
+        self.assertEqual(set(obs.index), {
+            u'1.SKB1.640202', u'1.SKB2.640194', u'1.SKB3.640195',
+            u'1.SKB4.640189', u'1.SKB5.640181', u'1.SKB6.640176',
+            u'1.SKB7.640196', u'1.SKB8.640193', u'1.SKB9.640200',
+            u'1.SKD1.640179', u'1.SKD2.640178', u'1.SKD3.640198',
+            u'1.SKD4.640185', u'1.SKD5.640186', u'1.SKD6.640190',
+            u'1.SKD7.640191', u'1.SKD8.640184', u'1.SKD9.640182',
+            u'1.SKM1.640183', u'1.SKM2.640199', u'1.SKM3.640197',
+            u'1.SKM4.640180', u'1.SKM5.640177', u'1.SKM6.640187',
+            u'1.SKM7.640188', u'1.SKM8.640201', u'1.SKM9.640192'})
+
+        self.assertEqual(set(obs.columns), {
+            u'physical_location', u'has_physical_specimen',
+            u'has_extracted_data', u'sample_type',
+            u'required_sample_info_status', u'collection_timestamp',
+            u'host_subject_id', u'description', u'latitude', u'longitude',
+            u'season_environment', u'assigned_from_geo', u'texture',
+            u'taxon_id', u'depth', u'host_taxid', u'common_name',
+            u'water_content_soil', u'elevation', u'temp', u'tot_nitro',
+            u'samp_salinity', u'altitude', u'env_biome', u'country', u'ph',
+            u'anonymized_name', u'tot_org_carb', u'description_duplicate',
+            u'env_feature'})
+
+    def test_categories(self):
+        exp = {'sample_id', 'season_environment', 'assigned_from_geo',
+               'texture', 'taxon_id', 'depth', 'host_taxid',
+               'common_name', 'water_content_soil', 'elevation',
+               'temp', 'tot_nitro', 'samp_salinity', 'altitude',
+               'env_biome', 'country', 'ph', 'anonymized_name',
+               'tot_org_carb', 'description_duplicate', 'env_feature',
+               'study_id', 'physical_location',
+               'has_physical_specimen', 'has_extracted_data',
+               'sample_type', 'required_sample_info_status',
+               'collection_timestamp', 'host_subject_id',
+               'description', 'latitude', 'longitude'}
+        obs = set(self.tester.categories())
+        self.assertItemsEqual(obs, exp)
+
+    def test_iter(self):
+        """iter returns an iterator over the sample ids"""
+        obs = self.tester.__iter__()
+        self.assertTrue(isinstance(obs, Iterable))
+        self.assertEqual(set(obs), self.exp_sample_ids)
+
+    def test_contains_true(self):
+        """contains returns true if the sample id exists"""
+        self.assertTrue('1.SKM7.640188' in self.tester)
+
+    def test_contains_false(self):
+        """contains returns false if the sample id does not exists"""
+        self.assertFalse('Not_a_Sample' in self.tester)
+
+    def test_keys(self):
+        """keys returns an iterator over the sample ids"""
+        obs = self.tester.keys()
+        self.assertTrue(isinstance(obs, Iterable))
+        self.assertEqual(set(obs), self.exp_sample_ids)
+
+    def test_values(self):
+        """values returns an iterator over the values"""
+        obs = self.tester.values()
+        self.assertTrue(isinstance(obs, Iterable))
+        exp = {Sample('1.SKB1.640202', self.tester),
+               Sample('1.SKB2.640194', self.tester),
+               Sample('1.SKB3.640195', self.tester),
+               Sample('1.SKB4.640189', self.tester),
+               Sample('1.SKB5.640181', self.tester),
+               Sample('1.SKB6.640176', self.tester),
+               Sample('1.SKB7.640196', self.tester),
+               Sample('1.SKB8.640193', self.tester),
+               Sample('1.SKB9.640200', self.tester),
+               Sample('1.SKD1.640179', self.tester),
+               Sample('1.SKD2.640178', self.tester),
+               Sample('1.SKD3.640198', self.tester),
+               Sample('1.SKD4.640185', self.tester),
+               Sample('1.SKD5.640186', self.tester),
+               Sample('1.SKD6.640190', self.tester),
+               Sample('1.SKD7.640191', self.tester),
+               Sample('1.SKD8.640184', self.tester),
+               Sample('1.SKD9.640182', self.tester),
+               Sample('1.SKM1.640183', self.tester),
+               Sample('1.SKM2.640199', self.tester),
+               Sample('1.SKM3.640197', self.tester),
+               Sample('1.SKM4.640180', self.tester),
+               Sample('1.SKM5.640177', self.tester),
+               Sample('1.SKM6.640187', self.tester),
+               Sample('1.SKM7.640188', self.tester),
+               Sample('1.SKM8.640201', self.tester),
+               Sample('1.SKM9.640192', self.tester)}
+        # Creating a list and looping over it since unittest does not call
+        # the __eq__ function on the objects
+        for o, e in zip(sorted(list(obs), key=lambda x: x.id),
+                        sorted(exp, key=lambda x: x.id)):
+            self.assertEqual(o, e)
+
+    def test_items(self):
+        """items returns an iterator over the (key, value) tuples"""
+        obs = self.tester.items()
+        self.assertTrue(isinstance(obs, Iterable))
+        exp = [('1.SKB1.640202', Sample('1.SKB1.640202', self.tester)),
+               ('1.SKB2.640194', Sample('1.SKB2.640194', self.tester)),
+               ('1.SKB3.640195', Sample('1.SKB3.640195', self.tester)),
+               ('1.SKB4.640189', Sample('1.SKB4.640189', self.tester)),
+               ('1.SKB5.640181', Sample('1.SKB5.640181', self.tester)),
+               ('1.SKB6.640176', Sample('1.SKB6.640176', self.tester)),
+               ('1.SKB7.640196', Sample('1.SKB7.640196', self.tester)),
+               ('1.SKB8.640193', Sample('1.SKB8.640193', self.tester)),
+               ('1.SKB9.640200', Sample('1.SKB9.640200', self.tester)),
+               ('1.SKD1.640179', Sample('1.SKD1.640179', self.tester)),
+               ('1.SKD2.640178', Sample('1.SKD2.640178', self.tester)),
+               ('1.SKD3.640198', Sample('1.SKD3.640198', self.tester)),
+               ('1.SKD4.640185', Sample('1.SKD4.640185', self.tester)),
+               ('1.SKD5.640186', Sample('1.SKD5.640186', self.tester)),
+               ('1.SKD6.640190', Sample('1.SKD6.640190', self.tester)),
+               ('1.SKD7.640191', Sample('1.SKD7.640191', self.tester)),
+               ('1.SKD8.640184', Sample('1.SKD8.640184', self.tester)),
+               ('1.SKD9.640182', Sample('1.SKD9.640182', self.tester)),
+               ('1.SKM1.640183', Sample('1.SKM1.640183', self.tester)),
+               ('1.SKM2.640199', Sample('1.SKM2.640199', self.tester)),
+               ('1.SKM3.640197', Sample('1.SKM3.640197', self.tester)),
+               ('1.SKM4.640180', Sample('1.SKM4.640180', self.tester)),
+               ('1.SKM5.640177', Sample('1.SKM5.640177', self.tester)),
+               ('1.SKM6.640187', Sample('1.SKM6.640187', self.tester)),
+               ('1.SKM7.640188', Sample('1.SKM7.640188', self.tester)),
+               ('1.SKM8.640201', Sample('1.SKM8.640201', self.tester)),
+               ('1.SKM9.640192', Sample('1.SKM9.640192', self.tester))]
+        # Creating a list and looping over it since unittest does not call
+        # the __eq__ function on the objects
+        for o, e in zip(sorted(list(obs)), sorted(exp)):
+            self.assertEqual(o, e)
+
+    def test_get(self):
+        """get returns the correct sample object"""
+        obs = self.tester.get('1.SKM7.640188')
+        exp = Sample('1.SKM7.640188', self.tester)
+        self.assertEqual(obs, exp)
+
+    def test_get_none(self):
+        """get returns none if the sample id is not present"""
+        self.assertTrue(self.tester.get('Not_a_Sample') is None)
+
+
+@qiita_test_checker()
+class TestSampleTemplateReadWrite(SetUpTestSampleTemplate):
+    """Tests the SampleTemplate class"""
+
+    def setUp(self):
+        self._set_up()
+        info = {
+            "timeseries_type_id": 1,
+            "metadata_complete": True,
+            "mixs_compliant": True,
+            "number_samples_collected": 25,
+            "number_samples_promised": 28,
+            "portal_type_id": 3,
+            "study_alias": "FCM",
+            "study_description": "Microbiome of people who eat nothing but "
+                                 "fried chicken",
+            "study_abstract": "Exploring how a high fat diet changes the "
+                              "gut microbiome",
+            "emp_person_id": StudyPerson(2),
+            "principal_investigator_id": StudyPerson(3),
+            "lab_person_id": StudyPerson(1)
+        }
+        self.new_study = Study.create(User('test@foo.bar'),
+                                      "Fried Chicken Microbiome", [1], info)
 
     def test_create_duplicate(self):
         """Create raises an error when creating a duplicated SampleTemplate"""
@@ -839,33 +1022,9 @@ class TestSampleTemplate(TestCase):
         with self.assertRaises(QiitaDBUnknownIDError):
             SampleTemplate.delete(5)
 
-    def test_exists_true(self):
-        """Exists returns true when the SampleTemplate already exists"""
-        self.assertTrue(SampleTemplate.exists(self.test_study.id))
-
     def test_exists_false(self):
         """Exists returns false when the SampleTemplate does not exists"""
         self.assertFalse(SampleTemplate.exists(self.new_study.id))
-
-    def test_get_sample_ids(self):
-        """get_sample_ids returns the correct set of sample ids"""
-        obs = self.tester._get_sample_ids(self.conn_handler)
-        self.assertEqual(obs, self.exp_sample_ids)
-
-    def test_len(self):
-        """Len returns the correct number of sample ids"""
-        self.assertEqual(len(self.tester), 27)
-
-    def test_getitem(self):
-        """Get item returns the correct sample object"""
-        obs = self.tester['1.SKM7.640188']
-        exp = Sample('1.SKM7.640188', self.tester)
-        self.assertEqual(obs, exp)
-
-    def test_getitem_error(self):
-        """Get item raises an error if key does not exists"""
-        with self.assertRaises(KeyError):
-            self.tester['Not_a_Sample']
 
     def test_update_category(self):
         """setitem raises an error (currently not allowed)"""
@@ -940,36 +1099,6 @@ class TestSampleTemplate(TestCase):
         with self.assertRaises(QiitaDBError):
             st.update(self.metadata_dict_updated_column_error)
 
-    def test_to_dataframe(self):
-        obs = self.tester.to_dataframe()
-        # We don't test the specific values as this would blow up the size
-        # of this file as the amount of lines would go to ~1000
-
-        # 27 samples
-        self.assertEqual(len(obs), 27)
-        self.assertEqual(set(obs.index), {
-            u'1.SKB1.640202', u'1.SKB2.640194', u'1.SKB3.640195',
-            u'1.SKB4.640189', u'1.SKB5.640181', u'1.SKB6.640176',
-            u'1.SKB7.640196', u'1.SKB8.640193', u'1.SKB9.640200',
-            u'1.SKD1.640179', u'1.SKD2.640178', u'1.SKD3.640198',
-            u'1.SKD4.640185', u'1.SKD5.640186', u'1.SKD6.640190',
-            u'1.SKD7.640191', u'1.SKD8.640184', u'1.SKD9.640182',
-            u'1.SKM1.640183', u'1.SKM2.640199', u'1.SKM3.640197',
-            u'1.SKM4.640180', u'1.SKM5.640177', u'1.SKM6.640187',
-            u'1.SKM7.640188', u'1.SKM8.640201', u'1.SKM9.640192'})
-
-        self.assertEqual(set(obs.columns), {
-            u'physical_location', u'has_physical_specimen',
-            u'has_extracted_data', u'sample_type',
-            u'required_sample_info_status', u'collection_timestamp',
-            u'host_subject_id', u'description', u'latitude', u'longitude',
-            u'season_environment', u'assigned_from_geo', u'texture',
-            u'taxon_id', u'depth', u'host_taxid', u'common_name',
-            u'water_content_soil', u'elevation', u'temp', u'tot_nitro',
-            u'samp_salinity', u'altitude', u'env_biome', u'country', u'ph',
-            u'anonymized_name', u'tot_org_carb', u'description_duplicate',
-            u'env_feature'})
-
     def test_add_category(self):
         column = "new_column"
         dtype = "varchar"
@@ -1012,21 +1141,6 @@ class TestSampleTemplate(TestCase):
         obs = {k: v['new_column'] for k, v in self.tester.items()}
         self.assertEqual(obs, exp)
 
-    def test_categories(self):
-        exp = {'sample_id', 'season_environment', 'assigned_from_geo',
-               'texture', 'taxon_id', 'depth', 'host_taxid',
-               'common_name', 'water_content_soil', 'elevation',
-               'temp', 'tot_nitro', 'samp_salinity', 'altitude',
-               'env_biome', 'country', 'ph', 'anonymized_name',
-               'tot_org_carb', 'description_duplicate', 'env_feature',
-               'study_id', 'physical_location',
-               'has_physical_specimen', 'has_extracted_data',
-               'sample_type', 'required_sample_info_status',
-               'collection_timestamp', 'host_subject_id',
-               'description', 'latitude', 'longitude'}
-        obs = set(self.tester.categories())
-        self.assertItemsEqual(obs, exp)
-
     def test_remove_category(self):
         with self.assertRaises(QiitaDBColumnError):
             self.tester.remove_category('does not exist')
@@ -1038,109 +1152,6 @@ class TestSampleTemplate(TestCase):
 
         for v in self.tester.values():
             self.assertNotIn('elevation', v)
-
-    def test_iter(self):
-        """iter returns an iterator over the sample ids"""
-        obs = self.tester.__iter__()
-        self.assertTrue(isinstance(obs, Iterable))
-        self.assertEqual(set(obs), self.exp_sample_ids)
-
-    def test_contains_true(self):
-        """contains returns true if the sample id exists"""
-        self.assertTrue('1.SKM7.640188' in self.tester)
-
-    def test_contains_false(self):
-        """contains returns false if the sample id does not exists"""
-        self.assertFalse('Not_a_Sample' in self.tester)
-
-    def test_keys(self):
-        """keys returns an iterator over the sample ids"""
-        obs = self.tester.keys()
-        self.assertTrue(isinstance(obs, Iterable))
-        self.assertEqual(set(obs), self.exp_sample_ids)
-
-    def test_values(self):
-        """values returns an iterator over the values"""
-        obs = self.tester.values()
-        self.assertTrue(isinstance(obs, Iterable))
-        exp = {Sample('1.SKB1.640202', self.tester),
-               Sample('1.SKB2.640194', self.tester),
-               Sample('1.SKB3.640195', self.tester),
-               Sample('1.SKB4.640189', self.tester),
-               Sample('1.SKB5.640181', self.tester),
-               Sample('1.SKB6.640176', self.tester),
-               Sample('1.SKB7.640196', self.tester),
-               Sample('1.SKB8.640193', self.tester),
-               Sample('1.SKB9.640200', self.tester),
-               Sample('1.SKD1.640179', self.tester),
-               Sample('1.SKD2.640178', self.tester),
-               Sample('1.SKD3.640198', self.tester),
-               Sample('1.SKD4.640185', self.tester),
-               Sample('1.SKD5.640186', self.tester),
-               Sample('1.SKD6.640190', self.tester),
-               Sample('1.SKD7.640191', self.tester),
-               Sample('1.SKD8.640184', self.tester),
-               Sample('1.SKD9.640182', self.tester),
-               Sample('1.SKM1.640183', self.tester),
-               Sample('1.SKM2.640199', self.tester),
-               Sample('1.SKM3.640197', self.tester),
-               Sample('1.SKM4.640180', self.tester),
-               Sample('1.SKM5.640177', self.tester),
-               Sample('1.SKM6.640187', self.tester),
-               Sample('1.SKM7.640188', self.tester),
-               Sample('1.SKM8.640201', self.tester),
-               Sample('1.SKM9.640192', self.tester)}
-        # Creating a list and looping over it since unittest does not call
-        # the __eq__ function on the objects
-        for o, e in zip(sorted(list(obs), key=lambda x: x.id),
-                        sorted(exp, key=lambda x: x.id)):
-            self.assertEqual(o, e)
-
-    def test_items(self):
-        """items returns an iterator over the (key, value) tuples"""
-        obs = self.tester.items()
-        self.assertTrue(isinstance(obs, Iterable))
-        exp = [('1.SKB1.640202', Sample('1.SKB1.640202', self.tester)),
-               ('1.SKB2.640194', Sample('1.SKB2.640194', self.tester)),
-               ('1.SKB3.640195', Sample('1.SKB3.640195', self.tester)),
-               ('1.SKB4.640189', Sample('1.SKB4.640189', self.tester)),
-               ('1.SKB5.640181', Sample('1.SKB5.640181', self.tester)),
-               ('1.SKB6.640176', Sample('1.SKB6.640176', self.tester)),
-               ('1.SKB7.640196', Sample('1.SKB7.640196', self.tester)),
-               ('1.SKB8.640193', Sample('1.SKB8.640193', self.tester)),
-               ('1.SKB9.640200', Sample('1.SKB9.640200', self.tester)),
-               ('1.SKD1.640179', Sample('1.SKD1.640179', self.tester)),
-               ('1.SKD2.640178', Sample('1.SKD2.640178', self.tester)),
-               ('1.SKD3.640198', Sample('1.SKD3.640198', self.tester)),
-               ('1.SKD4.640185', Sample('1.SKD4.640185', self.tester)),
-               ('1.SKD5.640186', Sample('1.SKD5.640186', self.tester)),
-               ('1.SKD6.640190', Sample('1.SKD6.640190', self.tester)),
-               ('1.SKD7.640191', Sample('1.SKD7.640191', self.tester)),
-               ('1.SKD8.640184', Sample('1.SKD8.640184', self.tester)),
-               ('1.SKD9.640182', Sample('1.SKD9.640182', self.tester)),
-               ('1.SKM1.640183', Sample('1.SKM1.640183', self.tester)),
-               ('1.SKM2.640199', Sample('1.SKM2.640199', self.tester)),
-               ('1.SKM3.640197', Sample('1.SKM3.640197', self.tester)),
-               ('1.SKM4.640180', Sample('1.SKM4.640180', self.tester)),
-               ('1.SKM5.640177', Sample('1.SKM5.640177', self.tester)),
-               ('1.SKM6.640187', Sample('1.SKM6.640187', self.tester)),
-               ('1.SKM7.640188', Sample('1.SKM7.640188', self.tester)),
-               ('1.SKM8.640201', Sample('1.SKM8.640201', self.tester)),
-               ('1.SKM9.640192', Sample('1.SKM9.640192', self.tester))]
-        # Creating a list and looping over it since unittest does not call
-        # the __eq__ function on the objects
-        for o, e in zip(sorted(list(obs)), sorted(exp)):
-            self.assertEqual(o, e)
-
-    def test_get(self):
-        """get returns the correct sample object"""
-        obs = self.tester.get('1.SKM7.640188')
-        exp = Sample('1.SKM7.640188', self.tester)
-        self.assertEqual(obs, exp)
-
-    def test_get_none(self):
-        """get returns none if the sample id is not present"""
-        self.assertTrue(self.tester.get('Not_a_Sample') is None)
 
     def test_to_file(self):
         """to file writes a tab delimited file with all the metadata"""


### PR DESCRIPTION
Fixes one item from #1029 

Splits the metadata template tests between DB read only tests and DB read write tests (so it saves time since it does not have to rebuild the database in each test).

I just wanted to move tests around, but I fixed a couple of small issues:
 - MetadataTemplate no longer has a create function so I removed the test (it was a leftover)
 - to_dataframe is not a classmethod so it does not need the _check_subclass class and by extension it does not need a test on MetadataTemplate
 - Delete did not had the call to _check_subclass, so I added it and a test on MetadataTemplate

Since this is a performance PR, some times:

Now:
```
$ nosetests qiita_db/metadata_template/test/
............../Users/jose/qiime_software/QiiTa/qiita_db/metadata_template/util.py:103: QiitaDBWarning: Sample names were already prefixed with the study id.
  QiitaDBWarning)
../Users/jose/qiime_software/QiiTa/qiita_db/metadata_template/util.py:103: QiitaDBWarning: Sample names were already prefixed with the study id.
  QiitaDBWarning)
....................................................................................................................................................
----------------------------------------------------------------------
Ran 164 tests in 61.491s

OK
```

Before:
```
$ nosetests qiita_db/metadata_template/test/
......................................./Users/jose/qiime_software/QiiTa/qiita_db/metadata_template/util.py:103: QiitaDBWarning: Sample names were already prefixed with the study id.
  QiitaDBWarning)
../Users/jose/qiime_software/QiiTa/qiita_db/metadata_template/util.py:103: QiitaDBWarning: Sample names were already prefixed with the study id.
  QiitaDBWarning)
............................................................................................................................
----------------------------------------------------------------------
Ran 165 tests in 163.808s

OK
```

Any future PR on the metadata template depends on this one, since this reduces developer time (less time on tests, more time coding), so a fast review/merge is appreciated.