### PR TITLE
Add ON UPDATE CASCADE to the sample ids FK

### DIFF
--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -637,7 +637,11 @@ class MetadataTemplate(QiitaObject):
                            for col, dtype in zip(headers, datatypes)]
         conn_handler.add_to_queue(
             queue_name,
-            "CREATE TABLE qiita.{0} (sample_id varchar NOT NULL, {1})".format(
+            "CREATE TABLE qiita.{0} ("
+            "sample_id varchar NOT NULL, {1}, "
+            "CONSTRAINT fk_{0} FOREIGN KEY (sample_id) "
+            "REFERENCES qiita.study_sample (sample_id) "
+            "ON UPDATE CASCADE)".format(
                 table_name, ', '.join(column_datatype)))
 
         # Insert values on custom table

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -627,7 +627,9 @@ class TestPrepTemplateReadOnly(BaseTestPrepTemplate):
             'emp_status varchar, experiment_design_description varchar, '
             'library_construction_protocol varchar, '
             'linkerprimersequence varchar, platform varchar, '
-            'run_prefix varchar, str_column varchar)')
+            'run_prefix varchar, str_column varchar, '
+            'CONSTRAINT fk_prep_2 FOREIGN KEY (sample_id) REFERENCES '
+            'qiita.study_sample (sample_id) ON UPDATE CASCADE)')
 
         sql_insert_dynamic = (
             'INSERT INTO qiita.prep_2 '

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -795,12 +795,14 @@ class TestSampleTemplateReadOnly(BaseTestSampleTemplate):
 
         sql_crate_table = (
             'CREATE TABLE qiita.sample_2 (sample_id varchar NOT NULL, '
-            'collection_timestamp timestamp, ''description varchar, '
+            'collection_timestamp timestamp, description varchar, '
             'dna_extracted bool, host_subject_id varchar, int_column integer, '
             'latitude float8, longitude float8, '
             'physical_specimen_location varchar, '
             'physical_specimen_remaining bool, sample_type varchar, '
-            'str_column varchar)')
+            'str_column varchar, '
+            'CONSTRAINT fk_sample_2 FOREIGN KEY (sample_id) REFERENCES '
+            'qiita.study_sample (sample_id) ON UPDATE CASCADE)')
 
         sql_insert_dynamic = (
             'INSERT INTO qiita.sample_2 '

--- a/qiita_db/support_files/patches/24.sql
+++ b/qiita_db/support_files/patches/24.sql
@@ -1,0 +1,57 @@
+-- May 7, 2015
+-- This patch adds the ON UPDATE CASCADE constraint to all the FK
+-- that are referencing the sample ids
+
+DO $do$
+DECLARE
+    dyn_t varchar;
+    fk_vals RECORD;
+BEGIN
+
+-- The dynamic tables do not have a FK set on their sample ID
+-- We need to find the dynamic tables existing in the system and we add the
+-- FK constraint to them.
+FOR dyn_t IN
+    SELECT DISTINCT table_name
+    FROM information_schema.columns
+    WHERE (SUBSTR(table_name, 1, 7) = 'sample_'
+           OR SUBSTR(table_name, 1, 5) = 'prep_')
+        AND table_schema = 'qiita'
+        AND table_name NOT IN ('prep_template',
+                               'prep_template_preprocessed_data',
+                               'prep_template_filepath',
+                               'prep_columns',
+                               'sample_template_filepath',
+                               'prep_template_sample')
+LOOP
+    EXECUTE 'ALTER TABLE qiita.' || dyn_t || '
+                ADD CONSTRAINT fk_' || dyn_t || '
+                FOREIGN KEY (sample_id)'
+                'REFERENCES qiita.study_sample (sample_id);';
+END LOOP;
+
+-- Search for all the tables that are pointing to the sample_id
+-- and add the FK constraint with ON UPDATE CASCADE
+FOR fk_vals IN 
+    SELECT r.table_name, r.column_name, fk.constraint_name
+        FROM information_schema.constraint_column_usage u
+        INNER JOIN information_schema.referential_constraints fk
+            ON u.constraint_catalog = fk.unique_constraint_catalog
+            AND u.constraint_schema = fk.unique_constraint_schema
+            AND u.constraint_name = fk.unique_constraint_name
+        INNER JOIN information_schema.key_column_usage r
+            ON r.constraint_catalog = fk.constraint_catalog
+            AND r.constraint_schema = fk.constraint_schema
+            AND r.constraint_name = fk.constraint_name
+        WHERE u.column_name = 'sample_id'
+            AND u.table_schema = 'qiita'
+            AND u.table_name = 'study_sample'
+LOOP
+    EXECUTE 'ALTER TABLE qiita.' || fk_vals.table_name || '
+                DROP CONSTRAINT ' || fk_vals.constraint_name || ',
+                ADD CONSTRAINT ' || fk_vals.constraint_name ||'
+                    FOREIGN KEY (' || fk_vals.column_name ||')
+                    REFERENCES qiita.study_sample( sample_id )
+                    ON UPDATE CASCADE;';
+END LOOP;
+END $do$;


### PR DESCRIPTION
This adds the ON UPDATE CASCADE to the FK that points to the sample ids.

While developing the patch I noticed that the dynamic tables did not had the Foreign Key referencing the sample ids. The first part of the patch is adding that FK, while the second one is adding the ON UPDATE CASCADE to everything that references to sample id.

I've also updated the code so when the dynamic tables are created, the FK with ON UPDATE CASCADE constraint is also added to them.

@ElDeveloper @adamrp @wasade @squirrelo I would appreciate a review on this since this is blocking the update of an EMP study, and there is some people waiting on this to be able to update the study to EBI.