### PR TITLE
Disable make processed data private

### DIFF
--- a/qiita_db/metadata_template/__init__.py
+++ b/qiita_db/metadata_template/__init__.py
@@ -9,8 +9,10 @@
 from .sample_template import SampleTemplate
 from .prep_template import PrepTemplate
 from .util import load_template_to_dataframe
-from .constants import TARGET_GENE_DATA_TYPES, SAMPLE_TEMPLATE_COLUMNS
+from .constants import (TARGET_GENE_DATA_TYPES, SAMPLE_TEMPLATE_COLUMNS,
+                        PREP_TEMPLATE_COLUMNS)
 
 
 __all__ = ['SampleTemplate', 'PrepTemplate', 'load_template_to_dataframe',
-           'TARGET_GENE_DATA_TYPES', 'SAMPLE_TEMPLATE_COLUMNS']
+           'TARGET_GENE_DATA_TYPES', 'SAMPLE_TEMPLATE_COLUMNS',
+           'PREP_TEMPLATE_COLUMNS']

--- a/qiita_db/metadata_template/__init__.py
+++ b/qiita_db/metadata_template/__init__.py
@@ -9,8 +9,8 @@
 from .sample_template import SampleTemplate
 from .prep_template import PrepTemplate
 from .util import load_template_to_dataframe
-from .constants import TARGET_GENE_DATA_TYPES
+from .constants import TARGET_GENE_DATA_TYPES, SAMPLE_TEMPLATE_COLUMNS
 
 
 __all__ = ['SampleTemplate', 'PrepTemplate', 'load_template_to_dataframe',
-           'TARGET_GENE_DATA_TYPES']
+           'TARGET_GENE_DATA_TYPES', 'SAMPLE_TEMPLATE_COLUMNS']

--- a/qiita_db/metadata_template/__init__.py
+++ b/qiita_db/metadata_template/__init__.py
@@ -10,9 +10,10 @@ from .sample_template import SampleTemplate
 from .prep_template import PrepTemplate
 from .util import load_template_to_dataframe
 from .constants import (TARGET_GENE_DATA_TYPES, SAMPLE_TEMPLATE_COLUMNS,
-                        PREP_TEMPLATE_COLUMNS)
+                        PREP_TEMPLATE_COLUMNS,
+                        PREP_TEMPLATE_COLUMNS_TARGET_GENE)
 
 
 __all__ = ['SampleTemplate', 'PrepTemplate', 'load_template_to_dataframe',
            'TARGET_GENE_DATA_TYPES', 'SAMPLE_TEMPLATE_COLUMNS',
-           'PREP_TEMPLATE_COLUMNS']
+           'PREP_TEMPLATE_COLUMNS', 'PREP_TEMPLATE_COLUMNS_TARGET_GENE']

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -32,8 +32,8 @@ from qiita_db.util import (exists_table, get_db_files_base_dir, get_mountpoint,
                            get_count)
 from qiita_db.metadata_template.prep_template import PrepTemplate, PrepSample
 from qiita_db.metadata_template.sample_template import SampleTemplate, Sample
-from qiita_db.metadata_template.constants import (
-    PREP_TEMPLATE_COLUMNS, PREP_TEMPLATE_COLUMNS_TARGET_GENE)
+from qiita_db.metadata_template import (PREP_TEMPLATE_COLUMNS,
+                                        PREP_TEMPLATE_COLUMNS_TARGET_GENE)
 
 
 class BaseTestPrepSample(TestCase):

--- a/qiita_pet/handlers/study_handlers/description_handlers.py
+++ b/qiita_pet/handlers/study_handlers/description_handlers.py
@@ -22,7 +22,8 @@ from qiita_db.study import Study
 from qiita_db.data import RawData, PreprocessedData, ProcessedData
 from qiita_db.ontology import Ontology
 from qiita_db.metadata_template import (PrepTemplate, SampleTemplate,
-                                        load_template_to_dataframe)
+                                        load_template_to_dataframe,
+                                        SAMPLE_TEMPLATE_COLUMNS)
 from qiita_db.util import convert_to_id, get_mountpoint
 from qiita_db.exceptions import (QiitaDBUnknownIDError, QiitaDBColumnError,
                                  QiitaDBExecutionError, QiitaDBDuplicateError,
@@ -624,6 +625,18 @@ class StudyDescriptionHandler(BaseHandler):
         user_level = user.level
         sample_template_exists = SampleTemplate.exists(study.id)
 
+        if sample_template_exists:
+            st = SampleTemplate(study.id)
+            missing_cols = st.check_restrictions(
+                [SAMPLE_TEMPLATE_COLUMNS['qiita_main']])
+            allow_approval = len(missing_cols) == 0
+            approval_deny_msg = (
+                "Processed data approval request is disabled due to missing "
+                "columns in the sample template: %s" % ', '.join(missing_cols))
+        else:
+            allow_approval = False
+            approval_deny_msg = ""
+
         # The general information of the study can be changed if the study is
         # not public or if the user is an admin, in which case they can always
         # modify the information of the study
@@ -638,6 +651,8 @@ class StudyDescriptionHandler(BaseHandler):
                     show_edit_btn=show_edit_btn,
                     show_data_tabs=sample_template_exists,
                     full_access=full_access,
+                    allow_approval=allow_approval,
+                    approval_deny_msg=approval_deny_msg,
                     top_tab=top_tab,
                     sub_tab=sub_tab,
                     prep_tab=prep_tab)

