### PR TITLE
URGENT: Allowing preprocessing single-lane raw data that do not have run prefix

### DIFF
--- a/qiita_pet/uimodules/prep_template_tab.py
+++ b/qiita_pet/uimodules/prep_template_tab.py
@@ -191,7 +191,9 @@ class PrepTemplateInfoTab(BaseUIModule):
                     "linked with the Raw Data")
             else:
                 if prep_template.data_type() in TARGET_GENE_DATA_TYPES:
-                    key = ('demultiplex_multiple' if len(raw_data_files) > 2
+                    raw_forward_fps = [fp for _, fp, ftype in raw_data_files
+                                       if ftype == 'raw_forward_seqs']
+                    key = ('demultiplex_multiple' if len(raw_forward_fps) > 1
                            else 'demultiplex')
                     missing_cols = prep_template.check_restrictions(
                         [PREP_TEMPLATE_COLUMNS_TARGET_GENE[key]])


### PR DESCRIPTION
@ackermag found today that she cannot preprocess a study that had a RawData with a single lane because the PrepTemplate was missing the run_prefix.

There was a bug in the way the constraints was checked, as it was assuming that only the forward reads and the barcodes where added. If the reverse reads were added, the test fail and asked for the run_prefix.

This PR fix that problem. This is blocking the processing of current studies so having this merged and deployed is really urgent. @antgonza @ElDeveloper @squirrelo can I have a fast review of this?