### PR TITLE
Fix base object

### DIFF
--- a/qiita_db/base.py
+++ b/qiita_db/base.py
@@ -27,7 +27,7 @@ Classes
 
 from __future__ import division
 from qiita_core.exceptions import IncompetentQiitaDeveloperError
-from .sql_connection import SQLConnectionHandler
+from .sql_connection import SQLConnectionHandler, Transaction
 from .exceptions import QiitaDBNotImplementedError, QiitaDBUnknownIDError
 
 
@@ -192,47 +192,60 @@ class QiitaStatusObject(QiitaObject):
     _status_setter_checks
     """
 
-    @property
-    def status(self):
-        r"""String with the current status of the analysis"""
-        # Check that self._table is actually defined
-        self._check_subclass()
+    def status(self, trans=None):
+        r"""String with the current status of the object
 
+        Parameters
+        ----------
+        trans: Transaction, optional
+            Transaction in which this method should be executed
+        """
         # Get the DB status of the object
-        conn_handler = SQLConnectionHandler()
-        return conn_handler.execute_fetchone(
-            "SELECT status FROM qiita.{0}_status WHERE {0}_status_id = "
-            "(SELECT {0}_status_id FROM qiita.{0} WHERE "
-            "{0}_id = %s)".format(self._table),
-            (self._id, ))[0]
+        trans = trans if trans is not None else Transaction(
+            "status_%s_%s" % (self.__class__.__name__, self._id))
+        with trans:
+            sql = """SELECT status FROM qiita.{0}_status
+                     WHERE {0}_status_id = (
+                        SELECT {0}_status_id FROM qiita.{0}
+                        WHERE {0}_id = %s)""".format(self._table)
+            trans.add(sql, [self._id])
+            return trans.execute()[-1][0][0]
 
-    def _status_setter_checks(self, conn_handler):
+    def _status_setter_checks(self, trans):
         r"""Perform any extra checks that needed to be done before setting the
         object status on the database. Should be overwritten by the subclasses
+
+        Parameters
+        ----------
+        trans: Transaction
+            Transaction in which this method should be executed
         """
         raise QiitaDBNotImplementedError()
 
-    @status.setter
-    def status(self, status):
-        r"""Change the status of the analysis
+    def set_status(self, status, trans=None):
+        r"""Change the status of the object
 
         Parameters
         ----------
         status: str
             The new object status
+        trans: Transaction, optional
+            Transaction in which this method should be executed
         """
-        # Check that self._table is actually defined
-        self._check_subclass()
+        trans = trans if trans is not None else Transaction(
+            "set_status_%s_%s" % (self.__class__.__name__, self._id))
 
-        # Perform any extra checks needed before we update the status in the DB
-        conn_handler = SQLConnectionHandler()
-        self._status_setter_checks(conn_handler)
-
-        # Update the status of the object
-        conn_handler.execute(
-            "UPDATE qiita.{0} SET {0}_status_id = "
-            "(SELECT {0}_status_id FROM qiita.{0}_status WHERE status = %s) "
-            "WHERE {0}_id = %s".format(self._table), (status, self._id))
+        with trans:
+            # Perform any extra checks needed before we update the
+            # status in the DB
+            self._status_setter_checks(trans)
+            # Update the status of the object
+            sql = """UPDATE qiita.{0} SET {0}_status_id = (
+                        SELECT {0}_status_id
+                        FROM qiita.{0}_status WHERE status = %s)
+                    WHERE {0}_id = %s""".format(self._table)
+            self.add(sql, [status, self._id])
+            self.execute()
 
     def check_status(self, status, exclude=False):
         r"""Checks status of object.
@@ -264,21 +277,20 @@ class QiitaStatusObject(QiitaObject):
         Table setup:
         foo: foo_status_id  ----> foo_status: foo_status_id, status
         """
