### PR TITLE
Fix extend functionality

### DIFF
--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -842,6 +842,11 @@ class MetadataTemplate(QiitaObject):
                 min_md_template = md_template[new_cols].loc[existing_samples]
                 values = as_python_types(min_md_template, new_cols)
                 values.append(existing_samples)
+                # psycopg2 requires a list of tuples, in which each tuple is a
+                # set of values to use in the string formatting of the query.
+                # We have all the values in different lists (but in the same
+                # order) so use zip to create the list of tuples that psycopg2
+                # requires.
                 values = [v for v in zip(*values)]
                 set_str = ["{0} = %s".format(col) for col in new_cols]
                 sql = """UPDATE qiita.{0}

--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -37,6 +37,7 @@ Methods
 
 from __future__ import division
 from future.utils import viewitems, viewvalues
+from future.builtins import zip
 from os.path import join
 from functools import partial
 from collections import defaultdict
@@ -55,7 +56,7 @@ from qiita_db.exceptions import (QiitaDBUnknownIDError, QiitaDBColumnError,
 from qiita_db.base import QiitaObject
 from qiita_db.sql_connection import SQLConnectionHandler
 from qiita_db.util import (exists_table, get_table_cols, convert_to_id,
-                           get_mountpoint, insert_filepaths, scrub_data)
+                           get_mountpoint, insert_filepaths)
 from qiita_db.logger import LogEntry
 from .util import (as_python_types, get_datatypes, get_invalid_sample_names,
                    prefix_sample_names_with_id)

--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -793,17 +793,14 @@ class MetadataTemplate(QiitaObject):
         """
         # Check if we are adding new samples
         sample_ids = md_template.index.tolist()
-        sql = """SELECT sample_id FROM qiita.{0}
-                 WHERE {1}=%s""".format(self._table, self._id_column)
-        curr_samples = set(
-            s[0] for s in conn_handler.execute_fetchall(sql, (self._id,)))
+        curr_samples = set(self.keys())
         existing_samples = curr_samples.intersection(sample_ids)
         new_samples = set(sample_ids).difference(existing_samples)
 
         # Check if we are adding new columns
         table_name = self._table_name(self._id)
         # Get the required columns from the DB
-        db_cols = sorted(get_table_cols(self._table, conn_handler))
+        db_cols = get_table_cols(self._table, conn_handler)
         # Remove the sample_id and _id_column columns
         db_cols.remove('sample_id')
         db_cols.remove(self._id_column)
@@ -837,10 +834,9 @@ class MetadataTemplate(QiitaObject):
 
             if existing_samples:
                 warnings.warn(
-                    "The new columns '%s' have been added to the existing "
-                    "samples '%s'. Any other value of these samples have been "
-                    "modified." % (", ".join(new_cols),
-                                   ", ".join(existing_samples)),
+                    "No values have been modified for samples '%s'. However, "
+                    "the following columns have been added to them: '%s'"
+                    % (", ".join(existing_samples), ", ".join(new_cols)),
                     QiitaDBWarning)
                 # The values for the new columns are the only ones that get
                 # added to the database. None of the existing values will be

--- a/qiita_db/metadata_template/sample_template.py
+++ b/qiita_db/metadata_template/sample_template.py
@@ -242,76 +242,11 @@ class SampleTemplate(MetadataTemplate):
         conn_handler.create_queue(queue_name)
 
         md_template = self._clean_validate_template(md_template, self.study_id,
+                                                    self.study_id,
                                                     conn_handler)
 
