### PR TITLE
List proc data in search

### DIFF
--- a/qiita_pet/handlers/study_handlers/listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/listing_handlers.py
@@ -43,7 +43,7 @@ def _get_shared_links_for_study(study):
     return ", ".join(shared)
 
 
-def _build_single_study_info(study, info):
+def _build_single_study_info(study, info, study_proc, proc_samples):
     """Clean up and add to the study info for HTML purposes
 
     Parameters
@@ -75,6 +75,9 @@ def _build_single_study_info(study, info):
     info["pi"] = study_person_linkifier((PI.email, PI.name))
     del info["principal_investigator_id"]
     del info["email"]
+    # Build the proc data info list for the child row in datatable
+    info["proc_data_info"] = _build_single_proc_data_info(
+        study, study_proc, proc_samples)
     return info
 
 
@@ -174,11 +177,8 @@ def _build_study_info(user, study_proc=None, proc_samples=None):
                 for pid in proc_data:
                     proc_samples[pid] = ProcessedData(pid).samples
 
-        study_info = _build_single_study_info(study, info)
-        # Build the proc data info list for the child row in datatable
-        study_info["proc_data_info"] = _build_single_proc_data_info(
-            study, study_proc, proc_samples)
-
+        study_info = _build_single_study_info(study, info, study_proc,
+                                              proc_samples)
         infolist.append(study_info)
     return infolist
 

--- a/qiita_pet/handlers/study_handlers/listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/listing_handlers.py
@@ -8,6 +8,7 @@
 from __future__ import division
 from json import dumps
 from future.utils import viewitems
+from collections import defaultdict
 
 from tornado.web import authenticated, HTTPError
 from tornado.gen import coroutine, Task
@@ -52,9 +53,9 @@ def _build_single_study_info(study, info, study_proc, proc_samples):
         The study to build information for
     info : dict
         Information from Study.get_info
-    study_proc : dict of lists
+    study_proc : dict of dict of lists
         Dictionary keyed on study_id that lists all processed data associated
-        with that study.
+        with that study. This list of processed data ids is keyed by data type
     proc_samples : dict of lists
         Dictionary keyed on proc_data_id that lists all samples associated with
         that processed data.
@@ -82,13 +83,14 @@ def _build_single_study_info(study, info, study_proc, proc_samples):
     del info["principal_investigator_id"]
     del info["email"]
     # Build the proc data info list for the child row in datatable
-    info["proc_data_info"] = [
-        _build_single_proc_data_info(pd_id, proc_samples[pd_id])
-        for pd_id in study_proc[study.id]]
+    for data_type, proc_datas in viewitems(study_proc[study.id]):
+        info["proc_data_info"] = [
+            _build_single_proc_data_info(pd_id, data_type, proc_samples[pd_id])
+            for pd_id in proc_datas]
     return info
 
 
-def _build_single_proc_data_info(proc_data_id, samples):
+def _build_single_proc_data_info(proc_data_id, data_type, samples):
     """Build the proc data info list for the child row in datatable
 
     Parameters
@@ -96,6 +98,8 @@ def _build_single_proc_data_info(proc_data_id, samples):
     proc_data_id : int
         The processed data attached to he study, in the form
         {study_id: [proc_data_id, proc_data_id, ...], ...}
+    data_type : str
+        Data type of the processed data
     proc_samples : dict of lists
         The samples available in the processed data, in the form
         {proc_data_id: [samp1, samp2, ...], ...}
@@ -108,7 +112,7 @@ def _build_single_proc_data_info(proc_data_id, samples):
     proc_data = ProcessedData(proc_data_id)
     proc_info = proc_data.processing_info
     proc_info['pid'] = proc_data_id
-    proc_info['data_type'] = proc_data.data_type()
+    proc_info['data_type'] = data_type
     proc_info['samples'] = sorted(samples)
     proc_info['processed_date'] = str(proc_info['processed_date'])
     return proc_info
@@ -171,11 +175,13 @@ def _build_study_info(user, study_proc=None, proc_samples=None):
         study = Study(info['study_id'])
         # Build the processed data info for the study if none passed
         if build_samples:
-            proc_data = study.processed_data()
+            proc_data_list = study.processed_data()
             proc_samples = {}
-            study_proc = {study.id: proc_data}
-            for pid in proc_data:
-                proc_samples[pid] = ProcessedData(pid).samples
+            study_proc = {study.id: defaultdict(list)}
+            for pid in proc_data_list:
+                proc_data = ProcessedData(pid)
+                study_proc[study.id][proc_data.data_type()].append(pid)
+                proc_samples[pid] = proc_data.samples
 
         study_info = _build_single_study_info(study, info, study_proc,
                                               proc_samples)

--- a/qiita_pet/handlers/study_handlers/listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/listing_handlers.py
@@ -120,6 +120,8 @@ def _build_study_info(user, study_proc=None, proc_samples=None):
         info["status"] = status
         info["study_id"] = study.id
         info["pi"] = study_person_linkifier((PI.email, PI.name))
+        del info["principal_investigator_id"]
+        del info["email"]
         # Build the proc data info list for the child row in datatable
         proc_data_info = []
         for pid in study_proc[study.id]:

--- a/qiita_pet/handlers/study_handlers/listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/listing_handlers.py
@@ -123,7 +123,7 @@ def _build_study_info(user, study_proc=None, proc_samples=None):
         with that study. Required if proc_samples given.
     proc_samples : dict of lists, optional
         Dictionary keyed on proc_data_id that lists all samples associated with
-        that processed data. Rquired if study_proc given.
+        that processed data. Required if study_proc given.
 
     Returns
     -------

