### PR TITLE
Portals object removal fix

### DIFF
--- a/qiita_db/portal.py
+++ b/qiita_db/portal.py
@@ -134,15 +134,14 @@ class Portal(QiitaObject):
                  JOIN qiita.analysis USING (analysis_id)
                  WHERE portal_type_id = %s and dflt = FALSE"""
         analyses = conn_handler.execute_fetchall(sql, [portal_id])
-        if studies:
+        if analyses:
             raise QiitaDBError(
                 " Cannot delete portal '%s', analyses still attached: %s" %
                 (portal, ', '.join([str(a[0]) for a in analyses])))
 
-        # Remove portal and default analyses for all users, unlink others
+        # Remove portal and default analyses for all users
         sql = """DO $do$
             DECLARE
-                pid bigint;
                 aid bigint;
             BEGIN
                 FOR aid IN
@@ -162,14 +161,10 @@ class Portal(QiitaObject):
                     DELETE FROM qiita.analysis
                     WHERE analysis_id = aid;
                 END LOOP;
-
-                DELETE FROM qiita.analysis_portal
-                WHERE portal_type_id = %s;
-
                 DELETE FROM qiita.portal_type WHERE portal_type_id = %s;
             END $do$;"""
         conn_handler = SQLConnectionHandler()
-        conn_handler.execute(sql, [portal_id] * 3)
+        conn_handler.execute(sql, [portal_id] * 2)
 
     @staticmethod
     def exists(portal):

--- a/qiita_db/test/test_portal.py
+++ b/qiita_db/test/test_portal.py
@@ -53,6 +53,7 @@ class TestPortal(TestCase):
     def test_remove_portal(self):
         Portal.create("NEWPORTAL", "SOMEDESC")
         # Select some samples on a default analysis
+        qiita_config.portal = "NEWPORTAL"
         a = Analysis(User("test@foo.bar").default_analysis)
         a.add_samples({1: ['1.SKB8.640193', '1.SKD5.640186']})
 

--- a/qiita_db/test/test_portal.py
+++ b/qiita_db/test/test_portal.py
@@ -5,26 +5,26 @@ import numpy.testing as npt
 from qiita_core.util import qiita_test_checker
 from qiita_core.exceptions import IncompetentQiitaDeveloperError
 from qiita_db.portal import Portal
-from qiita_db.study import Study
+from qiita_db.study import Study, StudyPerson
 from qiita_db.user import User
 from qiita_db.analysis import Analysis
 from qiita_db.exceptions import (QiitaDBError, QiitaDBDuplicateError,
                                  QiitaDBWarning)
-from qiita_db.util import get_count
 from qiita_core.qiita_settings import qiita_config
 
 
 @qiita_test_checker()
 class TestPortal(TestCase):
+    portal = qiita_config.portal
+
     def setUp(self):
         self.study = Study(1)
         self.analysis = Analysis(1)
         self.qiita_portal = Portal('QIITA')
         self.emp_portal = Portal('EMP')
-        self.portal = qiita_config.portal
 
     def tearDown(self):
-        qiita_config.portal = qiita_config.portal
+        qiita_config.portal = self.portal
 
     def test_list_portals(self):
         obs = Portal.list_portals()
@@ -56,12 +56,6 @@ class TestPortal(TestCase):
         a = Analysis(User("test@foo.bar").default_analysis)
         a.add_samples({1: ['1.SKB8.640193', '1.SKD5.640186']})
 
-        # Add analysis to this new portal
-        new_id = get_count("qiita.analysis") + 1
-        qiita_config.portal = "NEWPORTAL"
-        Analysis.create(User("test@foo.bar"), "newportal analysis", "desc")
-        qiita_config.portal = "QIITA"
-
         Portal.delete("NEWPORTAL")
         obs = self.conn_handler.execute_fetchall(
             "SELECT * FROM qiita.portal_type")
@@ -73,13 +67,45 @@ class TestPortal(TestCase):
         obs = self.conn_handler.execute_fetchall(
             "SELECT * FROM qiita.analysis_portal")
         exp = [[1, 1], [2, 1], [3, 1], [4, 1], [5, 1], [6, 1], [7, 2], [8, 2],
-               [9, 2], [10, 2], [new_id, 1]]
+               [9, 2], [10, 2]]
         self.assertItemsEqual(obs, exp)
 
         with self.assertRaises(IncompetentQiitaDeveloperError):
             Portal.delete("NOEXISTPORTAL")
         with self.assertRaises(QiitaDBError):
             Portal.delete("QIITA")
+
+        Portal.create("NEWPORTAL2", "SOMEDESC")
+        # Add analysis to this new portal and make sure error raised
+        qiita_config.portal = "NEWPORTAL2"
+        Analysis.create(User("test@foo.bar"), "newportal analysis", "desc")
+        qiita_config.portal = "QIITA"
+        with self.assertRaises(QiitaDBError):
+            Portal.delete("NEWPORTAL2")
+
+        # Add study to this new portal and make sure error raised
+        info = {
+            "timeseries_type_id": 1,
+            "metadata_complete": True,
+            "mixs_compliant": True,
+            "number_samples_collected": 25,
+            "number_samples_promised": 28,
+            "study_alias": "FCM",
+            "study_description": "Microbiome of people who eat nothing but "
+                                 "fried chicken",
+            "study_abstract": "Exploring how a high fat diet changes the "
+                              "gut microbiome",
+            "emp_person_id": StudyPerson(2),
+            "principal_investigator_id": StudyPerson(3),
+            "lab_person_id": StudyPerson(1)
+        }
+        Portal.create("NEWPORTAL3", "SOMEDESC")
+        qiita_config.portal = "NEWPORTAL3"
+        Study.create(User('test@foo.bar'), "Fried chicken microbiome",
+                     [1], info)
+        qiita_config.portal = "QIITA"
+        with self.assertRaises(QiitaDBError):
+            Portal.delete("NEWPORTAL3")
 
     def test_check_studies(self):
         with self.assertRaises(QiitaDBError):


### PR DESCRIPTION
There was some checks missing in the tests and therefore an issue was not caught. If an analysis is created in the portal, it will be unlinked. Also, selected samples for a default analysis will now be deleted properly.