-        # Raise warning and filter out existing samples
-        sample_ids = md_template.index.tolist()
-        sql = ("SELECT sample_id FROM qiita.required_sample_info WHERE "
-               "study_id = %d" % self.id)
-        curr_samples = set(s[0] for s in conn_handler.execute_fetchall(sql))
-        existing_samples = curr_samples.intersection(sample_ids)
-        if existing_samples:
-            warnings.warn(
-                "The following samples already exist and will be ignored: "
-                "%s" % ", ".join(curr_samples.intersection(
-                                 sorted(existing_samples))), QiitaDBWarning)
-            md_template.drop(existing_samples, inplace=True)
-
-        # Get some useful information from the metadata template
-        sample_ids = md_template.index.tolist()
-        num_samples = len(sample_ids)
-        headers = list(md_template.keys())
-
-        # Get the required columns from the DB
-        db_cols = get_table_cols(self._table, conn_handler)
-        # Remove the sample_id and study_id columns
-        db_cols.remove('sample_id')
-        db_cols.remove(self._id_column)
-
-        # Insert values on required columns
-        values = as_python_types(md_template, db_cols)
-        values.insert(0, sample_ids)
-        values.insert(0, [self.study_id] * num_samples)
-        values = [v for v in zip(*values)]
-        conn_handler.add_to_queue(
-            queue_name,
-            "INSERT INTO qiita.{0} ({1}, sample_id, {2}) "
-            "VALUES (%s, %s, {3})".format(self._table, self._id_column,
-                                          ', '.join(db_cols),
-                                          ', '.join(['%s'] * len(db_cols))),
-            values, many=True)
-
-        # Add missing columns to the sample template dynamic table
-        headers = list(set(headers).difference(db_cols))
-        datatypes = get_datatypes(md_template.ix[:, headers])
-        table_name = self._table_name(self.study_id)
-        new_cols = set(md_template.columns).difference(
-            set(self.metadata_headers()))
-        dtypes_dict = dict(zip(md_template.ix[:, headers], datatypes))
-        for category in new_cols:
-            # Insert row on *_columns table
-            conn_handler.add_to_queue(
-                queue_name,
-                "INSERT INTO qiita.{0} ({1}, column_name, column_type) "
-                "VALUES (%s, %s, %s)".format(self._column_table,
-                                             self._id_column),
-                (self.study_id, category, dtypes_dict[category]))
-            # Insert row on dynamic table
-            conn_handler.add_to_queue(
-                queue_name,
-                "ALTER TABLE qiita.{0} ADD COLUMN {1} {2}".format(
-                    table_name, scrub_data(category), dtypes_dict[category]))
-
-        # Insert values on custom table
-        values = as_python_types(md_template, headers)
-        values.insert(0, sample_ids)
-        values = [v for v in zip(*values)]
-        conn_handler.add_to_queue(
-            queue_name,
-            "INSERT INTO qiita.{0} (sample_id, {1}) "
-            "VALUES (%s, {2})".format(table_name, ", ".join(headers),
-                                      ', '.join(["%s"] * len(headers))),
-            values, many=True)
+        self._add_common_extend_steps_to_queue(md_template, conn_handler,
+                                               queue_name)
         conn_handler.execute_queue(queue_name)
 
         self.generate_files()

--- a/qiita_db/metadata_template/sample_template.py
+++ b/qiita_db/metadata_template/sample_template.py
@@ -7,23 +7,19 @@
 # -----------------------------------------------------------------------------
 
 from __future__ import division
-from future.builtins import zip
 from os.path import join
 from time import strftime
 
 import pandas as pd
-import warnings
 
 from qiita_core.exceptions import IncompetentQiitaDeveloperError
 from qiita_db.exceptions import (QiitaDBDuplicateError, QiitaDBError,
-                                 QiitaDBWarning, QiitaDBUnknownIDError)
+                                 QiitaDBUnknownIDError)
 from qiita_db.sql_connection import SQLConnectionHandler
-from qiita_db.util import (get_table_cols, get_required_sample_info_status,
-                           get_mountpoint, scrub_data)
+from qiita_db.util import get_required_sample_info_status, get_mountpoint
 from qiita_db.study import Study
 from qiita_db.data import RawData
 from .base_metadata_template import BaseSample, MetadataTemplate
-from .util import as_python_types, get_datatypes
 from .prep_template import PrepTemplate
 
 

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -28,7 +28,7 @@ from qiita_db.exceptions import (QiitaDBDuplicateError, QiitaDBUnknownIDError,
 from qiita_db.sql_connection import SQLConnectionHandler
 from qiita_db.study import Study, StudyPerson
 from qiita_db.user import User
-from qiita_db.util import exists_table, get_table_cols, get_count
+from qiita_db.util import exists_table, get_count
 from qiita_db.metadata_template.sample_template import SampleTemplate, Sample
 from qiita_db.metadata_template.prep_template import PrepTemplate, PrepSample
 


### PR DESCRIPTION
Some background:

The extend functionality was first introduced to add new samples to a sample template. However, if there was a new column, that new column was also added to the database. The problem is that at the beginning of the function, the existing samples were filtered from the metadata template so the existing samples didn't get the values for the new column.

This PR includes:
- the bug described above is fixed in a way that now extend can be used to add new columns, new samples or both.
 - moving part of the extend functionality to the base class, in preparation for adding it to the prep template (it will be needed in the refactor).
- the tests of the extend function were quite limited (they just tested that the sample id was there). I created a bunch of new tests, so the functionality is better tested in all the possible paths the function can be executed.