-        # Check that self._table is actually defined
-        self._check_subclass()
+        trans = Transaction("check_status_%s_%s"
+                            % (self.__class__.__name__, self._id))
+        with trans:
+            sql = "SELECT DISTINCT status FROM qiita.{0}_status".format(
+                self._table)
+            trans.add(sql, [self._id])
+            statuses = [x[0] for x in trans.execute()[-1]]
 
-        # Get all available statuses
-        conn_handler = SQLConnectionHandler()
+            # Check that all the provided statuses are valid statuses
+            if set(status).difference(statuses):
+                raise ValueError("%s are not valid status values"
+                                 % set(status).difference(statuses))
 
-        statuses = [x[0] for x in conn_handler.execute_fetchall(
-            "SELECT DISTINCT status FROM qiita.{0}_status".format(self._table),
-            (self._id, ))]
+            # Get the DB status of the object
+            dbstatus = self.status(trans)
 
-        # Check that all the provided statuses are valid statuses
-        if set(status).difference(statuses):
-            raise ValueError("%s are not valid status values"
-                             % set(status).difference(statuses))
-
-        # Get the DB status of the object
-        dbstatus = self.status
         return dbstatus not in status if exclude else dbstatus in status

--- a/qiita_db/base.py
+++ b/qiita_db/base.py
@@ -27,7 +27,7 @@ Classes
 
 from __future__ import division
 from qiita_core.exceptions import IncompetentQiitaDeveloperError
-from .sql_connection import SQLConnectionHandler, Transaction
+from .sql_connection import Transaction
 from .exceptions import QiitaDBNotImplementedError, QiitaDBUnknownIDError
 
 

--- a/qiita_db/base.py
+++ b/qiita_db/base.py
@@ -293,7 +293,7 @@ class QiitaStatusObject(QiitaObject):
             # Check that all the provided statuses are valid statuses
             if set(status).difference(statuses):
                 raise ValueError("%s are not valid status values"
-                                 % set(status).difference(statuses))
+                                 % ', '.join(set(status).difference(statuses)))
 
             # Get the DB status of the object
             dbstatus = self.status(trans)

--- a/qiita_db/base.py
+++ b/qiita_db/base.py
@@ -142,7 +142,7 @@ class QiitaObject(object):
         ----------
         id_: object
             The object identifier
-        trans: Transaction
+        trans: Transaction, optional
             Transaction in which this method should be executed
 
         Raises
@@ -199,6 +199,11 @@ class QiitaStatusObject(QiitaObject):
         ----------
         trans: Transaction, optional
             Transaction in which this method should be executed
