### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Qiita
 [![Build Status](https://travis-ci.org/biocore/qiita.png?branch=master)](https://travis-ci.org/biocore/qiita)
 [![Coverage Status](https://coveralls.io/repos/biocore/qiita/badge.png?branch=master)](https://coveralls.io/r/biocore/qiita)
 
-Qiita (canonically pronounced *cheetah*) is a meta-analysis environment for microbiome (and other "comparative -omics") datasets. You can find the public Qiita server at [qiita.microbio.me](qiita.microbio.me).
+Qiita (canonically pronounced *cheetah*) is a meta-analysis environment for microbiome (and other "comparative -omics") datasets. You can find the public Qiita server at [qiita.microbio.me](http://qiita.microbio.me).
 
 Qiita is currently in pre-alpha status. We are very open to community contributions and feedback. If you're interested in contributing to Qiita, see [CONTRIBUTING.md](https://github.com/biocore/qiita/blob/master/CONTRIBUTING.md). If you'd like to report bugs or request features, you can do that in the [Qiita issue tracker](https://github.com/biocore/qiita/issues).
 


### PR DESCRIPTION
Link to qiita.microbio.me needs to be an absolute URL