### PR TITLE
Use URL messages for messaging.

### DIFF
--- a/qiita_pet/handlers/auth_handlers.py
+++ b/qiita_pet/handlers/auth_handlers.py
@@ -52,8 +52,7 @@ class AuthCreateHandler(BaseHandler):
                 msg = ("Unable to send verification email. Please contact the "
                        "qiita developers at <a href='mailto:qiita-help"
                        "@gmail.com'>qiita-help@gmail.com</a>")
-                error_msg = u"?error=" + url_escape(msg)
-                self.redirect(u"/?level=danger&message=" + error_msg)
+                self.redirect(u"/?level=danger&message=" + url_escape(msg))
                 return
             self.redirect(u"/")
         else:

--- a/qiita_pet/handlers/base_handlers.py
+++ b/qiita_pet/handlers/base_handlers.py
@@ -59,7 +59,9 @@ class BaseHandler(RequestHandler):
 class MainHandler(BaseHandler):
     '''Index page'''
     def get(self):
-        self.render("index.html", message='', level='')
+        msg = self.get_argument('message', '')
+        lvl = self.get_argument('level', '')
+        self.render("index.html", message=msg, level=lvl)
 
 
 class MockupHandler(BaseHandler):


### PR DESCRIPTION
Needed for failed email messages. Now when URL has level and message in it, the message is rendered correctly.