+
+        Returns
+        -------
+        str
+            The status of the object
         """
         # Get the DB status of the object
         trans = trans if trans is not None else Transaction(

--- a/qiita_db/sql_connection.py
+++ b/qiita_db/sql_connection.py
@@ -876,3 +876,21 @@ class Transaction(object):
         self._conn_handler._connection.rollback()
         # Reset the queries
         self._queries = []
+
+
+def get_transaction(trans, name):
+    """Returns a new Transaction if trans is not None, else returns trans.
+
+    Parameters
+    ----------
+    trans : Transaction or None
+        The variable to check if the transaction already exists or not
+    name : str
+        The name of the new transaction
+
+    Returns
+    -------
+    Transaction
+        `trans` if it is not None or a new Transaction with name `name`
+    """
+    return trans if trans is not None else Transaction(name)

--- a/qiita_db/test/test_base.py
+++ b/qiita_db/test/test_base.py
@@ -85,7 +85,7 @@ class QiitaStatusObjectTest(TestCase):
 
     def test_status(self):
         """Correctly returns the status of the object"""
-        self.assertEqual(self.tester.status, "in_construction")
+        self.assertEqual(self.tester.status(), "in_construction")
 
     def test_check_status_single(self):
         """check_status works passing a single status"""

--- a/qiita_db/test/test_base.py
+++ b/qiita_db/test/test_base.py
@@ -15,6 +15,7 @@ from qiita_db.exceptions import QiitaDBUnknownIDError
 from qiita_db.data import RawData
 from qiita_db.study import Study, StudyPerson
 from qiita_db.analysis import Analysis
+from qiita_db.sql_connection import Transaction
 
 
 @qiita_test_checker()
@@ -49,8 +50,9 @@ class QiitaBaseTest(TestCase):
 
     def test_check_id(self):
         """Correctly checks if an id exists on the database"""
-        self.assertTrue(self.tester._check_id(1))
-        self.assertFalse(self.tester._check_id(100))
+        with Transaction("test_check_id") as trans:
+            self.assertTrue(self.tester._check_id(1, trans))
+            self.assertFalse(self.tester._check_id(100, trans))
 
     def test_equal_self(self):
         """Equality works with the same object"""

--- a/qiita_db/test/test_sql_connection.py
+++ b/qiita_db/test/test_sql_connection.py
@@ -7,7 +7,8 @@ from psycopg2.extensions import (ISOLATION_LEVEL_AUTOCOMMIT,
                                  ISOLATION_LEVEL_READ_COMMITTED,
                                  TRANSACTION_STATUS_IDLE)
 
-from qiita_db.sql_connection import SQLConnectionHandler, Transaction
+from qiita_db.sql_connection import (SQLConnectionHandler, Transaction,
+                                     get_transaction)
 from qiita_core.util import qiita_test_checker
 from qiita_core.qiita_settings import qiita_config
 
@@ -610,6 +611,14 @@ class TestTransaction(TestBase):
 
             trans.add(sql, args, many=True)
             self.assertEqual(trans.index, 7)
+
+    def test_get_transaction(self):
+        trans = Transaction("test_get_transaction")
+        obs = get_transaction(trans, "test")
+        self.assertEqual(obs, trans)
+
+        obs = get_transaction(None, "test")
+        self.assertEqual(obs._name, "test")
 
 if __name__ == "__main__":
     main()

--- a/qiita_db/user.py
+++ b/qiita_db/user.py
@@ -83,6 +83,8 @@ class User(QiitaObject):
         """
         sql = "SELECT EXISTS(SELECT * FROM qiita.qiita_user WHERE email = %s)"
         trans.add(sql, [id_])
+        # The value that we want is the result of the last SQL query,
+        # and it is stored in the first value of the first row
         return trans.execute()[-1][0][0]
 
     @classmethod

--- a/qiita_db/user.py
+++ b/qiita_db/user.py
@@ -66,26 +66,24 @@ class User(QiitaObject):
     # The following columns are considered not part of the user info
     _non_info = {"email", "user_level_id", "password"}
 
-    def _check_id(self, id_):
+    def _check_id(self, id_, trans):
         r"""Check that the provided ID actually exists in the database
 
         Parameters
         ----------
         id_ : object
             The ID to test
+        trans: Transaction
+            Transaction in which this method should be executed
 
         Notes
         -----
         This function overwrites the base function, as sql layout doesn't
         follow the same conventions done in the other classes.
         """
-        self._check_subclass()
-
-        conn_handler = SQLConnectionHandler()
-
-        return conn_handler.execute_fetchone(
-            "SELECT EXISTS(SELECT * FROM qiita.qiita_user WHERE "
-            "email = %s)", (id_, ))[0]
+        sql = "SELECT EXISTS(SELECT * FROM qiita.qiita_user WHERE email = %s)"
+        trans.add(sql, [id_])
+        return trans.execute()[-1][0][0]
 
     @classmethod
     def iter(cls):


### PR DESCRIPTION
Tests are expected to fail.

There are some case where we need to instantiate an object in a transaction, in order to do that, we need to modify the base object.

Also sometimes we check the status inside a transaction. This means that the `status` property is no longer a property and it becomes a method, so we can pass in the transaction in case that it is needed.

The changes in here affected the `User` object, so I also fix it since it was already checked on the list.