### PR TITLE
Fix demux to_ascii for fasta files

### DIFF
--- a/qiita_ware/demux.py
+++ b/qiita_ware/demux.py
@@ -438,7 +438,10 @@ def to_ascii(demux, samples=None):
     for samp, idx, seq, qual, bc_ori, bc_cor, bc_err in fetch(demux, samples):
         seq_id = id_fmt % {'sample': samp, 'idx': idx, 'bc_ori': bc_ori,
                            'bc_cor': bc_cor, 'bc_diff': bc_err}
-        yield formatter(seq_id, seq, qual.astype(np.uint8))
+        if qual is not None:
+            qual = qual.astype(np.uint8)
+
+        yield formatter(seq_id, seq, qual)
 
 
 def to_per_sample_ascii(demux, samples=None):

--- a/qiita_ware/test/test_demux.py
+++ b/qiita_ware/test/test_demux.py
@@ -246,11 +246,9 @@ class DemuxTests(TestCase):
         with tempfile.NamedTemporaryFile('r+', suffix='.fna',
                                          delete=False) as f:
             f.write(seqdata)
-            f.flush()
-            f.close()
 
-            to_hdf5(f.name, self.hdf5_file)
-            self.to_remove.append(f.name)
+        self.to_remove.append(f.name)
+        to_hdf5(f.name, self.hdf5_file)
 
         npt.assert_equal(self.hdf5_file['a/sequence'][:], np.array(["x", "xy",
                                                                     "xyz"]))
@@ -283,14 +281,13 @@ class DemuxTests(TestCase):
         with tempfile.NamedTemporaryFile('r+', suffix='.fq',
                                          delete=False) as f:
             f.write(fqdata)
-            f.flush()
-            f.close()
-            to_hdf5(f.name, self.hdf5_file)
-            self.to_remove.append(f.name)
 
         exp = [(b"@a_0 orig_bc=abc new_bc=abc bc_diffs=0\nxyz\n+\nABC\n"),
                (b"@b_0 orig_bc=abw new_bc=wbc bc_diffs=4\nqwe\n+\nDFG\n"),
                (b"@b_1 orig_bc=abw new_bc=wbc bc_diffs=4\nqwe\n+\nDEF\n")]
+        self.to_remove.append(f.name)
+        to_hdf5(f.name, self.hdf5_file)
+
 
         obs = list(to_ascii(self.hdf5_file, samples=['a', 'b']))
         self.assertEqual(obs, exp)
@@ -299,10 +296,9 @@ class DemuxTests(TestCase):
         with tempfile.NamedTemporaryFile('r+', suffix='.fq',
                                          delete=False) as f:
             f.write(fqdata)
-            f.flush()
-            f.close()
-            to_hdf5(f.name, self.hdf5_file)
-            self.to_remove.append(f.name)
+
+        self.to_remove.append(f.name)
+        to_hdf5(f.name, self.hdf5_file)
 
         exp = [('a', [(b"@a_0 orig_bc=abc new_bc=abc bc_diffs=0\nxyz\n+\n"
                        "ABC\n")]),

--- a/qiita_ware/test/test_demux.py
+++ b/qiita_ware/test/test_demux.py
@@ -282,12 +282,29 @@ class DemuxTests(TestCase):
                                          delete=False) as f:
             f.write(fqdata)
 
-        exp = [(b"@a_0 orig_bc=abc new_bc=abc bc_diffs=0\nxyz\n+\nABC\n"),
-               (b"@b_0 orig_bc=abw new_bc=wbc bc_diffs=4\nqwe\n+\nDFG\n"),
-               (b"@b_1 orig_bc=abw new_bc=wbc bc_diffs=4\nqwe\n+\nDEF\n")]
         self.to_remove.append(f.name)
         to_hdf5(f.name, self.hdf5_file)
 
+        exp = [b"@a_0 orig_bc=abc new_bc=abc bc_diffs=0\nxyz\n+\nABC\n",
+               b"@b_0 orig_bc=abw new_bc=wbc bc_diffs=4\nqwe\n+\nDFG\n",
+               b"@b_1 orig_bc=abw new_bc=wbc bc_diffs=4\nqwe\n+\nDEF\n"]
+
+        obs = list(to_ascii(self.hdf5_file, samples=['a', 'b']))
+        self.assertEqual(obs, exp)
+
+    def test_to_ascii_fasta(self):
+        with tempfile.NamedTemporaryFile('r+', suffix='.fna',
+                                         delete=False) as f:
+            f.write(seqdata)
+
+        self.to_remove.append(f.name)
+        to_hdf5(f.name, self.hdf5_file)
+
+        exp = [b">a_0 orig_bc=abc new_bc=abc bc_diffs=0\nx\n",
+               b">a_1 orig_bc=aby new_bc=ybc bc_diffs=2\nxy\n",
+               b">a_2 orig_bc=abz new_bc=zbc bc_diffs=3\nxyz\n",
+               b">b_0 orig_bc=abx new_bc=xbc bc_diffs=1\nxyz\n",
+               b">b_1 orig_bc=abw new_bc=wbc bc_diffs=4\nabcd\n"]
 
         obs = list(to_ascii(self.hdf5_file, samples=['a', 'b']))
         self.assertEqual(obs, exp)


### PR DESCRIPTION
Previously, this function would fail with fasta files because the call to qual.astype would fail (because qual is None when the file is fasta)