--- a/qiita_pet/handlers/study_handlers/listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/listing_handlers.py
@@ -62,12 +62,15 @@ def _build_study_info(user, study_proc=None, proc_samples=None):
     Both study_proc and proc_samples must be passed, or neither passed.
     """
     # Logic check to make sure both needed parts passed
+    build_info = False
     if study_proc is not None and proc_samples is None:
         raise IncompetentQiitaDeveloperError(
             'Must pass proc_samples when study_proc given')
     elif proc_samples is not None and study_proc is None:
         raise IncompetentQiitaDeveloperError(
             'Must pass study_proc when proc_samples given')
+    elif proc_samples is None:
+        build_info = True
 
     # get list of studies for table
     study_list = user.user_studies.union(
@@ -89,7 +92,7 @@ def _build_study_info(user, study_proc=None, proc_samples=None):
         study = Study(info['study_id'])
         status = study.status
         # if needed, get all the proc data info since no search results passed
-        if study_proc is None:
+        if build_info:
             proc_data = study.processed_data()
             proc_samples = {}
             study_proc = {study.id: proc_data}

--- a/qiita_pet/handlers/study_handlers/listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/listing_handlers.py
@@ -44,7 +44,21 @@ def _get_shared_links_for_study(study):
 
 
 def _build_single_study_info(study, info):
-    # Clean up and add to the study info for HTML purposes
+    """Clean up and add to the study info for HTML purposes
+
+    Parameters
+    ----------
+    study : Study object
+        The study to build information for
+    info : dict
+        Information from Study.get_info
+
+    Returns
+    -------
+    dict
+        info-information + extra information for the study,
+        slightly HTML formatted
+    """
     PI = StudyPerson(info['principal_investigator_id'])
     status = study.status
     if info['pmid'] is not None:
@@ -64,8 +78,27 @@ def _build_single_study_info(study, info):
     return info
 
 
-def _build_proc_data_info(study, study_proc, proc_samples):
-    # Build the proc data info list for the child row in datatable
+def _build_single_proc_data_info(study, study_proc, proc_samples):
+    """Build the proc data info list for the child row in datatable
+
+
+    Parameters
+    ----------
+    study : Study object
+        The study to build information for
+    study_proc : dict of lists
+        The processed data attached to he study, in the form
+        {study_id: [proc_data_id, proc_data_id, ...], ...}
+    proc_samples : dict of lists
+        The samples available in the processed data, in the form
+        {proc_data_id: [samp1, samp2, ...], ...}
+
+    Returns
+    -------
+    dict of dicts
+        The information for the processed data, in the form
+        {proc_data_id: {info: value, ...}, ...}
+    """
     proc_data_info = []
     for pid in study_proc[study.id]:
         proc_data = ProcessedData(pid)
@@ -143,8 +176,8 @@ def _build_study_info(user, study_proc=None, proc_samples=None):
 
         study_info = _build_single_study_info(study, info)
         # Build the proc data info list for the child row in datatable
-        study_info["proc_data_info"] = _build_proc_data_info(study, study_proc,
-                                                             proc_samples)
+        study_info["proc_data_info"] = _build_single_proc_data_info(
+            study, study_proc, proc_samples)
 
         infolist.append(study_info)
     return infolist

--- a/qiita_pet/handlers/study_handlers/listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/listing_handlers.py
@@ -131,10 +131,12 @@ def _build_study_info(user, study_proc=None, proc_samples=None):
         proc_data_info = []
         for pid in study_proc[study.id]:
             proc_data = ProcessedData(pid)
-            info = proc_data.processing_info
-            info['pid'] = pid
-            info['samples'] = proc_samples[pid]
-            proc_data_info.append(info)
+            proc_info = proc_data.processing_info
+            proc_info['pid'] = pid
+            proc_info['data_type'] = proc_data.data_type()
+            proc_info['samples'] = sorted(proc_samples[pid])
+            proc_info['processed_date'] = str(proc_info['processed_date'])
+            proc_data_info.append(proc_info)
 
         infolist.append({
             "checkbox": "<input type='checkbox' value='%d' />" % study.id,
@@ -235,7 +237,6 @@ class SearchStudiesAJAX(BaseHandler):
 
         if user != self.current_user.id:
             raise HTTPError(403, 'Unauthorized search!')
-        res = None
         if query:
             # Search for samples matching the query
             search = QiitaStudySearch()

--- a/qiita_pet/handlers/study_handlers/listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/listing_handlers.py
@@ -83,10 +83,11 @@ def _build_single_study_info(study, info, study_proc, proc_samples):
     del info["principal_investigator_id"]
     del info["email"]
     # Build the proc data info list for the child row in datatable
+    info["proc_data_info"] = []
     for data_type, proc_datas in viewitems(study_proc[study.id]):
-        info["proc_data_info"] = [
+        info["proc_data_info"].extend([
             _build_single_proc_data_info(pd_id, data_type, proc_samples[pd_id])
-            for pd_id in proc_datas]
+            for pd_id in proc_datas])
     return info
 
 

--- a/qiita_pet/templates/list_studies.html
+++ b/qiita_pet/templates/list_studies.html
@@ -62,7 +62,7 @@ $(document).ready(function() {
               {"render": function ( data, type, row, meta ) {
                     var glyph = 'remove';
                     if(data === true) { glyph = 'ok' } 
-                    return "<span id='shared_html_"+ data.study_id +"'>"+ data +"</span><br/><a class='btn btn-primary btn-xs' data-toggle='modal' data-target='#share-study-modal-view' onclick='modify_sharing("+ data.study_id +");'>Modify</a>";
+                    return "<span id='shared_html_"+ row.study_id +"'>"+ data +"</span><br/><a class='btn btn-primary btn-xs' data-toggle='modal' data-target='#share-study-modal-view' onclick='modify_sharing("+ row.study_id +");'>Modify</a>";
               }, targets: [7]},
               ],
             "oLanguage": {

--- a/qiita_pet/templates/list_studies.html
+++ b/qiita_pet/templates/list_studies.html
@@ -27,12 +27,12 @@ $(document).ready(function() {
 
         $('#studies-table').dataTable({
             "columns": [
-              { "data": "checkbox", "orderable": false},
-              { "data": "title" },
-              { "data": "abstract" },
-              { "data": "id" },
-              { "data": "meta_complete" },
-              { "data": "num_samples" },
+              { "className": 'details-control', "orderable": false},
+              { "data": "study_title" },
+              { "data": "study_abstract" },
+              { "data": "study_id" },
+              { "data": "metadata_complete" },
+              { "data": "number_samples_collected" },
               { "data": "num_raw_data" },
               { "data": "shared" },
               { "data": "pi" },
@@ -41,12 +41,29 @@ $(document).ready(function() {
               {"className": 'details-control', "orderable": false, "data": null, "defaultContent": '<span class="glyphicon glyphicon-chevron-down"></span>'}
             ],
             order: [[10, "desc"], [ 1, "asc" ]],
-            columnDefs: [{type:'natural', targets:[3,4,5,9]}, {"targets": [ 2 ],"visible": false}],
+            columnDefs: [
+              {type:'natural', targets:[3,4,5,9]},
+              {"targets": [ 2 ],"visible": false},
+              // render the study checkbox cell
+              {"render": function ( data, type, row, meta ) {
+                    return "<input type='checkbox' value='"+ row.study_id +"'>";
+              }, targets: [0]},
+              // render the title cell
+              {"render": function ( data, type, row, meta ) {
+                    return "<a href='#' data-toggle='modal' data-target='#study-abstract-modal' onclick=\"fillAbstract('studies-table', "+ meta.row +")\"><span class='glyphicon glyphicon-file' aria-hidden='true'></span></a> | <a href='/study/description/"+ row.study_id +"' id='study"+ meta.row +"-title'>"+ data +"</a>";
+              }, targets: [1]},
+              // render the metadata complete cell
+              {"render": function ( data, type, row, meta ) {
+                    var glyph = 'remove';
+                    if(data === true) { glyph = 'ok' } 
+                    return "<span class='glyphicon glyphicon-"+ glyph +"'></span>";
+              }, targets: [4]}
+              ],
             "oLanguage": {
                 "sSearch": "Narrow search results by column data (Title, abstract, PI, etc):",
                 "sLoadingRecords": "Loading table data",
                 "sZeroRecords": "No studies found"
-            }, 
+            },
             "ajax": {
                 "url": ajaxURL + "&query=",
                 "error": function(jqXHR, textStatus, ex) {
@@ -153,7 +170,7 @@ function add_metacat(metacat) {
                 <th>Principal Investigator</th>
                 <th>Pubmed ID(s)</th>
                 <th>Status</th>
-                <th></th>
+                <th>Expand</th>
             </tr>
         </thead>
     </table>

--- a/qiita_pet/templates/list_studies.html
+++ b/qiita_pet/templates/list_studies.html
@@ -81,7 +81,7 @@ $(document).ready(function() {
         });
     // Add event listener for opening and closing details
     $('#studies-table tbody').on('click', 'td.details-control', function () {
-      var table = $('#studies-table').DataTable();
+        var table = $('#studies-table').DataTable();
         var tr = $(this).closest('tr');
         var row = table.row( tr );
  

--- a/qiita_pet/templates/list_studies.html
+++ b/qiita_pet/templates/list_studies.html
@@ -1,7 +1,11 @@
 {% extends sitebase.html %}
 {% block head %}
 <link rel="stylesheet" href="/static/vendor/css/jquery.dataTables.css" type="text/css">
-
+<style>
+td.details-control {
+  cursor: pointer;
+}
+</style>
 <script src="/static/vendor/js/jquery.dataTables.min.js"></script>
 <script src="/static/vendor/js/jquery.dataTables.plugin.natural.js"></script>
 
@@ -12,10 +16,10 @@ $(document).ready(function() {
 
         function format ( d ) {
             // `d` is the original data object for the row
-            var proc_data_table = '<table cellpadding="5" cellspacing="0" border="0" style="padding-left:50px;"><tr><th></th><th>ID</th><th>Data type</th><th>Processed Date</th><th>Reference</th></tr>';
+            var proc_data_table = '<h4>Processed Data</h4><table class="table" cellpadding="5" cellspacing="0" border="0" style="padding-left:50px;"><tr><th></th><th>ID</th><th>Data type</th><th>Processed Date</th><th>Algorithm</th><th>Reference</th><th>Samples</th></tr>';
             for(i=0;i<d.proc_data_info.length;i++) {
               var proc_data = d.proc_data_info[i];
-              proc_data_table += '<tr><td><input type="checkbox"></td><td>' + proc_data.pid + '</td><td>' + proc_data.data_type + '</td><td>' + proc_data.processed_date + '</td><td>' + proc_data.refrence + ' ' + proc_data.reference_version + '</td></tr>';
+              proc_data_table += '<tr><td><input type="checkbox"></td><td>' + proc_data.pid + '</td><td>' + proc_data.data_type + '</td><td>' + proc_data.processed_date + '</td><td>' + proc_data.algorithm + '</td><td>' + proc_data.reference_name + ' ' + proc_data.reference_version + '</td><td>' + proc_data.samples.length + '</td></tr>';
             }
             proc_data_table += '</table>';
             return proc_data_table;
@@ -23,7 +27,7 @@ $(document).ready(function() {
 
         $('#studies-table').dataTable({
             "columns": [
-              {"className": 'details-control', "orderable": false, "data": null, "defaultContent": ''},
+              { "data": "checkbox", "orderable": false},
               { "data": "title" },
               { "data": "abstract" },
               { "data": "id" },
@@ -33,7 +37,8 @@ $(document).ready(function() {
               { "data": "shared" },
               { "data": "pi" },
               { "data": "pmid" },
-              { "data": "status" }
+              { "data": "status" },
+              {"className": 'details-control', "orderable": false, "data": null, "defaultContent": '<span class="glyphicon glyphicon-chevron-down"></span>'}
             ],
             order: [[10, "desc"], [ 1, "asc" ]],
             columnDefs: [{type:'natural', targets:[3,4,5,9]}, {"targets": [ 2 ],"visible": false}],
@@ -53,6 +58,7 @@ $(document).ready(function() {
         });
     // Add event listener for opening and closing details
     $('#studies-table tbody').on('click', 'td.details-control', function () {
+      var table = $('#studies-table').DataTable();
         var tr = $(this).closest('tr');
         var row = table.row( tr );
  
@@ -133,7 +139,7 @@ function add_metacat(metacat) {
 <div class="row">
   <div class="col-sm-12" id="user-studies-div">
     <h1>Available Studies</h1>
-    <table id="studies-table" class="display table-bordered table-hover">
+    <table id="studies-table" class="table table-bordered">
         <thead>
             <tr>
                 <th></th>
@@ -147,10 +153,9 @@ function add_metacat(metacat) {
                 <th>Principal Investigator</th>
                 <th>Pubmed ID(s)</th>
                 <th>Status</th>
+                <th></th>
             </tr>
         </thead>
-        <tbody>
-        </tbody>
     </table>
 <!--Abstract Modal-->
 <div class="modal fade" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel" aria-hidden="true" id="study-abstract-modal">

--- a/qiita_pet/templates/list_studies.html
+++ b/qiita_pet/templates/list_studies.html
@@ -57,7 +57,13 @@ $(document).ready(function() {
                     var glyph = 'remove';
                     if(data === true) { glyph = 'ok' } 
                     return "<span class='glyphicon glyphicon-"+ glyph +"'></span>";
-              }, targets: [4]}
+              }, targets: [4]},
+              // render the shared with cell
+              {"render": function ( data, type, row, meta ) {
+                    var glyph = 'remove';
+                    if(data === true) { glyph = 'ok' } 
+                    return "<span id='shared_html_"+ data.study_id +"'>"+ data +"</span><br/><a class='btn btn-primary btn-xs' data-toggle='modal' data-target='#share-study-modal-view' onclick='modify_sharing("+ data.study_id +");'>Modify</a>";
+              }, targets: [7]},
               ],
             "oLanguage": {
                 "sSearch": "Narrow search results by column data (Title, abstract, PI, etc):",

--- a/qiita_pet/templates/list_studies.html
+++ b/qiita_pet/templates/list_studies.html
@@ -9,9 +9,21 @@
 var current_study;
 var ajaxURL = "/study/search/?&user={{current_user.id}}&sEcho=" + Math.floor(Math.random()*1001);
 $(document).ready(function() {
+
+        function format ( d ) {
+            // `d` is the original data object for the row
+            var proc_data_table = '<table cellpadding="5" cellspacing="0" border="0" style="padding-left:50px;"><tr><th></th><th>ID</th><th>Data type</th><th>Processed Date</th><th>Reference</th></tr>';
+            for(i=0;i<d.proc_data_info.length;i++) {
+              var proc_data = d.proc_data_info[i];
+              proc_data_table += '<tr><td><input type="checkbox"></td><td>' + proc_data.pid + '</td><td>' + proc_data.data_type + '</td><td>' + proc_data.processed_date + '</td><td>' + proc_data.refrence + ' ' + proc_data.reference_version + '</td></tr>';
+            }
+            proc_data_table += '</table>';
+            return proc_data_table;
+        }
+
         $('#studies-table').dataTable({
             "columns": [
-              { "data": "checkbox" },
+              {"className": 'details-control', "orderable": false, "data": null, "defaultContent": ''},
               { "data": "title" },
               { "data": "abstract" },
               { "data": "id" },
@@ -39,6 +51,22 @@ $(document).ready(function() {
                 }
             } 
         });
+    // Add event listener for opening and closing details
+    $('#studies-table tbody').on('click', 'td.details-control', function () {
+        var tr = $(this).closest('tr');
+        var row = table.row( tr );
+ 
+        if ( row.child.isShown() ) {
+            // This row is already open - close it
+            row.child.hide();
+            tr.removeClass('shown');
+        }
+        else {
+            // Open this row
+            row.child( format(row.data()) ).show();
+            tr.addClass('shown');
+        }
+    } );
 
     $('#users_list').chosen({width: "100%"});
     $('#users_list').on('change', function(evt, params) {

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -2,6 +2,7 @@ from unittest import main
 from json import loads
 
 from qiita_pet.test.tornado_test_base import TestHandlerBase
+from qiita_core.exceptions import IncompetentQiitaDeveloperError
 from qiita_db.study import StudyPerson, Study
 from qiita_db.util import get_count, check_count
 from qiita_db.user import User
@@ -14,7 +15,7 @@ class TestHelpers(TestHandlerBase):
     database = True
 
     def setUp(self):
-        self.proc_data_exp = [{
+        self.proc_data_exp = {
             'pid': 1,
             'processed_date': '2012-10-01 09:30:27',
             'data_type': '18S',
@@ -36,7 +37,7 @@ class TestHelpers(TestHandlerBase):
                         '1.SKM1.640183', '1.SKM2.640199', '1.SKM3.640197',
                         '1.SKM4.640180', '1.SKM5.640177', '1.SKM6.640187',
                         '1.SKM7.640188', '1.SKM8.640201', '1.SKM9.640192']
-        }]
+        }
         self.single_exp = {
             'study_id': 1,
             'status': 'private',
@@ -64,7 +65,7 @@ class TestHelpers(TestHandlerBase):
                     '//www.ncbi.nlm.nih.gov/pubmed/7891011">7891011</a>',
             'pi': '<a target="_blank" href="mailto:PI_dude@foo.bar">'
                   'PIDude</a>',
-            'proc_data_info': self.proc_data_exp
+            'proc_data_info': [self.proc_data_exp]
         }
         self.exp = [self.single_exp]
         super(TestHelpers, self).setUp()
@@ -76,7 +77,7 @@ class TestHelpers(TestHandlerBase):
 
     def test_build_single_study_info(self):
         study_proc = {1: [1]}
-        proc_samples = {1: self.proc_data_exp[0]['samples']}
+        proc_samples = {1: self.proc_data_exp['samples']}
         study_info = {
             'study_id': 1,
             'email': 'test@foo.bar',
@@ -104,14 +105,17 @@ class TestHelpers(TestHandlerBase):
         self.assertEqual(obs, self.single_exp)
 
     def test_build_single_proc_data_info(self):
-        study_proc = {1: [1]}
-        proc_samples = {1: self.proc_data_exp[0]['samples']}
-        obs = _build_single_proc_data_info(Study(1), study_proc, proc_samples)
+        obs = _build_single_proc_data_info(1, self.proc_data_exp['samples'])
         self.assertEqual(obs, self.proc_data_exp)
 
     def test_build_study_info(self):
         obs = _build_study_info(User('test@foo.bar'))
         self.assertEqual(obs, self.exp)
+
+        with self.assertRaises(IncompetentQiitaDeveloperError):
+            obs = _build_study_info(User('test@foo.bar'), study_proc={})
+        with self.assertRaises(IncompetentQiitaDeveloperError):
+            obs = _build_study_info(User('test@foo.bar'), proc_samples={})
 
     def test_build_study_info_new_study(self):
         info = {

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -34,7 +34,7 @@ class TestHelpers(TestHandlerBase):
                 'Identification of the Microbiomes for Cannabis Soils',
             'num_raw_data': 4,
             'number_samples_collected': 27,
-            'shared': 
+            'shared':
                 '<a target="_blank" href="mailto:shared@foo.bar">Shared</a>',
             'pmid': '<a target="_blank" href="http://www.ncbi.nlm.nih.gov/'
                     'pubmed/123456">123456</a>, <a target="_blank" href="http:'
@@ -106,10 +106,6 @@ class TestHelpers(TestHandlerBase):
             'pi':
                 '<a target="_blank" href="mailto:PI_dude@foo.bar">PIDude</a>',
             'proc_data_info': []})
-        for key, val in obs[1].iteritems():
-            if self.exp[1][key] != val:
-                print key
-                print self.exp[1][key], val
         self.assertEqual(obs, self.exp)
 
 
@@ -318,7 +314,7 @@ class TestSearchStudiesAJAX(TestHandlerBase):
                 '<a target="_blank" href="mailto:PI_dude@foo.bar">PIDude</a>',
             'study_id': 1,
             'number_samples_collected': 27,
-            'shared': 
+            'shared':
                 '<a target="_blank" href="mailto:shared@foo.bar">Shared</a>',
             'metadata_complete': True,
             'pmid': '<a target="_blank" href="http://www.ncbi.nlm.nih.gov/'
@@ -361,11 +357,6 @@ class TestSearchStudiesAJAX(TestHandlerBase):
             })
         self.assertEqual(response.code, 200)
         # make sure responds properly
-        obs = loads(response.body)
-        for key, val in self.json['aaData'][0].viewitems():
-            if obs['aaData'][0][key] != val:
-                print key
-                print obs['aaData'][0][key], "<><><>", val
         self.assertEqual(loads(response.body), self.json)
 
         response = self.get('/study/search/', {

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -7,13 +7,65 @@ from qiita_db.data import ProcessedData
 from qiita_db.util import get_count, check_count
 from qiita_db.user import User
 from qiita_pet.handlers.study_handlers.listing_handlers import (
-    _get_shared_links_for_study, _build_study_info)
+    _get_shared_links_for_study, _build_study_info, _build_single_study_info,
+    _build_proc_data_info)
 
 
 class TestHelpers(TestHandlerBase):
     database = True
 
     def setUp(self):
+        self.single_exp = {
+            'study_id': 1,
+            'status': 'private',
+            'study_abstract':
+                'This is a preliminary study to examine the microbiota '
+                'associated with the Cannabis plant. Soils samples '
+                'from the bulk soil, soil associated with the roots, '
+                'and the rhizosphere were extracted and the DNA '
+                'sequenced. Roots from three independent plants of '
+                'different strains were examined. These roots were '
+                'obtained November 11, 2011 from plants that had been '
+                'harvested in the summer. Future studies will attempt '
+                'to analyze the soils and rhizospheres from the same '
+                'location at different time points in the plant '
+                'lifecycle.',
+            'metadata_complete': True,
+            'study_title':
+                'Identification of the Microbiomes for Cannabis Soils',
+            'num_raw_data': 4,
+            'number_samples_collected': 27,
+            'shared':
+                '<a target="_blank" href="mailto:shared@foo.bar">Shared</a>',
+            'pmid': '<a target="_blank" href="http://www.ncbi.nlm.nih.gov/'
+                    'pubmed/123456">123456</a>, <a target="_blank" href="http:'
+                    '//www.ncbi.nlm.nih.gov/pubmed/7891011">7891011</a>',
+            'pi': '<a target="_blank" href="mailto:PI_dude@foo.bar">'
+                  'PIDude</a>'
+        }
+        self.proc_data_exp = [{
+            'pid': 1,
+            'processed_date': '2012-10-01 09:30:27',
+            'data_type': '18S',
+            'algorithm': 'uclust',
+            'reference_name': 'Greengenes',
+            'reference_version': '13_8',
+            'taxonomy_filepath': 'GreenGenes_13_8_97_otu_taxonomy.txt',
+            'sequence_filepath': 'GreenGenes_13_8_97_otus.fasta',
+            'tree_filepath': 'GreenGenes_13_8_97_otus.tree',
+            'similarity': 0.97,
+            'enable_rev_strand_match': True,
+            'suppress_new_clusters': True,
+            'samples': ['1.SKB1.640202', '1.SKB2.640194', '1.SKB3.640195',
+                        '1.SKB4.640189', '1.SKB5.640181', '1.SKB6.640176',
+                        '1.SKB7.640196', '1.SKB8.640193', '1.SKB9.640200',
+                        '1.SKD1.640179', '1.SKD2.640178', '1.SKD3.640198',
+                        '1.SKD4.640185', '1.SKD5.640186', '1.SKD6.640190',
+                        '1.SKD7.640191', '1.SKD8.640184', '1.SKD9.640182',
+                        '1.SKM1.640183', '1.SKM2.640199', '1.SKM3.640197',
+                        '1.SKM4.640180', '1.SKM5.640177', '1.SKM6.640187',
+                        '1.SKM7.640188', '1.SKM8.640201', '1.SKM9.640192']
+        }]
         self.exp = [{
             'study_id': 1,
             'status': 'public',
@@ -71,6 +123,42 @@ class TestHelpers(TestHandlerBase):
         obs = _get_shared_links_for_study(Study(1))
         exp = '<a target="_blank" href="mailto:shared@foo.bar">Shared</a>'
         self.assertEqual(obs, exp)
+
+    def test_build_single_study_info(self):
+        study_info = {
+            'study_id': 1,
+            'email': 'test@foo.bar',
+            'principal_investigator_id': 3,
+            'pmid': ['123456', '7891011'],
+            'study_title':
+                'Identification of the Microbiomes for Cannabis Soils',
+            'metadata_complete': True,
+            'number_samples_collected': 27,
+            'study_abstract':
+                'This is a preliminary study to examine the microbiota '
+                'associated with the Cannabis plant. Soils samples '
+                'from the bulk soil, soil associated with the roots, '
+                'and the rhizosphere were extracted and the DNA '
+                'sequenced. Roots from three independent plants of '
+                'different strains were examined. These roots were '
+                'obtained November 11, 2011 from plants that had been '
+                'harvested in the summer. Future studies will attempt '
+                'to analyze the soils and rhizospheres from the same '
+                'location at different time points in the plant '
+                'lifecycle.'
+            }
+        obs = _build_single_study_info(Study(1), study_info)
+        for key, val in self.single_exp.iteritems():
+            if obs[key] != val:
+                print key
+                print obs[key], val
+        self.assertEqual(obs, self.single_exp)
+
+    def test_build_proc_data_info(self):
+        study_proc = {1: [1]}
+        proc_samples = {1: self.proc_data_exp[0]['samples']}
+        obs = _build_proc_data_info(Study(1), study_proc, proc_samples)
+        self.assertEqual(obs, self.proc_data_exp)
 
     def test_build_study_info(self):
         ProcessedData(1).status = 'public'

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -15,6 +15,29 @@ class TestHelpers(TestHandlerBase):
     database = True
 
     def setUp(self):
+        self.proc_data_exp = [{
+            'pid': 1,
+            'processed_date': '2012-10-01 09:30:27',
+            'data_type': '18S',
+            'algorithm': 'uclust',
+            'reference_name': 'Greengenes',
+            'reference_version': '13_8',
+            'taxonomy_filepath': 'GreenGenes_13_8_97_otu_taxonomy.txt',
+            'sequence_filepath': 'GreenGenes_13_8_97_otus.fasta',
+            'tree_filepath': 'GreenGenes_13_8_97_otus.tree',
+            'similarity': 0.97,
+            'enable_rev_strand_match': True,
+            'suppress_new_clusters': True,
+            'samples': ['1.SKB1.640202', '1.SKB2.640194', '1.SKB3.640195',
+                        '1.SKB4.640189', '1.SKB5.640181', '1.SKB6.640176',
+                        '1.SKB7.640196', '1.SKB8.640193', '1.SKB9.640200',
+                        '1.SKD1.640179', '1.SKD2.640178', '1.SKD3.640198',
+                        '1.SKD4.640185', '1.SKD5.640186', '1.SKD6.640190',
+                        '1.SKD7.640191', '1.SKD8.640184', '1.SKD9.640182',
+                        '1.SKM1.640183', '1.SKM2.640199', '1.SKM3.640197',
+                        '1.SKM4.640180', '1.SKM5.640177', '1.SKM6.640187',
+                        '1.SKM7.640188', '1.SKM8.640201', '1.SKM9.640192']
+        }]
         self.single_exp = {
             'study_id': 1,
             'status': 'private',
@@ -41,82 +64,10 @@ class TestHelpers(TestHandlerBase):
                     'pubmed/123456">123456</a>, <a target="_blank" href="http:'
                     '//www.ncbi.nlm.nih.gov/pubmed/7891011">7891011</a>',
             'pi': '<a target="_blank" href="mailto:PI_dude@foo.bar">'
-                  'PIDude</a>'
-        }
-        self.proc_data_exp = [{
-            'pid': 1,
-            'processed_date': '2012-10-01 09:30:27',
-            'data_type': '18S',
-            'algorithm': 'uclust',
-            'reference_name': 'Greengenes',
-            'reference_version': '13_8',
-            'taxonomy_filepath': 'GreenGenes_13_8_97_otu_taxonomy.txt',
-            'sequence_filepath': 'GreenGenes_13_8_97_otus.fasta',
-            'tree_filepath': 'GreenGenes_13_8_97_otus.tree',
-            'similarity': 0.97,
-            'enable_rev_strand_match': True,
-            'suppress_new_clusters': True,
-            'samples': ['1.SKB1.640202', '1.SKB2.640194', '1.SKB3.640195',
-                        '1.SKB4.640189', '1.SKB5.640181', '1.SKB6.640176',
-                        '1.SKB7.640196', '1.SKB8.640193', '1.SKB9.640200',
-                        '1.SKD1.640179', '1.SKD2.640178', '1.SKD3.640198',
-                        '1.SKD4.640185', '1.SKD5.640186', '1.SKD6.640190',
-                        '1.SKD7.640191', '1.SKD8.640184', '1.SKD9.640182',
-                        '1.SKM1.640183', '1.SKM2.640199', '1.SKM3.640197',
-                        '1.SKM4.640180', '1.SKM5.640177', '1.SKM6.640187',
-                        '1.SKM7.640188', '1.SKM8.640201', '1.SKM9.640192']
-        }]
-        self.exp = [{
-            'study_id': 1,
-            'status': 'public',
-            'study_abstract':
-                'This is a preliminary study to examine the microbiota '
-                'associated with the Cannabis plant. Soils samples '
-                'from the bulk soil, soil associated with the roots, '
-                'and the rhizosphere were extracted and the DNA '
-                'sequenced. Roots from three independent plants of '
-                'different strains were examined. These roots were '
-                'obtained November 11, 2011 from plants that had been '
-                'harvested in the summer. Future studies will attempt '
-                'to analyze the soils and rhizospheres from the same '
-                'location at different time points in the plant '
-                'lifecycle.',
-            'metadata_complete': True,
-            'study_title':
-                'Identification of the Microbiomes for Cannabis Soils',
-            'num_raw_data': 4,
-            'number_samples_collected': 27,
-            'shared':
-                '<a target="_blank" href="mailto:shared@foo.bar">Shared</a>',
-            'pmid': '<a target="_blank" href="http://www.ncbi.nlm.nih.gov/'
-                    'pubmed/123456">123456</a>, <a target="_blank" href="http:'
-                    '//www.ncbi.nlm.nih.gov/pubmed/7891011">7891011</a>',
-            'pi': '<a target="_blank" href="mailto:PI_dude@foo.bar">'
                   'PIDude</a>',
-            'proc_data_info': [{
-                'pid': 1,
-                'processed_date': '2012-10-01 09:30:27',
-                'data_type': '18S',
-                'algorithm': 'uclust',
-                'reference_name': 'Greengenes',
-                'reference_version': '13_8',
-                'taxonomy_filepath': 'GreenGenes_13_8_97_otu_taxonomy.txt',
-                'sequence_filepath': 'GreenGenes_13_8_97_otus.fasta',
-                'tree_filepath': 'GreenGenes_13_8_97_otus.tree',
-                'similarity': 0.97,
-                'enable_rev_strand_match': True,
-                'suppress_new_clusters': True,
-                'samples': ['1.SKB1.640202', '1.SKB2.640194', '1.SKB3.640195',
-                            '1.SKB4.640189', '1.SKB5.640181', '1.SKB6.640176',
-                            '1.SKB7.640196', '1.SKB8.640193', '1.SKB9.640200',
-                            '1.SKD1.640179', '1.SKD2.640178', '1.SKD3.640198',
-                            '1.SKD4.640185', '1.SKD5.640186', '1.SKD6.640190',
-                            '1.SKD7.640191', '1.SKD8.640184', '1.SKD9.640182',
-                            '1.SKM1.640183', '1.SKM2.640199', '1.SKM3.640197',
-                            '1.SKM4.640180', '1.SKM5.640177', '1.SKM6.640187',
-                            '1.SKM7.640188', '1.SKM8.640201', '1.SKM9.640192']
-                }]
-        }]
+            'proc_data_info': self.proc_data_exp
+        }
+        self.exp = [self.single_exp]
         super(TestHelpers, self).setUp()
 
     def test_get_shared_links_for_study(self):
@@ -125,6 +76,8 @@ class TestHelpers(TestHandlerBase):
         self.assertEqual(obs, exp)
 
     def test_build_single_study_info(self):
+        study_proc = {1: [1]}
+        proc_samples = {1: self.proc_data_exp[0]['samples']}
         study_info = {
             'study_id': 1,
             'email': 'test@foo.bar',
@@ -147,7 +100,8 @@ class TestHelpers(TestHandlerBase):
                 'location at different time points in the plant '
                 'lifecycle.'
             }
-        obs = _build_single_study_info(Study(1), study_info)
+        obs = _build_single_study_info(Study(1), study_info, study_proc,
+                                       proc_samples)
         self.assertEqual(obs, self.single_exp)
 
     def test_build_single_proc_data_info(self):
@@ -157,12 +111,10 @@ class TestHelpers(TestHandlerBase):
         self.assertEqual(obs, self.proc_data_exp)
 
     def test_build_study_info(self):
-        ProcessedData(1).status = 'public'
         obs = _build_study_info(User('test@foo.bar'))
         self.assertEqual(obs, self.exp)
 
     def test_build_study_info_new_study(self):
-        ProcessedData(1).status = 'public'
         info = {
             'timeseries_type_id': 1,
             'portal_type_id': 1,

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -15,28 +15,27 @@ class TestHelpers(TestHandlerBase):
 
     def setUp(self):
         self.exp = [{
+            'study_id': 1,
             'status': 'public',
-            'checkbox': "<input type='checkbox' value='1' />",
-            'abstract': 'This is a preliminary study to examine the microbiota'
-                        ' associated with the Cannabis plant. Soils samples '
-                        'from the bulk soil, soil associated with the roots, '
-                        'and the rhizosphere were extracted and the DNA '
-                        'sequenced. Roots from three independent plants of '
-                        'different strains were examined. These roots were '
-                        'obtained November 11, 2011 from plants that had been '
-                        'harvested in the summer. Future studies will attempt '
-                        'to analyze the soils and rhizospheres from the same '
-                        'location at different time points in the plant '
-                        'lifecycle.',
-            'meta_complete': "<span class='glyphicon glyphicon-ok'></span>",
-            'title': '<a href=\'#\' data-toggle=\'modal\' data-target=\''
-                     '#study-abstract-modal\' onclick=\'fillAbstract("studies-'
-                     'table", 0)\'><span class=\'glyphicon glyphicon'
-                     '-file\' aria-hidden=\'true\'></span></a> | <a href=\'/'
-                     'study/description/1\' id=\'study0-title\'>Identification'
-                     ' of the Microbiomes for Cannabis Soils</a>',
-            'num_raw_data': 4, 'id': 1, 'num_samples': 27,
-            'shared': 'Not Available',
+            'study_abstract':
+                'This is a preliminary study to examine the microbiota '
+                'associated with the Cannabis plant. Soils samples '
+                'from the bulk soil, soil associated with the roots, '
+                'and the rhizosphere were extracted and the DNA '
+                'sequenced. Roots from three independent plants of '
+                'different strains were examined. These roots were '
+                'obtained November 11, 2011 from plants that had been '
+                'harvested in the summer. Future studies will attempt '
+                'to analyze the soils and rhizospheres from the same '
+                'location at different time points in the plant '
+                'lifecycle.',
+            'metadata_complete': True,
+            'study_title':
+                'Identification of the Microbiomes for Cannabis Soils',
+            'num_raw_data': 4,
+            'number_samples_collected': 27,
+            'shared': 
+                '<a target="_blank" href="mailto:shared@foo.bar">Shared</a>',
             'pmid': '<a target="_blank" href="http://www.ncbi.nlm.nih.gov/'
                     'pubmed/123456">123456</a>, <a target="_blank" href="http:'
                     '//www.ncbi.nlm.nih.gov/pubmed/7891011">7891011</a>',
@@ -95,23 +94,22 @@ class TestHelpers(TestHandlerBase):
         Study.create(user, 'test_study_1', efo=[1], info=info)
         obs = _build_study_info(user)
         self.exp.append({
+            'study_id': 2,
             'status': 'sandbox',
-            'checkbox': "<input type='checkbox' value='2' />",
-            'abstract': 'abstract',
-            'meta_complete': "<span class='glyphicon glyphicon-remove'>"
-            "</span>",
-            'title': '<a href=\'#\' data-toggle=\'modal\' data-target=\'#study'
-            '-abstract-modal\' onclick=\'fillAbstract("studies-table"'
-            ', 1)\'><span class=\'glyphicon glyphicon-file\' aria-hidden=\''
-            'true\'></span></a> | <a href=\'/study/description/2\' id=\''
-            'study1-title\'>test_study_1</a>',
-            'num_raw_data': 0, 'id': 2, 'num_samples': '0',
-            'shared': "<span id='shared_html_2'></span><br/><a class='btn "
-            "btn-primary btn-xs' data-toggle='modal' data-target='#share-study"
-            "-modal-view' onclick='modify_sharing(2);'>Modify</a>",
-            'pmid': '', 'pi':
-            '<a target="_blank" href="mailto:PI_dude@foo.bar">PIDude</a>',
+            'study_abstract': 'abstract',
+            'metadata_complete': False,
+            'study_title': 'test_study_1',
+            'num_raw_data': 0,
+            'number_samples_collected': 0,
+            'shared': '',
+            'pmid': '',
+            'pi':
+                '<a target="_blank" href="mailto:PI_dude@foo.bar">PIDude</a>',
             'proc_data_info': []})
+        for key, val in obs[1].iteritems():
+            if self.exp[1][key] != val:
+                print key
+                print self.exp[1][key], val
         self.assertEqual(obs, self.exp)
 
 
@@ -296,38 +294,33 @@ class TestCreateStudyAJAX(TestHandlerBase):
 
 
 class TestSearchStudiesAJAX(TestHandlerBase):
-    database = False
+    database = True
 
     json = {
         'iTotalRecords': 1, 'sEcho': 1021, 'iTotalDisplayRecords': 1,
         'aaData': [{
             'status': 'private',
-            'checkbox': "<input type='checkbox' value='1' />",
-            'title': '<a href=\'#\' data-toggle=\'modal\' data-target=\'#study'
-            '-abstract-modal\' onclick=\'fillAbstract("studies-table"'
-            ', 0)\'><span class=\'glyphicon glyphicon-file\' aria-hidden=\''
-            'true\'></span></a> | <a href=\'/study/description/1\' id=\''
-            'study0-title\'>Identification of the Microbiomes for Cannabis '
-            'Soils</a>',
-            'abstract': 'This is a preliminary study to examine the microbiota'
-            ' associated with the Cannabis plant. Soils samples from the bulk'
-            ' soil, soil associated with the roots, and the rhizosphere were '
-            'extracted and the DNA sequenced. Roots from three independent '
-            'plants of different strains were examined. These roots were '
-            'obtained November 11, 2011 from plants that had been harvested in'
-            ' the summer. Future studies will attempt to analyze the soils and'
-            ' rhizospheres from the same location at different time points in '
-            'the plant lifecycle.',
-            'pi': '<a target="_blank" href="mailto:PI_dude@foo.bar">PIDude'
-            '</a>',
-            'id': 1,
-            'num_samples': 27,
-            'shared': '<span id=\'shared_html_1\'><a target="_blank" href="'
-            'mailto:shared@foo.bar">Shared</a></span><br/><a class=\'btn '
-            'btn-primary btn-xs\' data-toggle=\'modal\' data-target=\'#share'
-            '-study-modal-view\' onclick=\'modify_sharing(1);\'>Modify</a>',
-            'meta_complete': "<span class='glyphicon glyphicon-ok'>"
-            "</span>",
+            'study_title':
+                'Identification of the Microbiomes for Cannabis Soils',
+            'study_abstract':
+                'This is a preliminary study to examine the microbiota '
+                'associated with the Cannabis plant. Soils samples '
+                'from the bulk soil, soil associated with the roots, '
+                'and the rhizosphere were extracted and the DNA '
+                'sequenced. Roots from three independent plants of '
+                'different strains were examined. These roots were '
+                'obtained November 11, 2011 from plants that had been '
+                'harvested in the summer. Future studies will attempt '
+                'to analyze the soils and rhizospheres from the same '
+                'location at different time points in the plant '
+                'lifecycle.',
+            'pi':
+                '<a target="_blank" href="mailto:PI_dude@foo.bar">PIDude</a>',
+            'study_id': 1,
+            'number_samples_collected': 27,
+            'shared': 
+                '<a target="_blank" href="mailto:shared@foo.bar">Shared</a>',
+            'metadata_complete': True,
             'pmid': '<a target="_blank" href="http://www.ncbi.nlm.nih.gov/'
             'pubmed/123456">123456</a>, <a target="_blank" href="http://www.'
             'ncbi.nlm.nih.gov/pubmed/7891011">7891011</a>',
@@ -368,6 +361,11 @@ class TestSearchStudiesAJAX(TestHandlerBase):
             })
         self.assertEqual(response.code, 200)
         # make sure responds properly
+        obs = loads(response.body)
+        for key, val in self.json['aaData'][0].viewitems():
+            if obs['aaData'][0][key] != val:
+                print key
+                print obs['aaData'][0][key], "<><><>", val
         self.assertEqual(loads(response.body), self.json)
 
         response = self.get('/study/search/', {

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -8,7 +8,7 @@ from qiita_db.util import get_count, check_count
 from qiita_db.user import User
 from qiita_pet.handlers.study_handlers.listing_handlers import (
     _get_shared_links_for_study, _build_study_info, _build_single_study_info,
-    _build_proc_data_info)
+    _build_single_proc_data_info)
 
 
 class TestHelpers(TestHandlerBase):
@@ -148,16 +148,12 @@ class TestHelpers(TestHandlerBase):
                 'lifecycle.'
             }
         obs = _build_single_study_info(Study(1), study_info)
-        for key, val in self.single_exp.iteritems():
-            if obs[key] != val:
-                print key
-                print obs[key], val
         self.assertEqual(obs, self.single_exp)
 
-    def test_build_proc_data_info(self):
+    def test_build_single_proc_data_info(self):
         study_proc = {1: [1]}
         proc_samples = {1: self.proc_data_exp[0]['samples']}
-        obs = _build_proc_data_info(Study(1), study_proc, proc_samples)
+        obs = _build_single_proc_data_info(Study(1), study_proc, proc_samples)
         self.assertEqual(obs, self.proc_data_exp)
 
     def test_build_study_info(self):

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -76,7 +76,7 @@ class TestHelpers(TestHandlerBase):
         self.assertEqual(obs, exp)
 
     def test_build_single_study_info(self):
-        study_proc = {1: [1]}
+        study_proc = {1: {'18S': [1]}}
         proc_samples = {1: self.proc_data_exp['samples']}
         study_info = {
             'study_id': 1,
@@ -105,7 +105,8 @@ class TestHelpers(TestHandlerBase):
         self.assertEqual(obs, self.single_exp)
 
     def test_build_single_proc_data_info(self):
-        obs = _build_single_proc_data_info(1, self.proc_data_exp['samples'])
+        obs = _build_single_proc_data_info(1, '18S',
+                                           self.proc_data_exp['samples'])
         self.assertEqual(obs, self.proc_data_exp)
 
     def test_build_study_info(self):

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -3,7 +3,6 @@ from json import loads
 
 from qiita_pet.test.tornado_test_base import TestHandlerBase
 from qiita_db.study import StudyPerson, Study
-from qiita_db.data import ProcessedData
 from qiita_db.util import get_count, check_count
 from qiita_db.user import User
 from qiita_pet.handlers.study_handlers.listing_handlers import (

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -40,7 +40,31 @@ class TestHelpers(TestHandlerBase):
             'pmid': '<a target="_blank" href="http://www.ncbi.nlm.nih.gov/'
                     'pubmed/123456">123456</a>, <a target="_blank" href="http:'
                     '//www.ncbi.nlm.nih.gov/pubmed/7891011">7891011</a>',
-            'pi': '<a target="_blank" href="mailto:PI_dude@foo.bar">PIDude</a>'
+            'pi': '<a target="_blank" href="mailto:PI_dude@foo.bar">'
+                  'PIDude</a>',
+            'proc_data_info': [{
+                'pid': 1,
+                'processed_date': '2012-10-01 09:30:27',
+                'data_type': '18S',
+                'algorithm': 'uclust',
+                'reference_name': 'Greengenes',
+                'reference_version': '13_8',
+                'taxonomy_filepath': 'GreenGenes_13_8_97_otu_taxonomy.txt',
+                'sequence_filepath': 'GreenGenes_13_8_97_otus.fasta',
+                'tree_filepath': 'GreenGenes_13_8_97_otus.tree',
+                'similarity': 0.97,
+                'enable_rev_strand_match': True,
+                'suppress_new_clusters': True,
+                'samples': ['1.SKB1.640202', '1.SKB2.640194', '1.SKB3.640195',
+                            '1.SKB4.640189', '1.SKB5.640181', '1.SKB6.640176',
+                            '1.SKB7.640196', '1.SKB8.640193', '1.SKB9.640200',
+                            '1.SKD1.640179', '1.SKD2.640178', '1.SKD3.640198',
+                            '1.SKD4.640185', '1.SKD5.640186', '1.SKD6.640190',
+                            '1.SKD7.640191', '1.SKD8.640184', '1.SKD9.640182',
+                            '1.SKM1.640183', '1.SKM2.640199', '1.SKM3.640197',
+                            '1.SKM4.640180', '1.SKM5.640177', '1.SKM6.640187',
+                            '1.SKM7.640188', '1.SKM8.640201', '1.SKM9.640192']
+                }]
         }]
         super(TestHelpers, self).setUp()
 
@@ -86,7 +110,8 @@ class TestHelpers(TestHandlerBase):
             "btn-primary btn-xs' data-toggle='modal' data-target='#share-study"
             "-modal-view' onclick='modify_sharing(2);'>Modify</a>",
             'pmid': '', 'pi':
-            '<a target="_blank" href="mailto:PI_dude@foo.bar">PIDude</a>'})
+            '<a target="_blank" href="mailto:PI_dude@foo.bar">PIDude</a>',
+            'proc_data_info': []})
         self.assertEqual(obs, self.exp)
 
 
@@ -306,7 +331,30 @@ class TestSearchStudiesAJAX(TestHandlerBase):
             'pmid': '<a target="_blank" href="http://www.ncbi.nlm.nih.gov/'
             'pubmed/123456">123456</a>, <a target="_blank" href="http://www.'
             'ncbi.nlm.nih.gov/pubmed/7891011">7891011</a>',
-            'num_raw_data': 4}]}
+            'num_raw_data': 4,
+            'proc_data_info': [{
+                'pid': 1,
+                'processed_date': '2012-10-01 09:30:27',
+                'data_type': '18S',
+                'algorithm': 'uclust',
+                'reference_name': 'Greengenes',
+                'reference_version': '13_8',
+                'taxonomy_filepath': 'GreenGenes_13_8_97_otu_taxonomy.txt',
+                'sequence_filepath': 'GreenGenes_13_8_97_otus.fasta',
+                'tree_filepath': 'GreenGenes_13_8_97_otus.tree',
+                'similarity': 0.97,
+                'enable_rev_strand_match': True,
+                'suppress_new_clusters': True,
+                'samples': ['1.SKB1.640202', '1.SKB2.640194', '1.SKB3.640195',
+                            '1.SKB4.640189', '1.SKB5.640181', '1.SKB6.640176',
+                            '1.SKB7.640196', '1.SKB8.640193', '1.SKB9.640200',
+                            '1.SKD1.640179', '1.SKD2.640178', '1.SKD3.640198',
+                            '1.SKD4.640185', '1.SKD5.640186', '1.SKD6.640190',
+                            '1.SKD7.640191', '1.SKD8.640184', '1.SKD9.640182',
+                            '1.SKM1.640183', '1.SKM2.640199', '1.SKM3.640197',
+                            '1.SKM4.640180', '1.SKM5.640177', '1.SKM6.640187',
+                            '1.SKM7.640188', '1.SKM8.640201', '1.SKM9.640192']
+                }]}]}
     empty = {'aaData': [],
              'iTotalDisplayRecords': 0,
              'iTotalRecords': 0,


### PR DESCRIPTION
This adds the processed data listings to the study listings so you can select by processed data when creating an analysis. You can look at this by going to the study listing page and expanding rows using the end cell arrow for each row.

~~This requires the previous pull request (#1038) to be merged first.~~ Merged.