### PR TITLE
Creating generate_files function

### DIFF
--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -1026,6 +1026,17 @@ class MetadataTemplate(QiitaObject):
 
         return result
 
+    def generate_files(self):
+        r"""Generates all the files that contain data from this template
+
+        Raises
+        ------
+        QiitaDBNotImplementedError
+            This method should be implemented by the subclasses
+        """
+        raise QiitaDBNotImplementedError(
+            "generate_files should be implemented in the subclass!")
+
     def to_file(self, fp, samples=None):
         r"""Writes the MetadataTemplate to the file `fp` in tab-delimited
         format

--- a/qiita_db/metadata_template/prep_template.py
+++ b/qiita_db/metadata_template/prep_template.py
@@ -157,19 +157,8 @@ class PrepTemplate(MetadataTemplate):
             # some other error we haven't seen before so raise it
             raise
 
-        # figuring out the filepath of the backup
-        _id, fp = get_mountpoint('templates')[0]
-        fp = join(fp, '%d_prep_%d_%s.txt' % (study.id, prep_id,
-                  strftime("%Y%m%d-%H%M%S")))
-        # storing the backup
         pt = cls(prep_id)
-        pt.to_file(fp)
-
-        # adding the fp to the object
-        pt.add_filepath(fp)
-
-        # creating QIIME mapping file
-        pt.create_qiime_mapping_file(fp)
+        pt.generate_files()
 
         return pt
 
@@ -410,6 +399,22 @@ class PrepTemplate(MetadataTemplate):
         else:
             raise QiitaDBError("No studies found associated with prep "
                                "template ID %d" % self._id)
+
+    def generate_files(self):
+        r"""Generates all the files that contain data from this template
+        """
+        # figuring out the filepath of the prep template
+        _id, fp = get_mountpoint('templates')[0]
+        fp = join(fp, '%d_prep_%d_%s.txt' % (self.study_id, self._id,
+                  strftime("%Y%m%d-%H%M%S")))
+        # storing the template
+        self.to_file(fp)
+
+        # adding the fp to the object
+        self.add_filepath(fp)
+
+        # creating QIIME mapping file
+        self.create_qiime_mapping_file(fp)
 
     def create_qiime_mapping_file(self, prep_template_fp):
         """This creates the QIIME mapping file and links it in the db.

--- a/qiita_db/metadata_template/sample_template.py
+++ b/qiita_db/metadata_template/sample_template.py
@@ -10,7 +10,6 @@ from __future__ import division
 from future.builtins import zip
 from os.path import join
 from time import strftime
-from os.path import basename
 
 import pandas as pd
 import warnings
@@ -171,7 +170,7 @@ class SampleTemplate(MetadataTemplate):
         # generating all new QIIME mapping files
         for rd_id in Study(self.id).raw_data():
             for pt_id in RawData(rd_id).prep_templates:
-                pt = PrepTemplate(pt_id).generate_files()
+                PrepTemplate(pt_id).generate_files()
 
     def extend(self, md_template):
         """Adds the given sample template to the current one

--- a/qiita_db/metadata_template/sample_template.py
+++ b/qiita_db/metadata_template/sample_template.py
@@ -140,15 +140,8 @@ class SampleTemplate(MetadataTemplate):
 
         conn_handler.execute_queue(queue_name)
 
-        # figuring out the filepath of the backup
-        _id, fp = get_mountpoint('templates')[0]
-        fp = join(fp, '%d_%s.txt' % (study.id, strftime("%Y%m%d-%H%M%S")))
-        # storing the backup
         st = cls(study.id)
-        st.to_file(fp)
-
-        # adding the fp to the object
-        st.add_filepath(fp)
+        st.generate_files()
 
         return st
 
@@ -162,6 +155,23 @@ class SampleTemplate(MetadataTemplate):
             The ID of the study with which this sample template is associated
         """
         return self._id
