### PR TITLE
Removing the remove_category function

### DIFF
--- a/qiita_db/metadata_template/sample_template.py
+++ b/qiita_db/metadata_template/sample_template.py
@@ -481,32 +481,6 @@ class SampleTemplate(MetadataTemplate):
                     if '_qiime_' not in basename(fp):
                         pt.create_qiime_mapping_file(fp)
 
-    def remove_category(self, category):
-        """Remove a category from the sample template
-
-        Parameters
-        ----------
-        category : str
-            The category to remove
-
-        Raises
-        ------
-        QiitaDBColumnError
-            If the column does not exist in the table
-        """
-        table_name = self._table_name(self.study_id)
-        conn_handler = SQLConnectionHandler()
-
-        if category not in self.categories():
-            raise QiitaDBColumnError("Column %s does not exist in %s" %
-                                     (category, table_name))
-
-        # This operation may invalidate another user's perspective on the
-        # table
-        conn_handler.execute("""
-            ALTER TABLE qiita.{0} DROP COLUMN {1}""".format(table_name,
-                                                            category))
-
     def update_category(self, category, samples_and_values):
         """Update an existing column
 

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -1237,18 +1237,6 @@ class TestSampleTemplateReadWrite(BaseTestSampleTemplate):
         obs = {k: v['new_column'] for k, v in self.tester.items()}
         self.assertEqual(obs, exp)
 
-    def test_remove_category(self):
-        with self.assertRaises(QiitaDBColumnError):
-            self.tester.remove_category('does not exist')
-
-        for v in self.tester.values():
-            self.assertIn('elevation', v)
-
-        self.tester.remove_category('elevation')
-
-        for v in self.tester.values():
-            self.assertNotIn('elevation', v)
-
     def test_to_file(self):
         """to file writes a tab delimited file with all the metadata"""
         fd, fp = mkstemp()


### PR DESCRIPTION
I don't think the `remove_category` function is needed, so I'm removing it from the code base.

The reasons why I think this function should be removed:
 - It is not used in any place in the code base
 - It has a comment that says "This operation may invalidate another user's perspective on the table", but no checks o safe mechanism is put in place.
 - It is buggy: it is dropping a column from the dynamic table, but is not updating the study-columns table.
 - Leaves the filesystem in an inconsistent state: once the column is removed, the sample template file and the qiime mapping file is not being re-generated, so the files do not represent the data in the DB
 - Before removing any column in the metadata templates, multiple checks has to be done (i.e. it has been used in an analysis).

Since it is clear that a lot of though has to be put in this function, I think it is safer to just remove it for now and put it back once the functionality is needed and we actually have a design for all the mechanisms to notify users once a template has been changed in this way. Note that IMOO, adding new columns is not a big deal, however, removing columns is another story.
