### PR TITLE
Adding check_restrictions functionality

### DIFF
--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -1171,9 +1171,7 @@ class MetadataTemplate(QiitaObject):
         set of str
             The missing columns
         """
-        def _col_iter():
-            for restriction in restrictions:
-                for col in restriction.columns:
-                    yield col
+        cols = {col for restriction in restrictions
+                for col in restriction.columns}
 
-        return set(_col_iter()).difference(self.categories())
+        return cols.difference(self.categories())

--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -1157,3 +1157,24 @@ class MetadataTemplate(QiitaObject):
                     % (category, value_str, value_types_str, column_type))
 
             raise e
+
+    def check_restrictions(self, restrictions):
+        """Checks if the template fulfills the restrictions
+
+        Parameters
+        ----------
+        restrictions : list of Restriction
+            The restrictions to test if the template fulfills
+
+        Returns
+        -------
+        set of str
+            The missing columns
+        """
+        def _col_iter():
+            for restriction in restrictions:
+                for col in restriction.columns:
+                    yield col
+        categories = self.categories()
+        missing = {col for col in _col_iter() if col not in categories}
+        return missing

--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -1175,6 +1175,5 @@ class MetadataTemplate(QiitaObject):
             for restriction in restrictions:
                 for col in restriction.columns:
                     yield col
-        categories = self.categories()
-        missing = {col for col in _col_iter() if col not in categories}
-        return missing
+
+        return set(_col_iter()).difference(self.categories())

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -32,7 +32,8 @@ from qiita_db.util import (exists_table, get_db_files_base_dir, get_mountpoint,
                            get_count)
 from qiita_db.metadata_template.prep_template import PrepTemplate, PrepSample
 from qiita_db.metadata_template.sample_template import SampleTemplate, Sample
-from qiita_db.metadata_template.constants import PREP_TEMPLATE_COLUMNS
+from qiita_db.metadata_template.constants import (
+    PREP_TEMPLATE_COLUMNS, PREP_TEMPLATE_COLUMNS_TARGET_GENE)
 
 
 class BaseTestPrepSample(TestCase):
@@ -1298,6 +1299,20 @@ class TestPrepTemplateReadWrite(BaseTestPrepTemplate):
         exp = join(get_mountpoint('templates')[0][1],
                    '1_prep_1_qiime_19700101-000000.txt')
         self.assertEqual(pt.qiime_map_fp, exp)
+
+    def test_check_restrictions(self):
+        obs = self.tester.check_restrictions([PREP_TEMPLATE_COLUMNS['EBI']])
+        self.assertEqual(obs, set())
+
+        del self.metadata['primer']
+        pt = npt.assert_warns(QiitaDBWarning, PrepTemplate.create,
+                              self.metadata, self.new_raw_data,
+                              self.test_study, self.data_type)
+
+        obs = pt.check_restrictions(
+            [PREP_TEMPLATE_COLUMNS['EBI'],
+             PREP_TEMPLATE_COLUMNS_TARGET_GENE['demultiplex']])
+        self.assertEqual(obs, {'primer'})
 
 
 EXP_PREP_TEMPLATE = (

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -7,7 +7,6 @@
 # -----------------------------------------------------------------------------
 
 from future.builtins import zip
-from future.utils import viewvalues
 from unittest import TestCase, main
 from datetime import datetime
 from tempfile import mkstemp

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -7,6 +7,7 @@
 # -----------------------------------------------------------------------------
 
 from future.builtins import zip
+from future.utils import viewvalues
 from unittest import TestCase, main
 from datetime import datetime
 from tempfile import mkstemp
@@ -1954,6 +1955,16 @@ class TestSampleTemplateReadWrite(BaseTestSampleTemplate):
             'samp_salinity', 'altitude', 'env_biome', 'country', 'ph',
             'anonymized_name', 'tot_org_carb', 'description_duplicate',
             'env_feature'})
+
+    def test_check_restrictions(self):
+        obs = self.tester.check_restrictions([SAMPLE_TEMPLATE_COLUMNS['EBI']])
+        self.assertEqual(obs, set())
+
+        del self.metadata['collection_timestamp']
+        st = npt.assert_warns(QiitaDBWarning, SampleTemplate.create,
+                              self.metadata, self.new_study)
+        obs = st.check_restrictions([SAMPLE_TEMPLATE_COLUMNS['EBI']])
+        self.assertEqual(obs, {'collection_timestamp'})
 
 EXP_SAMPLE_TEMPLATE = (
     "sample_name\tcollection_timestamp\tdescription\tdna_extracted"


### PR DESCRIPTION
This adds the `check_restrictions` functionality to the metadata template objects. This functionality is needed to check the restrictions from the GUI and disable functionality as needed.

Should be easy to review!