### PR TITLE
BUG: Fix CSS layout problem with the documentation - Jose & Josh

### DIFF
--- a/qiita_pet/support_files/doc/source/_static/my-styles.css
+++ b/qiita_pet/support_files/doc/source/_static/my-styles.css
@@ -1,0 +1,3 @@
+.navbar-brand > img {
+    display: inline-block;
+  }

--- a/qiita_pet/support_files/doc/source/_templates/layout.html
+++ b/qiita_pet/support_files/doc/source/_templates/layout.html
@@ -1,0 +1,5 @@
+{# Import the theme's layout. #}
+{% extends "!layout.html" %}
+
+{# Custom CSS overrides #}
+{% set bootswatch_css_custom = ['_static/my-styles.css'] %}


### PR DESCRIPTION
Fixes a problem where the project's name would overlap with the
navigation bar below the logo.

Fixes #1261