+
+    def generate_files(self):
+        r"""Generates all the files that contain data from this template
+        """
+        # figuring out the filepath of the sample template
+        _id, fp = get_mountpoint('templates')[0]
+        fp = join(fp, '%d_%s.txt' % (self.id, strftime("%Y%m%d-%H%M%S")))
+        # storing the sample template
+        self.to_file(fp)
+
+        # adding the fp to the object
+        self.add_filepath(fp)
+
+        # generating all new QIIME mapping files
+        for rd_id in Study(self.id).raw_data():
+            for pt_id in RawData(rd_id).prep_templates:
+                pt = PrepTemplate(pt_id).generate_files()
 
     def extend(self, md_template):
         """Adds the given sample template to the current one
@@ -248,14 +258,7 @@ class SampleTemplate(MetadataTemplate):
             values, many=True)
         conn_handler.execute_queue(queue_name)
 
-        # figuring out the filepath of the backup
-        _id, fp = get_mountpoint('templates')[0]
-        fp = join(fp, '%d_%s.txt' % (self.id, strftime("%Y%m%d-%H%M%S")))
-        # storing the backup
-        self.to_file(fp)
-
-        # adding the fp to the object
-        self.add_filepath(fp)
+        self.generate_files()
 
     def update(self, md_template):
         r"""Update values in the sample template
@@ -318,21 +321,4 @@ class SampleTemplate(MetadataTemplate):
         for col in changed_cols:
             self.update_category(col, new_map[col].to_dict())
 
-        # figuring out the filepath of the backup
-        _id, fp = get_mountpoint('templates')[0]
-        fp = join(fp, '%d_%s.txt' % (self.id, strftime("%Y%m%d-%H%M%S")))
-        # storing the backup
-        self.to_file(fp)
-
-        # adding the fp to the object
-        self.add_filepath(fp)
-
-        # generating all new QIIME mapping files
-        for rd_id in Study(self.id).raw_data():
-            for pt_id in RawData(rd_id).prep_templates:
-                pt = PrepTemplate(pt_id)
-                for _, fp in pt.get_filepaths():
-                    # the difference between a prep and a qiime template is the
-                    # word qiime within the name of the file
-                    if '_qiime_' not in basename(fp):
-                        pt.create_qiime_mapping_file(fp)
+        self.generate_files()

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -1010,6 +1010,14 @@ class TestPrepTemplateReadWrite(BaseTestPrepTemplate):
         self.assertEqual(filepaths[0][0], 22)
         self.assertEqual(filepaths[1][0], 21)
 
+    def test_generate_files(self):
+        fp_count = get_count("qiita.filepath")
+        self.tester.generate_files()
+        obs = get_count("qiita.filepath")
+        # We just make sure that the count has been increased by 2, since
+        # the contents of the files have been tested elsewhere.
+        self.assertEqual(obs, fp_count + 2)
+
     def test_create_qiime_mapping_file(self):
         pt = PrepTemplate(1)
 

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -28,7 +28,7 @@ from qiita_db.exceptions import (QiitaDBDuplicateError, QiitaDBUnknownIDError,
 from qiita_db.sql_connection import SQLConnectionHandler
 from qiita_db.study import Study, StudyPerson
 from qiita_db.user import User
-from qiita_db.util import exists_table, get_table_cols
+from qiita_db.util import exists_table, get_table_cols, get_count
 from qiita_db.metadata_template.sample_template import SampleTemplate, Sample
 from qiita_db.metadata_template.prep_template import PrepTemplate, PrepSample
 
@@ -1331,6 +1331,14 @@ class TestSampleTemplateReadWrite(BaseTestSampleTemplate):
             st.update(self.metadata_dict_updated_sample_error)
         with self.assertRaises(QiitaDBError):
             st.update(self.metadata_dict_updated_column_error)
+
+    def test_generate_files(self):
+        fp_count = get_count("qiita.filepath")
+        self.tester.generate_files()
+        obs = get_count("qiita.filepath")
+        # We just make sure that the count has been increased by 2, since
+        # the contents of the files have been tested elsewhere.
+        self.assertEqual(obs, fp_count + 3)
 
     def test_to_file(self):
         """to file writes a tab delimited file with all the metadata"""


### PR DESCRIPTION
There was a lot of code duplication across the sample/prep template classes to generate the files; and in case of the sample template, there was a bug, since the extend function was modifying the contents of the template but it was not re-generating the qiime mapping file. There is another bug on the extend function, but I'll fix it in a different PR.

That being said, I just created a new function to encapsulate all the files creation and I removed the duplicated code and substitute it for a call to the new function.