### PR TITLE
BUG: Fix bug with Safari and MOI

### DIFF
--- a/qiita_pet/templates/analysis_waiting.html
+++ b/qiita_pet/templates/analysis_waiting.html
@@ -4,7 +4,9 @@
 <script src="/static/vendor/js/moi.js"></script>
 <script src="/static/vendor/js/moi_list.js"></script>
 <script type="text/javascript">
-    window.onload = function() {moi_list.init("{{group_id}}");};
+    $(document).ready(function() {
+      moi_list.init("{{group_id}}");
+    });
 </script>
 {% end %}
 

--- a/qiita_pet/templates/compute_wait.html
+++ b/qiita_pet/templates/compute_wait.html
@@ -2,7 +2,7 @@
 
 {%block head%}
 <script type="text/javascript">
-    window.onload = function() {
+    $(document).ready(function() {
 
         var host = 'ws://' + window.location.host + '/consumer/';
         var websocket = new WebSocket(host);
@@ -34,7 +34,7 @@
             }
         };
         websocket.onerror = function(evt) { };
-      };
+      });
 </script>
 {% end %}
 


### PR DESCRIPTION
Assigning a function to document.ready doesn't seem to be supported in Safari,
and thus the call to initialize MOI would never occurr (giving the impression
that WebSocket never started). Using jQuery's proxy for the ready callback
seems to resolve this problem.

Fixes #946