### PR TITLE
Removing add_category function

### DIFF
--- a/qiita_db/metadata_template/sample_template.py
+++ b/qiita_db/metadata_template/sample_template.py
@@ -433,37 +433,3 @@ class SampleTemplate(MetadataTemplate):
         for k, v in viewitems(samples_and_values):
             sample = self[k]
             sample[category] = v
-
-    def add_category(self, category, samples_and_values, dtype, default):
-        """Add a metadata category
-
-        Parameters
-        ----------
-        category : str
-            The category to add
-        samples_and_values : dict
-            A mapping of {sample_id: value}
-        dtype : str
-            The datatype of the column
-        default : object
-            The default value associated with the column. This must be
-            specified as these columns are added "not null".
-
-        Raises
-        ------
-        QiitaDBDuplicateError
-            If the column already exists
-        """
-        table_name = self._table_name(self.study_id)
-        conn_handler = SQLConnectionHandler()
-
-        if category in self.categories():
-            raise QiitaDBDuplicateError(category, "N/A")
-
-        conn_handler.execute("""
-            ALTER TABLE qiita.{0}
-            ADD COLUMN {1} {2}
-            NOT NULL DEFAULT '{3}'""".format(table_name, category, dtype,
-                                             default))
-
-        self.update_category(category, samples_and_values)

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -1196,48 +1196,6 @@ class TestSampleTemplateReadWrite(BaseTestSampleTemplate):
         with self.assertRaises(QiitaDBError):
             st.update(self.metadata_dict_updated_column_error)
 
-    def test_add_category(self):
-        column = "new_column"
-        dtype = "varchar"
-        default = "stuff"
-        mapping = {'1.SKB1.640202': "1",
-                   '1.SKB5.640181': "2",
-                   '1.SKD6.640190': "3"}
-
-        exp = {
-            '1.SKB1.640202': "1",
-            '1.SKB2.640194': "stuff",
-            '1.SKB3.640195': "stuff",
-            '1.SKB4.640189': "stuff",
-            '1.SKB5.640181': "2",
-            '1.SKB6.640176': "stuff",
-            '1.SKB7.640196': "stuff",
-            '1.SKB8.640193': "stuff",
-            '1.SKB9.640200': "stuff",
-            '1.SKD1.640179': "stuff",
-            '1.SKD2.640178': "stuff",
-            '1.SKD3.640198': "stuff",
-            '1.SKD4.640185': "stuff",
-            '1.SKD5.640186': "stuff",
-            '1.SKD6.640190': "3",
-            '1.SKD7.640191': "stuff",
-            '1.SKD8.640184': "stuff",
-            '1.SKD9.640182': "stuff",
-            '1.SKM1.640183': "stuff",
-            '1.SKM2.640199': "stuff",
-            '1.SKM3.640197': "stuff",
-            '1.SKM4.640180': "stuff",
-            '1.SKM5.640177': "stuff",
-            '1.SKM6.640187': "stuff",
-            '1.SKM7.640188': "stuff",
-            '1.SKM8.640201': "stuff",
-            '1.SKM9.640192': "stuff"}
-
-        self.tester.add_category(column, mapping, dtype, default)
-
-        obs = {k: v['new_column'] for k, v in self.tester.items()}
-        self.assertEqual(obs, exp)
-
     def test_to_file(self):
         """to file writes a tab delimited file with all the metadata"""
         fd, fp = mkstemp()


### PR DESCRIPTION
Reasons for it's removal:
 - It is not used anywhere in the code base
 - It has a bug, it is not modifying the `study_columns` table.
 - It is repetitive. The same functionality can be accomplished with the `extend` function.