--- a/qiita_pet/handlers/study_handlers/ebi_handlers.py
+++ b/qiita_pet/handlers/study_handlers/ebi_handlers.py
@@ -13,7 +13,9 @@ from qiita_ware.context import submit
 from qiita_ware.demux import stats as demux_stats
 from qiita_ware.dispatchable import submit_to_ebi
 from qiita_db.data import PreprocessedData
-from qiita_db.metadata_template import PrepTemplate, SampleTemplate
+from qiita_db.metadata_template import (PrepTemplate, SampleTemplate,
+                                        SAMPLE_TEMPLATE_COLUMNS,
+                                        PREP_TEMPLATE_COLUMNS)
 from qiita_db.study import Study
 from qiita_db.exceptions import QiitaDBUnknownIDError
 from qiita_pet.handlers.base_handlers import BaseHandler
@@ -58,11 +60,33 @@ class EBISubmitHandler(BaseHandler):
             stats.append(('Number of sequences', demux_file_stats.n))
             msg_level = 'success'
 
+        # Check if the templates have all the required columns for EBI
+        pt_missing_cols = prep_template.check_restrictions(
+            [PREP_TEMPLATE_COLUMNS['EBI']])
+        st_missing_cols = sample_template.check_restrictions(
+            [SAMPLE_TEMPLATE_COLUMNS['EBI']])
+        allow_submission = (len(pt_missing_cols) == 0 and
+                            len(st_missing_cols) == 0)
+
+        if not allow_submission:
+            msg_list = ["Submission to EBI disabled due to missing columns:"]
+            if len(pt_missing_cols) > 0:
+                msg_list.append("Columns missing in prep template: %s"
+                                % ', '.join(pt_missing_cols))
+            if len(st_missing_cols) > 0:
+                msg_list.append("Columns missing in sample template: %s"
+                                % ', '.join(st_missing_cols))
+            ebi_disabled_msg = "<br/>".join(msg_list)
+        else:
+            ebi_disabled_msg = None
+
         self.render('ebi_submission.html',
                     study_title=study.title, stats=stats, message=msg,
                     study_id=study.id, level=msg_level,
                     preprocessed_data_id=preprocessed_data_id,
-                    investigation_type=prep_template.investigation_type)
+                    investigation_type=prep_template.investigation_type,
+                    allow_submission=allow_submission,
+                    ebi_disabled_msg=ebi_disabled_msg)
 
     @authenticated
     def get(self, preprocessed_data_id):

--- a/qiita_pet/templates/ebi_submission.html
+++ b/qiita_pet/templates/ebi_submission.html
@@ -28,14 +28,18 @@
     <br/><br/>
     {% if investigation_type %}
       {% if level != 'danger' and maintenance is None %}
-        <br/>
-        What kind of submission do you want to do?
-        <select name="submission_type">
-          <option value="ADD">ADD</option>
-          <option value="MODIFY">MODIFY</option>
-        </select>
-        <br/><br/>
-        <input type="submit" class="btn btn-primary" value="Submit to EBI">
+        {% if allow_submission %}
+            <br/>
+            What kind of submission do you want to do?
+            <select name="submission_type">
+                <option value="ADD">ADD</option>
+                <option value="MODIFY">MODIFY</option>
+            </select>
+            <br/><br/>
+            <input type="submit" class="btn btn-primary" value="Submit to EBI">
+        {% else %}
+            <b>{% raw ebi_disabled_msg %}
+        {% end %}
       {% end %}
     {% else %}
       <b>You need to set an investigation type to continue!</b>

