### PR TITLE
Fix inconsistency on failure updating

### DIFF
--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -316,7 +316,7 @@ class BaseSample(QiitaObject):
                            (key, self._id, self._md_template.id))
 
     def add_setitem_queries(self, column, value, conn_handler, queue):
-        """Adds the SQL queries needed to set and item to the queue
+        """Adds the SQL queries needed to set a value to the provided queue
 
         Parameters
         ----------

--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -1252,7 +1252,7 @@ class MetadataTemplate(QiitaObject):
 
             if any([column_type != vt for vt in value_types]):
                 value_str = ', '.join(
-                    [v for value in viewvalues(samples_and_values)])
+                    [str(value) for value in viewvalues(samples_and_values)])
                 value_types_str = ', '.join(value_types)
 
                 raise ValueError(

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -53,6 +53,45 @@ class BaseTestPrepSample(TestCase):
 
 
 class TestPrepSampleReadOnly(BaseTestPrepSample):
+    def test_add_setitem_queries_error(self):
+        conn_handler = SQLConnectionHandler()
+        queue = "test_queue"
+        conn_handler.create_queue(queue)
+
+        with self.assertRaises(QiitaDBColumnError):
+            self.tester.add_setitem_queries(
+                'COL_DOES_NOT_EXIST', 'Foo', conn_handler, queue)
+
+    def test_add_setitem_queries_required(self):
+        conn_handler = SQLConnectionHandler()
+        queue = "test_queue"
+        conn_handler.create_queue(queue)
+
+        self.tester.add_setitem_queries(
+            'center_name', 'FOO', conn_handler, queue)
+
+        obs = conn_handler.queues[queue]
+        sql = """UPDATE qiita.common_prep_info
+                     SET center_name=%s
+                     WHERE sample_id=%s"""
+        exp = [(sql, ('FOO', '1.SKB8.640193'))]
+        self.assertEqual(obs, exp)
+
+    def test_add_setitem_queries_dynamic(self):
+        conn_handler = SQLConnectionHandler()
+        queue = "test_queue"
+        conn_handler.create_queue(queue)
+
+        self.tester.add_setitem_queries(
+            'barcodesequence', 'AAAAAAAAAAAA', conn_handler, queue)
+
+        obs = conn_handler.queues[queue]
+        sql = """UPDATE qiita.prep_1
+                         SET barcodesequence=%s
+                         WHERE sample_id=%s"""
+        exp = [(sql, ('AAAAAAAAAAAA', '1.SKB8.640193'))]
+        self.assertEqual(obs, exp)
+
     def test_init_unknown_error(self):
         """Init errors if the PrepSample id is not found in the template"""
         with self.assertRaises(QiitaDBUnknownIDError):

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -1253,7 +1253,6 @@ class TestSampleTemplateReadWrite(BaseTestSampleTemplate):
         self.assertFalse(SampleTemplate.exists(self.new_study.id))
 
     def test_update_category(self):
-        """setitem raises an error (currently not allowed)"""
         with self.assertRaises(QiitaDBUnknownIDError):
             self.tester.update_category('country', {"foo": "bar"})
 
@@ -1295,9 +1294,17 @@ class TestSampleTemplateReadWrite(BaseTestSampleTemplate):
         # testing that if fails when trying to change an int column value
         # to str
         st = SampleTemplate.create(self.metadata, self.new_study)
-        mapping = {'2.Sample1': "no_value"}
+
+        sql = """SELECT * FROM qiita.sample_2 ORDER BY sample_id"""
+        before = self.conn_handler.execute_fetchall(sql)
+        mapping = {'2.Sample1': 1, '2.Sample2': "no_value"}
+
         with self.assertRaises(ValueError):
             st.update_category('int_column', mapping)
+
+        after = self.conn_handler.execute_fetchall(sql)
+
+        self.assertEqual(before, after)
 
     def test_update(self):
         """Updates values in existing mapping file"""

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -61,9 +61,8 @@ class TestSampleReadOnly(BaseTestSample):
         with self.assertRaises(QiitaDBColumnError):
             self.tester.add_setitem_queries(
                 'COL_DOES_NOT_EXIST', 0.30, conn_handler, queue)
-            self.tester['column that does not exist'] = 0.30
 
-    def test_add_setitem_queries_dynamic(self):
+    def test_add_setitem_queries_required(self):
         conn_handler = SQLConnectionHandler()
         queue = "test_queue"
         conn_handler.create_queue(queue)
@@ -78,7 +77,7 @@ class TestSampleReadOnly(BaseTestSample):
         exp = [(sql, (True, '1.SKB8.640193'))]
         self.assertEqual(obs, exp)
 
-    def test_add_setitem_queries_required(self):
+    def test_add_setitem_queries_dynamic(self):
         conn_handler = SQLConnectionHandler()
         queue = "test_queue"
         conn_handler.create_queue(queue)


### PR DESCRIPTION
~~This PR depends on #1050, review and merge that one first.~~

Main motivation of the PR: the `update_category` function can leave the DB in an inconsistent state because the updates to the samples are done independently, so if one fails, the previous ones are already modified. By moving the `__setitem__` queries to a function that adds them to a queue, we can use that function in `update_category` to perform everything in a single transaction block.

Also, in a previous PR, @squirrelo commented that the way types in the error were checked was probably not correct (for some reason I received that notification from github today). I tested it and @squirrelo was right, so I fixed it here. It is less elegant, but at least is correct.