### PR TITLE
Transaction context improvement

### DIFF
--- a/qiita_db/test/test_sql_connection.py
+++ b/qiita_db/test/test_sql_connection.py
@@ -556,7 +556,7 @@ class TestTransaction(TestBase):
                 args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
                 trans.add(sql, args, many=True)
 
-            # We exited the second context, anything should have been executed
+            # We exited the second context, nothing should have been executed
             self.assertEqual(trans._contexts_entered, 1)
             self.assertEqual(
                 trans._conn_handler._connection.get_transaction_status(),

--- a/qiita_db/test/test_sql_connection.py
+++ b/qiita_db/test/test_sql_connection.py
@@ -312,7 +312,9 @@ class TestTransaction(TestBase):
             trans.add(sql, [20, False, "test_insert"])
             obs = trans.execute()
             self.assertEqual(obs, [None, None])
-            self._assert_sql_equal([("test_insert", False, 20)])
+            self._assert_sql_equal([])
+
+        self._assert_sql_equal([("test_insert", False, 20)])
 
     def test_execute_many(self):
         with Transaction("test_execute_many") as trans:
@@ -327,9 +329,11 @@ class TestTransaction(TestBase):
             obs = trans.execute()
             self.assertEqual(obs, [None, None, None, None])
 
-            self._assert_sql_equal([('insert1', True, 1),
-                                    ('insert3', True, 3),
-                                    ('insert2', False, 20)])
+            self._assert_sql_equal([])
+
+        self._assert_sql_equal([('insert1', True, 1),
+                                ('insert3', True, 3),
+                                ('insert2', False, 20)])
 
     def test_execute_return(self):
         with Transaction("test_execute_return") as trans:
@@ -373,7 +377,9 @@ class TestTransaction(TestBase):
             trans.add(sql, ["", "{0:0:0}"])
             obs = trans.execute()
             self.assertEqual(obs, [[['foo']], None])
-            self._assert_sql_equal([('', True, 2)])
+            self._assert_sql_equal([])
+
+        self._assert_sql_equal([('', True, 2)])
 
     def test_execute_error_bad_placeholder(self):
         with Transaction("test_execute_error_bad_placeholder") as trans:
@@ -435,7 +441,7 @@ class TestTransaction(TestBase):
             args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
             trans.add(sql, args, many=True)
 
-            obs = trans.execute(commit=False)
+            obs = trans.execute()
             exp = [[['insert1', 1]], [['insert2', 2]], [['insert3', 3]]]
             self.assertEqual(obs, exp)
 
@@ -453,7 +459,7 @@ class TestTransaction(TestBase):
             args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
             trans.add(sql, args, many=True)
 
-            obs = trans.execute(commit=False)
+            obs = trans.execute()
             exp = [[['insert1', 1]], [['insert2', 2]], [['insert3', 3]]]
             self.assertEqual(obs, exp)
 
@@ -470,7 +476,7 @@ class TestTransaction(TestBase):
             args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
             trans.add(sql, args, many=True)
 
-            obs = trans.execute(commit=False)
+            obs = trans.execute()
             exp = [[['insert1', 1]], [['insert2', 2]], [['insert3', 3]]]
             self.assertEqual(obs, exp)
 
@@ -483,9 +489,10 @@ class TestTransaction(TestBase):
             self.assertEqual(trans._queries, [(sql, args)])
 
             trans.execute()
+            self._assert_sql_equal([])
 
-            self._assert_sql_equal([('insert1', True, 1), ('insert3', True, 3),
-                                    ('insert2', False, 2)])
+        self._assert_sql_equal([('insert1', True, 1), ('insert3', True, 3),
+                                ('insert2', False, 2)])
 
     def test_context_manager_rollback(self):
         try:
@@ -495,7 +502,7 @@ class TestTransaction(TestBase):
                 args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
                 trans.add(sql, args, many=True)
 
-                trans.execute(commit=False)
+                trans.execute()
                 raise ValueError("Force exiting the context manager")
         except ValueError:
             pass
@@ -525,7 +532,7 @@ class TestTransaction(TestBase):
             args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
             trans.add(sql, args, many=True)
 
-            trans.execute(commit=False)
+            trans.execute()
             self._assert_sql_equal([])
 
         self._assert_sql_equal([('insert1', True, 1), ('insert2', True, 2),
@@ -598,7 +605,7 @@ class TestTransaction(TestBase):
             trans.add(sql, args, many=True)
             self.assertEqual(trans.index, 4)
 
-            trans.execute(commit=False)
+            trans.execute()
             self.assertEqual(trans.index, 4)
 
             trans.add(sql, args, many=True)

--- a/qiita_db/test/test_sql_connection.py
+++ b/qiita_db/test/test_sql_connection.py
@@ -199,15 +199,14 @@ class TestConnHandler(TestBase):
 
 class TestTransaction(TestBase):
     def test_init(self):
-        with Transaction("test_init") as obs:
-            obs = Transaction("test_init")
-            self.assertEqual(obs._name, "test_init")
-            self.assertEqual(obs._queries, [])
-            self.assertEqual(obs._results, [])
-            self.assertEqual(obs.index, 0)
-            self.assertTrue(
-                isinstance(obs._conn_handler, SQLConnectionHandler))
-            self.assertFalse(obs._is_inside_context)
+        obs = Transaction("test_init")
+        self.assertEqual(obs._name, "test_init")
+        self.assertEqual(obs._queries, [])
+        self.assertEqual(obs._results, [])
+        self.assertEqual(obs.index, 0)
+        self.assertTrue(
+            isinstance(obs._conn_handler, SQLConnectionHandler))
+        self.assertEqual(obs._contexts_entered, 0)
 
     def test_replace_placeholders(self):
         with Transaction("test_replace_placeholders") as trans:


### PR DESCRIPTION
While I started working transforming the code base to use transactions, I noticed that it was really hard to maintain a nice code. With the improvement in this PR to the Transaction context management, the code highly improves. It allows to enter multiple times in the context and only do something if we are leaving the last context.
Another change is the removal of the parameter `commit=False`. The execute function **will never commit**. Since the committing is automatically performed when exiting the context, you never want to explicitly commit, since through the code you don't know if there is something else in the transaction that shouldn't be committed...

What the changes in here allows you to do is:
```python
def test(trans=None):
    trans = trans if trans is not None else Transaction('test')
    with trans:
       trans.add("do something")
       return trans.execute() # This does not commit

trans = Transaction('foo')
with trans:
   trans.add("do_staff")
   val = test(trans) # This call will not commit the changes inside `test`
   res = trans.execute() # This does not commit

val = test() # This call will commit the changes inside `test`
```