--- a/qiita_pet/templates/study_description.html
+++ b/qiita_pet/templates/study_description.html
@@ -607,7 +607,7 @@ $(document).ready(function() {
     <!-- Show the preprocessed data tab -->
     {% module PreprocessedDataTab(study, full_access) %}
     <!-- Show the processed data tab -->
-    {% module ProcessedDataTab(study, full_access) %}
+    {% module ProcessedDataTab(study, full_access, allow_approval, approval_deny_msg) %}
   {% end %}
 </div>
 

--- a/qiita_pet/templates/study_description_templates/prep_template_panel.html
+++ b/qiita_pet/templates/study_description_templates/prep_template_panel.html
@@ -88,7 +88,11 @@
       <br/>
       {% if not preprocessed_data or preprocessing_status.startswith('failed') %}
         {% if study_status == 'sandbox' %}
-          <a class="btn btn-primary glyphicon glyphicon-play" data-toggle="modal" data-target="#preprocess-modal-view-{{prep_id}}" style="word-spacing: -10px;"> Preprocess</a>
+          {% if show_preprocess_btn %}
+            <a class="btn btn-primary glyphicon glyphicon-play" data-toggle="modal" data-target="#preprocess-modal-view-{{prep_id}}" style="word-spacing: -10px;"> Preprocess</a>
+          {% else %}
+            <b>{{ no_preprocess_msg }}</b>
+          {% end %}
         {% end %}
           <br>
           <i>Status:</i> {{preprocessing_status}}

--- a/qiita_pet/templates/study_description_templates/processed_data_info_tab.html
+++ b/qiita_pet/templates/study_description_templates/processed_data_info_tab.html
@@ -15,7 +15,11 @@
     {% end %}
   </table>
   {% if btn_to_show == 'request_approval' %}
-    <a class="btn btn-default glyphicon glyphicon-eye-open" onClick="request_approval({{pd_id}});" style="word-spacing: -10px;"> Request making this data private</a>
+    {% if allow_approval %}
+      <a class="btn btn-default glyphicon glyphicon-eye-open" onClick="request_approval({{pd_id}});" style="word-spacing: -10px;"> Request making this data private</a>
+    {% else %}
+      <b>{{ approval_deny_msg }}</b>
+    {% end %}
   {% elif btn_to_show == 'approve' %}
     <a class="btn btn-success glyphicon glyphicon-thumbs-up" onClick="approve_study({{pd_id}});" style="word-spacing: -10px;"> Approve this data to be private</a>
   {% elif btn_to_show == 'make_public' %}

--- a/qiita_pet/templates/study_description_templates/processed_data_tab.html
+++ b/qiita_pet/templates/study_description_templates/processed_data_tab.html
@@ -23,7 +23,7 @@
       </div>
       <!-- Create one tab pane for each processed data -->
       {% for pd_id, pd, _ in available_processed_data %}
-        {% module ProcessedDataInfoTab(study_id, pd) %}
+        {% module ProcessedDataInfoTab(study_id, pd, allow_approval, approval_deny_msg) %}
       {% end %}
     </div>
   {% else %}

--- a/qiita_pet/templates/study_description_templates/raw_data_editor_tab.html
+++ b/qiita_pet/templates/study_description_templates/raw_data_editor_tab.html
@@ -73,7 +73,7 @@
         <h4>Prep templates uploaded</h4>
         <div class="panel-group" id="prep-accordion-{{raw_data_id}}">
           {% for prep in available_prep_templates %}
-            {% module PrepTemplatePanel(prep, study_id, is_editable, ena_terms, study_status, user_defined_terms) %}
+            {% module PrepTemplatePanel(prep, study_id, is_editable, ena_terms, study_status, user_defined_terms, raw_data_files) %}
           {% end %}
         </div>
       </td>

--- a/qiita_pet/uimodules/processed_data_tab.py
+++ b/qiita_pet/uimodules/processed_data_tab.py
@@ -13,7 +13,7 @@ from .base_uimodule import BaseUIModule
 
 
 class ProcessedDataTab(BaseUIModule):
-    def render(self, study, full_access):
+    def render(self, study, full_access, allow_approval, approval_deny_msg):
         pd_gen = (ProcessedData(pd_id) for pd_id in study.processed_data())
         avail_pd = [(pd.id, pd, STATUS_STYLER[pd.status]) for pd in pd_gen
                     if full_access or pd.status == 'public']
@@ -21,11 +21,14 @@ class ProcessedDataTab(BaseUIModule):
         return self.render_string(
             "study_description_templates/processed_data_tab.html",
             available_processed_data=avail_pd,
-            study_id=study.id)
+            study_id=study.id,
+            allow_approval=allow_approval,
+            approval_deny_msg=approval_deny_msg)
 
 
 class ProcessedDataInfoTab(BaseUIModule):
-    def render(self, study_id, processed_data):
+    def render(self, study_id, processed_data, allow_approval,
+               approval_deny_msg):
         user = self.current_user
         # The request approval, approve processed data and make public buttons
         # are mutually exclusive. Only one of them will be shown, depending on
@@ -65,4 +68,6 @@ class ProcessedDataInfoTab(BaseUIModule):
             filepaths=filepaths,
             is_local_request=is_local_request,
             btn_to_show=btn_to_show,
-            show_revert_btn=show_revert_btn)
+            show_revert_btn=show_revert_btn,
+            allow_approval=allow_approval,
+            approval_deny_msg=approval_deny_msg)


### PR DESCRIPTION
Built on top of #1141 

If the user is missing some of the columns that are required for our system, we don't allow it to request making the data private, since that's not possible until the missing columns are added. The system shows a message with the missing columns.

Fixes partially #1128 