### PR TITLE
Add text_col to convert_to_id

### DIFF
--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -185,7 +185,6 @@ class DBUtilTests(TestCase):
                                        "status"), 3)
         self.assertEqual(convert_to_id("EMP", "portal_type", "portal"), 2)
 
-
     def test_convert_to_id_bad_value(self):
         """Tests that ids are returned correctly"""
         with self.assertRaises(IncompetentQiitaDeveloperError):

--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -181,6 +181,10 @@ class DBUtilTests(TestCase):
     def test_convert_to_id(self):
         """Tests that ids are returned correctly"""
         self.assertEqual(convert_to_id("directory", "filepath_type"), 8)
+        self.assertEqual(convert_to_id("running", "analysis_status",
+                                       "status"), 3)
+        self.assertEqual(convert_to_id("EMP", "portal_type", "portal"), 2)
+
 
     def test_convert_to_id_bad_value(self):
         """Tests that ids are returned correctly"""

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -831,7 +831,7 @@ def convert_to_id(value, table, text_col=None):
     IncompetentQiitaDeveloperError
         The passed string has no associated id
     """
-    text_col = text_col if text_col else table
+    text_col = table if None else text_col
     conn_handler = SQLConnectionHandler()
     sql = "SELECT {0}_id FROM qiita.{0} WHERE {1} = %s".format(table, text_col)
     _id = conn_handler.execute_fetchone(sql, (value, ))

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -809,7 +809,7 @@ def filepath_ids_to_rel_paths(filepath_ids):
         return {}
 
 
-def convert_to_id(value, table):
+def convert_to_id(value, table, text_col=None):
     """Converts a string value to its corresponding table identifier
 
     Parameters
@@ -818,6 +818,8 @@ def convert_to_id(value, table):
         The string value to convert
     table : str
         The table that has the conversion
+    text_col : str, optional
+        Column holding the string value. Defaults to same as table name.
 
     Returns
     -------
@@ -829,8 +831,9 @@ def convert_to_id(value, table):
     IncompetentQiitaDeveloperError
         The passed string has no associated id
     """
+    text_col = text_col if text_col else table
     conn_handler = SQLConnectionHandler()
-    sql = "SELECT {0}_id FROM qiita.{0} WHERE {0} = %s".format(table)
+    sql = "SELECT {0}_id FROM qiita.{0} WHERE {1} = %s".format(table, text_col)
     _id = conn_handler.execute_fetchone(sql, (value, ))
     if _id is None:
         raise IncompetentQiitaDeveloperError("%s not valid for table %s"

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -831,7 +831,7 @@ def convert_to_id(value, table, text_col=None):
     IncompetentQiitaDeveloperError
         The passed string has no associated id
     """
-    text_col = table if None else text_col
+    text_col = table if text_col is None else text_col
     conn_handler = SQLConnectionHandler()
     sql = "SELECT {0}_id FROM qiita.{0} WHERE {1} = %s".format(table, text_col)
     _id = conn_handler.execute_fetchone(sql, (value, ))


### PR DESCRIPTION
This allows convert_to_id to be used anywhere regardless of table design. Initially done as a holdover for issue #292, but with discussion, may end up being a fine fix for it instead of redoing the DB.

Needed for the portal types, so quick review appreciated.