### PR TITLE
Fix metadata template object for transaction

### DIFF
--- a/qiita_db/base.py
+++ b/qiita_db/base.py
@@ -128,8 +128,6 @@ class QiitaObject(object):
         the other classes. However, still defining here as there is only one
         subclass that doesn't follow this convention and it can override this.
         """
-        self._check_subclass()
-
         with TRN:
             sql = """SELECT EXISTS(
                         SELECT * FROM qiita.{0}
@@ -150,6 +148,7 @@ class QiitaObject(object):
             If `id_` does not correspond to any object
         """
         with TRN:
+            self._check_subclass()
             if not self._check_id(id_):
                 raise QiitaDBUnknownIDError(id_, self._table)
 

--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -205,7 +205,7 @@ class BaseSample(QiitaObject):
             A dictionary of the form {category: value}
         """
         with TRN:
-            sql = "SELECT * from qiita.{0} WHERE sample_id=%s".format(
+            sql = "SELECT * FROM qiita.{0} WHERE sample_id=%s".format(
                 self._dynamic_table)
             TRN.add(sql, [self._id])
             d = dict(TRN.execute_fetchindex()[0])

--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -52,7 +52,7 @@ from qiita_db.exceptions import (QiitaDBUnknownIDError, QiitaDBColumnError,
                                  QiitaDBNotImplementedError, QiitaDBError,
                                  QiitaDBWarning, QiitaDBDuplicateHeaderError)
 from qiita_db.base import QiitaObject
-from qiita_db.sql_connection import SQLConnectionHandler
+from qiita_db.sql_connection import TRN
 from qiita_db.util import (exists_table, get_table_cols,
                            get_mountpoint, insert_filepaths)
 from qiita_db.logger import LogEntry
@@ -172,20 +172,18 @@ class BaseSample(QiitaObject):
         bool
             True if already exists. False otherwise.
         """
-        cls._check_subclass()
-        conn_handler = SQLConnectionHandler()
-        return conn_handler.execute_fetchone(
-            "SELECT EXISTS(SELECT * FROM qiita.{0} WHERE sample_id=%s AND "
-            "{1}=%s)".format(cls._table, cls._id_column),
-            (sample_id, md_template.id))[0]
+        with TRN:
+            cls._check_subclass()
+            conn_handler = SQLConnectionHandler()
+            sql = """SELECT EXISTS(
+                        SELECT * FROM qiita.{0}
+                        WHERE sample_id=%s AND {1}=%s
+                    )""".format(cls._table, cls._id_column)
+            TRN.add(sql, [sample_id, md_template.id])
+            return TRN.execute_fetchlast()
 
-    def _get_categories(self, conn_handler):
+    def _get_categories(self):
         r"""Returns all the available metadata categories for the sample
-
-        Parameters
-        ----------
-        conn_handler : SQLConnectionHandler
-            The connection handler object connected to the DB
 
         Returns
         -------
@@ -197,7 +195,6 @@ class BaseSample(QiitaObject):
         # Remove the sample_id column as this column is used internally for
         # data storage and it doesn't actually belong to the metadata
         cols.remove('sample_id')
-
         return set(cols)
 
     def _to_dict(self):
@@ -208,16 +205,16 @@ class BaseSample(QiitaObject):
         dict of {str: str}
             A dictionary of the form {category: value}
         """
-        conn_handler = SQLConnectionHandler()
-        d = dict(conn_handler.execute_fetchone(
-            "SELECT * from qiita.{0} WHERE "
-            "sample_id=%s".format(self._dynamic_table),
-            (self._id, )))
+        with TRN:
+            sql = "SELECT * from qiita.{0} WHERE sample_id=%s".format(
+                self._dynamic_table)
+            TRN.add(sql, [self._id])
+            d = dict(TRN.execute_fetchindex()[0])
 
-        # Remove the sample_id, is not part of the metadata
-        del d['sample_id']
+            # Remove the sample_id, is not part of the metadata
+            del d['sample_id']
 
-        return d
+            return d
 
     def __len__(self):
         r"""Returns the number of metadata categories
@@ -227,9 +224,8 @@ class BaseSample(QiitaObject):
         int
             The number of metadata categories
         """
-        conn_handler = SQLConnectionHandler()
         # return the number of columns
-        return len(self._get_categories(conn_handler))
+        return len(self._get_categories())
 
     def __getitem__(self, key):
         r"""Returns the value of the metadata category `key`
@@ -253,21 +249,21 @@ class BaseSample(QiitaObject):
         --------
         get
         """
-        conn_handler = SQLConnectionHandler()
-        key = key.lower()
-        if key not in self._get_categories(conn_handler):
-            # The key is not available for the sample, so raise a KeyError
-            raise KeyError("Metadata category %s does not exists for sample %s"
-                           " in template %d" %
-                           (key, self._id, self._md_template.id))
+        with TRN:
+            key = key.lower()
+            if key not in self._get_categories():
+                # The key is not available for the sample, so raise a KeyError
+                raise KeyError(
+                    "Metadata category %s does not exists for sample %s"
+                    " in template %d" % (key, self._id, self._md_template.id))
 
-        sql = """SELECT {0} FROM qiita.{1}
-                 WHERE sample_id=%s""".format(key, self._dynamic_table)
+            sql = """SELECT {0} FROM qiita.{1}
+                     WHERE sample_id=%s""".format(key, self._dynamic_table)
+            TRN.add(sql, [self._id])
+            return TRN.execute_fetchlast()
 
-        return conn_handler.execute_fetchone(sql, (self._id, ))[0]
-
-    def add_setitem_queries(self, column, value, conn_handler, queue):
-        """Adds the SQL queries needed to set a value to the provided queue
+    def setitem(self, column, value):
+        """Sets `value` as value for the given `column`
 
         Parameters
         ----------
@@ -276,26 +272,22 @@ class BaseSample(QiitaObject):
         value : str
             The value to set. This is expected to be a str on the assumption
             that psycopg2 will cast as necessary when updating.
-        conn_handler : SQLConnectionHandler
-            The connection handler object connected to the DB
-        queue : str
-            The queue where the SQL statements will be added
 
         Raises
         ------
         QiitaDBColumnError
             If the column does not exist in the table
         """
-        # Check if the column exist in the table
-        if column not in self._get_categories(conn_handler):
-            raise QiitaDBColumnError("Column %s does not exist in %s" %
-                                     (column, self._dynamic_table))
+        with TRN:
+            # Check if the column exist in the table
+            if column not in self._get_categories():
+                raise QiitaDBColumnError("Column %s does not exist in %s" %
+                                         (column, self._dynamic_table))
 
-        sql = """UPDATE qiita.{0}
-                 SET {1}=%s
-                 WHERE sample_id=%s""".format(self._dynamic_table, column)
-
-        conn_handler.add_to_queue(queue, sql, (value, self._id))
+            sql = """UPDATE qiita.{0}
+                     SET {1}=%s
+                     WHERE sample_id=%s""".format(self._dynamic_table, column)
+            TRN.add(sql, [value, self._id])
 
     def __setitem__(self, column, value):
         r"""Sets the metadata value for the category `column`
@@ -313,36 +305,33 @@ class BaseSample(QiitaObject):
         ValueError
             If the value type does not match the one in the DB
         """
-        conn_handler = SQLConnectionHandler()
-        queue_name = "set_item_%s" % self._id
-        conn_handler.create_queue(queue_name)
+        with TRN:
+            self.setitem(column, value)
 
-        self.add_setitem_queries(column, value, conn_handler, queue_name)
+            try:
+                TRN.execute()
+            except ValueError as e:
+                # catching error so we can check if the error is due to
+                # different column type or something else
+                value_type = type_lookup(type(value))
 
-        try:
-            conn_handler.execute_queue(queue_name)
-        except ValueError as e:
-            # catching error so we can check if the error is due to different
-            # column type or something else
-            value_type = type_lookup(type(value))
+                sql = """SELECT udt_name
+                         FROM information_schema.columns
+                         WHERE column_name = %s
+                            AND table_schema = 'qiita'
+                            AND (table_name = %s OR table_name = %s)"""
+                TRN.add(sql, [column, self._table, self._dynamic_table])
+                column_type = TRN.execute_fetchlast()[0]
 
-            sql = """SELECT udt_name
-                     FROM information_schema.columns
-                     WHERE column_name = %s
-                        AND table_schema = 'qiita'
-                        AND (table_name = %s OR table_name = %s)"""
-            column_type = conn_handler.execute_fetchone(
-                sql, (column, self._table, self._dynamic_table))
+                if column_type != value_type:
+                    raise ValueError(
+                        'The new value being added to column: "{0}" is "{1}" '
+                        '(type: "{2}"). However, this column in the DB is of '
+                        'type "{3}". Please change the value in your updated '
+                        'template or reprocess your template.'.format(
+                            column, value, value_type, column_type))
 
-            if column_type != value_type:
-                raise ValueError(
-                    'The new value being added to column: "{0}" is "{1}" '
-                    '(type: "{2}"). However, this column in the DB is of '
-                    'type "{3}". Please change the value in your updated '
-                    'template or reprocess your template.'.format(
-                        column, value, value_type, column_type))
-
-            raise e
+                raise e
 
     def __delitem__(self, key):
         r"""Removes the sample with sample id `key` from the database
@@ -366,8 +355,7 @@ class BaseSample(QiitaObject):
         --------
         keys
         """
-        conn_handler = SQLConnectionHandler()
-        return iter(self._get_categories(conn_handler))
+        return iter(self._get_categories())
 
     def __contains__(self, key):
         r"""Checks if the metadata category `key` is present
@@ -382,8 +370,7 @@ class BaseSample(QiitaObject):
         bool
             True if the metadata category `key` is present, false otherwise
         """
-        conn_handler = SQLConnectionHandler()
-        return key.lower() in self._get_categories(conn_handler)
+        return key.lower() in self._get_categories()
 
     def keys(self):
         r"""Iterator over the metadata categories
@@ -486,14 +473,11 @@ class MetadataTemplate(QiitaObject):
 
     def _check_id(self, id_):
         r"""Checks that the MetadataTemplate id_ exists on the database"""
-        self._check_subclass()
-
-        conn_handler = SQLConnectionHandler()
-
-        return conn_handler.execute_fetchone(
-            "SELECT EXISTS(SELECT * FROM qiita.{0} WHERE "
-            "{1}=%s)".format(self._table, self._id_column),
-            (id_, ))[0]
+        with TRN:
+            sql = "SELECT EXISTS(SELECT * FROM qiita.{0} WHERE {1}=%s)".format(
+                self._table, self._id_column)
+            TRN.add(sql, [id_])
+            return TRN.execute_fetchlast()
 
     @classmethod
     def _table_name(cls, obj_id):
@@ -587,8 +571,7 @@ class MetadataTemplate(QiitaObject):
         return md_template
 
     @classmethod
-    def _add_common_creation_steps_to_queue(cls, md_template, obj_id,
-                                            conn_handler, queue_name):
+    def _common_creation_steps(cls, md_template, obj_id):
         r"""Adds the common creation steps to the queue in conn_handler
 
         Parameters
@@ -597,158 +580,153 @@ class MetadataTemplate(QiitaObject):
             The metadata template file contents indexed by sample ids
         obj_id : int
             The id of the object being created
-        conn_handler : SQLConnectionHandler
-            The connection handler object connected to the DB
-        queue_name : str
-            The queue where the SQL statements will be added
         """
-        cls._check_subclass()
+        with TRN:
+            cls._check_subclass()
 
-        # Get some useful information from the metadata template
-        sample_ids = md_template.index.tolist()
-        headers = sorted(md_template.keys().tolist())
+            # Get some useful information from the metadata template
+            sample_ids = md_template.index.tolist()
+            headers = sorted(md_template.keys().tolist())
 
-        # Insert values on template_sample table
-        values = [(obj_id, s_id) for s_id in sample_ids]
-        sql = "INSERT INTO qiita.{0} ({1}, sample_id) VALUES (%s, %s)".format(
-            cls._table, cls._id_column)
-        conn_handler.add_to_queue(queue_name, sql, values, many=True)
+            # Insert values on template_sample table
+            values = [(obj_id, s_id) for s_id in sample_ids]
+            sql = """INSERT INTO qiita.{0} ({1}, sample_id)
+                     VALUES (%s, %s)""".format(cls._table, cls._id_column)
+            TRN.add(sql, values, many=True)
 
-        # Insert rows on *_columns table
-        datatypes = get_datatypes(md_template.ix[:, headers])
-        # psycopg2 requires a list of tuples, in which each tuple is a set
-        # of values to use in the string formatting of the query. We have all
-        # the values in different lists (but in the same order) so use zip
-        # to create the list of tuples that psycopg2 requires.
-        values = [(obj_id, h, d) for h, d in zip(headers, datatypes)]
-        sql = ("INSERT INTO qiita.{0} ({1}, column_name, column_type) "
-               "VALUES (%s, %s, %s)").format(cls._column_table, cls._id_column)
-        conn_handler.add_to_queue(queue_name, sql, values, many=True)
+            # Insert rows on *_columns table
+            datatypes = get_datatypes(md_template.ix[:, headers])
+            # psycopg2 requires a list of tuples, in which each tuple is a set
+            # of values to use in the string formatting of the query. We have
+            # all the values in different lists (but in the same order) so use
+            # zip to create the list of tuples that psycopg2 requires.
+            values = [[obj_id, h, d] for h, d in zip(headers, datatypes)]
+            sql = """INSERT INTO qiita.{0} ({1}, column_name, column_type)
+                     VALUES (%s, %s, %s)""".format(cls._column_table,
+                                                   cls._id_column)
+            TRN.add(sql, values, many=True)
 
-        # Create table with custom columns
-        table_name = cls._table_name(obj_id)
-        column_datatype = ["%s %s" % (col, dtype)
-                           for col, dtype in zip(headers, datatypes)]
-        conn_handler.add_to_queue(
-            queue_name,
-            "CREATE TABLE qiita.{0} ("
-            "sample_id varchar NOT NULL, {1}, "
-            "CONSTRAINT fk_{0} FOREIGN KEY (sample_id) "
-            "REFERENCES qiita.study_sample (sample_id) "
-            "ON UPDATE CASCADE)".format(
-                table_name, ', '.join(column_datatype)))
+            # Create table with custom columns
+            table_name = cls._table_name(obj_id)
+            column_datatype = ["%s %s" % (col, dtype)
+                               for col, dtype in zip(headers, datatypes)]
+            sql = """CREATE TABLE qiita.{0} (
+                        sample_id varchar NOT NULL, {1},
+                        CONSTRAINT fk_{0} FOREIGN KEY (sample_id)
+                            REFERENCES qiita.study_sample (sample_id)
+                            ON UPDATE CASCADE
+                     )""".format(table_name, ', '.join(column_datatype))
+            TRN.add(sql)
 
-        # Insert values on custom table
-        values = as_python_types(md_template, headers)
-        values.insert(0, sample_ids)
-        values = [v for v in zip(*values)]
-        conn_handler.add_to_queue(
-            queue_name,
-            "INSERT INTO qiita.{0} (sample_id, {1}) "
-            "VALUES (%s, {2})".format(table_name, ", ".join(headers),
-                                      ', '.join(["%s"] * len(headers))),
-            values, many=True)
+            # Insert values on custom table
+            values = as_python_types(md_template, headers)
+            values.insert(0, sample_ids)
+            values = [list(v) for v in zip(*values)]
+            sql = """INSERT INTO qiita.{0} (sample_id, {1})
+                     VALUES (%s, {2})""".format(
+                table_name, ", ".join(headers),
+                ', '.join(["%s"] * len(headers)))
+            TRN.add(sql, values, many=True)
 
-    def _add_common_extend_steps_to_queue(self, md_template, conn_handler,
-                                          queue_name):
+    def _common_extend_steps(self, md_template):
         r"""Adds the common extend steps to the queue in conn_handler
 
         Parameters
         ----------
         md_template : DataFrame
             The metadata template file contents indexed by sample ids
-        conn_handler : SQLConnectionHandler
-            The connection handler object connected to the DB
-        queue_name : str
-            The queue where the SQL statements will be added
 
         Raises
         ------
         QiitaDBError
             If no new samples or new columns are present in `md_template`
         """
-        # Check if we are adding new samples
-        sample_ids = md_template.index.tolist()
-        curr_samples = set(self.keys())
-        existing_samples = curr_samples.intersection(sample_ids)
-        new_samples = set(sample_ids).difference(existing_samples)
+        with TRN:
+            # Check if we are adding new samples
+            sample_ids = md_template.index.tolist()
+            curr_samples = set(self.keys())
+            existing_samples = curr_samples.intersection(sample_ids)
+            new_samples = set(sample_ids).difference(existing_samples)
 
-        # Check if we are adding new columns
-        headers = md_template.keys().tolist()
-        new_cols = set(headers).difference(self.categories())
+            # Check if we are adding new columns
+            headers = md_template.keys().tolist()
+            new_cols = set(headers).difference(self.categories())
 
-        if not new_cols and not new_samples:
-            raise QiitaDBError(
-                "No new samples or new columns found in the template. If you "
-                "want to update existing values, you should use the 'update' "
-                "functionality.")
+            if not new_cols and not new_samples:
+                raise QiitaDBError(
+                    "No new samples or new columns found in the template. "
+                    "If you want to update existing values, you should use "
+                    "the 'update' functionality.")
 
-        table_name = self._table_name(self._id)
-        if new_cols:
-            # If we are adding new columns, add them first (simplifies code)
-            # Sorting the new columns to enforce an order
-            new_cols = sorted(new_cols)
-            datatypes = get_datatypes(md_template.ix[:, new_cols])
-            sql_cols = """INSERT INTO qiita.{0} ({1}, column_name, column_type)
-                          VALUES (%s, %s, %s)""".format(self._column_table,
-                                                        self._id_column)
-            sql_alter = """ALTER TABLE qiita.{0} ADD COLUMN {1} {2}"""
-            for category, dtype in zip(new_cols, datatypes):
-                conn_handler.add_to_queue(
-                    queue_name, sql_cols, (self._id, category, dtype))
-                conn_handler.add_to_queue(
-                    queue_name, sql_alter.format(table_name, category, dtype))
+            table_name = self._table_name(self._id)
+            if new_cols:
+                # If we are adding new columns, add them first (simplifies
+                # code). Sorting the new columns to enforce an order
+                new_cols = sorted(new_cols)
+                datatypes = get_datatypes(md_template.ix[:, new_cols])
+                sql_cols = """INSERT INTO qiita.{0}
+                                    ({1}, column_name, column_type)
+                              VALUES (%s, %s, %s)""".format(self._column_table,
+                                                            self._id_column)
+                sql_alter = """ALTER TABLE qiita.{0} ADD COLUMN {1} {2}"""
+                for category, dtype in zip(new_cols, datatypes):
+                    TRN.add(sql_cols, [self._id, category, dtype])
+                    TRN.add(sql_alter.format(table_name, category, dtype))
 
-            if existing_samples:
+                if existing_samples:
+                    warnings.warn(
+                        "No values have been modified for existing samples "
+                        "(%s). However, the following columns have been added "
+                        "to them: '%s'"
+                        % (len(existing_samples), ", ".join(new_cols)),
+                        QiitaDBWarning)
+                    # The values for the new columns are the only ones that get
+                    # added to the database. None of the existing values will
+                    # be modified (see update for that functionality)
+                    min_md_template = \
+                        md_template[new_cols].loc[existing_samples]
+                    values = as_python_types(min_md_template, new_cols)
+                    values.append(existing_samples)
+                    # psycopg2 requires a list of iterable, in which each
+                    # iterable is a set of values to use in the string
+                    # formatting of the query. We have all the values in
+                    # different lists (but in the same order) so use zip to
+                    # create the list of iterable that psycopg2 requires.
+                    values = [list(v) for v in zip(*values)]
+                    set_str = ["{0} = %s".format(col) for col in new_cols]
+                    sql = """UPDATE qiita.{0}
+                             SET {1}
+                             WHERE sample_id=%s""".format(table_name,
+                                                          ",".join(set_str))
+                    TRN.add(sql, values, many=True)
+            elif existing_samples:
                 warnings.warn(
-                    "No values have been modified for existing samples (%s). "
-                    "However, the following columns have been added to them: "
-                    "'%s'" % (len(existing_samples), ", ".join(new_cols)),
+                    "%d samples already exist in the template and "
+                    "their values won't be modified" % len(existing_samples),
                     QiitaDBWarning)
-                # The values for the new columns are the only ones that get
-                # added to the database. None of the existing values will be
-                # modified (see update for that functionality)
-                min_md_template = md_template[new_cols].loc[existing_samples]
-                values = as_python_types(min_md_template, new_cols)
-                values.append(existing_samples)
-                # psycopg2 requires a list of tuples, in which each tuple is a
-                # set of values to use in the string formatting of the query.
-                # We have all the values in different lists (but in the same
-                # order) so use zip to create the list of tuples that psycopg2
-                # requires.
-                values = [v for v in zip(*values)]
-                set_str = ["{0} = %s".format(col) for col in new_cols]
-                sql = """UPDATE qiita.{0}
-                         SET {1}
-                         WHERE sample_id=%s""".format(table_name,
-                                                      ",".join(set_str))
-                conn_handler.add_to_queue(queue_name, sql, values, many=True)
-        elif existing_samples:
-            warnings.warn(
-                "%d samples already exist in the template and "
-                "their values won't be modified" % len(existing_samples),
-                QiitaDBWarning)
 
-        if new_samples:
-            new_samples = sorted(new_samples)
-            # At this point we only want the information from the new samples
-            md_template = md_template.loc[new_samples]
+            if new_samples:
+                new_samples = sorted(new_samples)
+                # At this point we only want the information
+                # from the new samples
+                md_template = md_template.loc[new_samples]
 
-            # Insert values on required columns
-            values = [(self._id, s_id) for s_id in new_samples]
-            sql = """INSERT INTO qiita.{0} ({1}, sample_id)
-                     VALUES (%s, %s)""".format(self._table, self._id_column)
-            conn_handler.add_to_queue(queue_name, sql, values, many=True)
+                # Insert values on required columns
+                values = [[self._id, s_id] for s_id in new_samples]
+                sql = """INSERT INTO qiita.{0} ({1}, sample_id)
+                         VALUES (%s, %s)""".format(self._table,
+                                                   self._id_column)
+                TRN.add(sql, values, many=True)
 
-            # Insert values on custom table
-            values = as_python_types(md_template, headers)
-            values.insert(0, new_samples)
-            values = [v for v in zip(*values)]
-            sql = """INSERT INTO qiita.{0} (sample_id, {1})
-                     VALUES (%s, {2})""".format(
-                table_name, ", ".join(headers),
-                ', '.join(["%s"] * len(headers)))
-            conn_handler.add_to_queue(queue_name, sql, values, many=True)
+                # Insert values on custom table
+                values = as_python_types(md_template, headers)
+                values.insert(0, new_samples)
+                values = [list(v) for v in zip(*values)]
+                sql = """INSERT INTO qiita.{0} (sample_id, {1})
+                         VALUES (%s, {2})""".format(
+                    table_name, ", ".join(headers),
+                    ', '.join(["%s"] * len(headers)))
+                TRN.add(sql, values, many=True)
 
     @classmethod
     def exists(cls, obj_id):
@@ -767,24 +745,20 @@ class MetadataTemplate(QiitaObject):
         cls._check_subclass()
         return exists_table(cls._table_name(obj_id))
 
-    def _get_sample_ids(self, conn_handler):
+    def _get_sample_ids(self):
         r"""Returns all the available samples for the metadata template
-
-        Parameters
-        ----------
-        conn_handler : SQLConnectionHandler
-            The connection handler object connected to the DB
 
         Returns
         -------
         set of str
             The set of all available sample ids
         """
-        sample_ids = conn_handler.execute_fetchall(
-            "SELECT sample_id FROM qiita.{0} WHERE "
-            "{1}=%s".format(self._table, self._id_column),
-            (self._id, ))
-        return set(sample_id[0] for sample_id in sample_ids)
+        with TRN:
+            sql = "SELECT sample_id FROM qiita.{0} WHERE {1}=%s".format(
+                self._table, self._id_column)
+            TRN.add(sql, [self._id])
+            sample_ids = TRN.execute_fetchlast()
+            return set(sample_id[0] for sample_id in sample_ids)
 
     def __len__(self):
         r"""Returns the number of samples in the metadata template
@@ -794,8 +768,7 @@ class MetadataTemplate(QiitaObject):
         int
             The number of samples in the metadata template
         """
-        conn_handler = SQLConnectionHandler()
-        return len(self._get_sample_ids(conn_handler))
+        return len(self._get_sample_ids())
 
     def __getitem__(self, key):
         r"""Returns the metadata values for sample id `key`
@@ -819,11 +792,12 @@ class MetadataTemplate(QiitaObject):
         --------
         get
         """
-        if key in self:
-            return self._sample_cls(key, self)
-        else:
-            raise KeyError("Sample id %s does not exists in template %d"
-                           % (key, self._id))
+        with TRN:
+            if key in self:
+                return self._sample_cls(key, self)
+            else:
+                raise KeyError("Sample id %s does not exists in template %d"
+                               % (key, self._id))
 
     def __setitem__(self, key, value):
         r"""Sets the metadata values for sample id `key`
@@ -859,8 +833,7 @@ class MetadataTemplate(QiitaObject):
         --------
         keys
         """
-        conn_handler = SQLConnectionHandler()
-        return iter(self._get_sample_ids(conn_handler))
+        return iter(self._get_sample_ids())
 
     def __contains__(self, key):
         r"""Checks if the sample id `key` is present in the metadata template
@@ -876,7 +849,6 @@ class MetadataTemplate(QiitaObject):
             True if the sample id `key` is in the metadata template, false
             otherwise
         """
-        conn_handler = SQLConnectionHandler()
         return key in self._get_sample_ids(conn_handler)
 
     def keys(self):
@@ -901,9 +873,9 @@ class MetadataTemplate(QiitaObject):
         Iterator
             Iterator over Sample obj
         """
-        conn_handler = SQLConnectionHandler()
-        return iter(self._sample_cls(sample_id, self)
-                    for sample_id in self._get_sample_ids(conn_handler))
+        with TRN:
+            return iter(self._sample_cls(sample_id, self)
+                        for sample_id in self._get_sample_ids())
 
     def items(self):
         r"""Iterator over (sample_id, values) tuples, in sample id order
@@ -913,9 +885,9 @@ class MetadataTemplate(QiitaObject):
         Iterator
             Iterator over (sample_ids, values) tuples
         """
-        conn_handler = SQLConnectionHandler()
-        return iter((sample_id, self._sample_cls(sample_id, self))
-                    for sample_id in self._get_sample_ids(conn_handler))
+        with TRN:
+            return iter((sample_id, self._sample_cls(sample_id, self))
+                        for sample_id in self._get_sample_ids(conn_handler))
 
     def get(self, key):
         r"""Returns the metadata values for sample id `key`, or None if the
@@ -990,17 +962,18 @@ class MetadataTemplate(QiitaObject):
             If supplied, only the specified samples will be written to the
             file
         """
-        df = self.to_dataframe()
-        if samples is not None:
-            df = df.loc[samples]
+        with TRN:
+            df = self.to_dataframe()
+            if samples is not None:
+                df = df.loc[samples]
 
-        # Sorting the dataframe so multiple serializations of the metadata
-        # template are consistent.
-        df.sort_index(axis=0, inplace=True)
-        df.sort_index(axis=1, inplace=True)
+            # Sorting the dataframe so multiple serializations of the metadata
+            # template are consistent.
+            df.sort_index(axis=0, inplace=True)
+            df.sort_index(axis=1, inplace=True)
 
-        # Store the template in a file
-        df.to_csv(fp, index_label='sample_name', na_rep="", sep='\t')
+            # Store the template in a file
+            df.to_csv(fp, index_label='sample_name', na_rep="", sep='\t')
 
     def to_dataframe(self):
         """Returns the metadata template as a dataframe
@@ -1010,69 +983,64 @@ class MetadataTemplate(QiitaObject):
         pandas DataFrame
             The metadata in the template,indexed on sample id
         """
-        conn_handler = SQLConnectionHandler()
-        cols = sorted(get_table_cols(self._table_name(self._id)))
-        # Get all metadata for the template
-        sql = "SELECT {0} FROM qiita.{1}".format(", ".join(cols),
-                                                 self._table_name(self.id))
-        meta = conn_handler.execute_fetchall(sql, (self._id,))
+        with TRN:
+            cols = sorted(get_table_cols(self._table_name(self._id)))
+            # Get all metadata for the template
+            sql = "SELECT {0} FROM qiita.{1}".format(", ".join(cols),
+                                                     self._table_name(self.id))
+            TRN.add(sql, [self._id])
+            meta = conn_handler.execute_fetchindex()
 
-        # Create the dataframe and clean it up a bit
-        df = pd.DataFrame((list(x) for x in meta), columns=cols)
-        df.set_index('sample_id', inplace=True, drop=True)
+            # Create the dataframe and clean it up a bit
+            df = pd.DataFrame((list(x) for x in meta), columns=cols)
+            df.set_index('sample_id', inplace=True, drop=True)
 
-        return df
+            return df
 
     def add_filepath(self, filepath, fp_id=None):
         r"""Populates the DB tables for storing the filepath and connects the
         `self` objects with this filepath"""
-        # Check that this function has been called from a subclass
-        self._check_subclass()
+        with TRN:
+            fp_id = self._fp_id if fp_id is None else fp_id
 
-        # Check if the connection handler has been provided. Create a new
-        # one if not.
-        conn_handler = SQLConnectionHandler()
-        fp_id = self._fp_id if fp_id is None else fp_id
-
-        try:
-            fpp_id = insert_filepaths([(filepath, fp_id)], None,
-                                      "templates", "filepath",
-                                      move_files=False)[0]
-            values = (self._id, fpp_id)
-            conn_handler.execute(
-                "INSERT INTO qiita.{0} ({1}, filepath_id) "
-                "VALUES (%s, %s)".format(
-                    self._filepath_table, self._id_column), values)
-        except Exception as e:
-            LogEntry.create('Runtime', str(e),
-                            info={self.__class__.__name__: self.id})
-            raise e
+            try:
+                fpp_id = insert_filepaths([(filepath, fp_id)], None,
+                                          "templates", "filepath",
+                                          move_files=False)[0]
+                values = (self._id, fpp_id)
+                sql = """INSERT INTO qiita.{0} ({1}, filepath_id)
+                         VALUES (%s, %s)""".format(self._filepath_table,
+                                                   self._id_column)
+                TRN.add(sql, values)
+                TRN.excecute()
+            except Exception as e:
+                LogEntry.create('Runtime', str(e),
+                                info={self.__class__.__name__: self.id})
+                raise e
 
     def get_filepaths(self):
         r"""Retrieves the list of (filepath_id, filepath)"""
-        # Check that this function has been called from a subclass
-        self._check_subclass()
+        with TRN:
+            try:
+                sql = """SELECT filepath_id, filepath
+                         FROM qiita.filepath
+                         WHERE filepath_id IN (
+                            SELECT filepath_id FROM qiita.{0}
+                            WHERE {1}=%s)
+                         ORDER BY filepath_id DESC""".format(
+                    self._filepath_table, self._id_column)
 
-        # Check if the connection handler has been provided. Create a new
-        # one if not.
-        conn_handler = SQLConnectionHandler()
+                TRN.add(sql, [self.id])
+                filepath_ids = TRN.execute_fetchindex()
+            except Exception as e:
+                LogEntry.create('Runtime', str(e),
+                                info={self.__class__.__name__: self.id})
+                raise e
 
-        try:
-            filepath_ids = conn_handler.execute_fetchall(
-                "SELECT filepath_id, filepath FROM qiita.filepath WHERE "
-                "filepath_id IN (SELECT filepath_id FROM qiita.{0} WHERE "
-                "{1}=%s) ORDER BY filepath_id DESC".format(
-                    self._filepath_table, self._id_column),
-                (self.id, ))
-        except Exception as e:
-            LogEntry.create('Runtime', str(e),
-                            info={self.__class__.__name__: self.id})
-            raise e
+            _, fb = get_mountpoint('templates')[0]
+            base_fp = partial(join, fb)
 
-        _, fb = get_mountpoint('templates')[0]
-        base_fp = partial(join, fb)
-
-        return [(fpid, base_fp(fp)) for fpid, fp in filepath_ids]
+            return [(fpid, base_fp(fp)) for fpid, fp in filepath_ids]
 
     def categories(self):
         """Identifies the metadata columns present in a template
@@ -1103,50 +1071,52 @@ class MetadataTemplate(QiitaObject):
             If md_template and db do not have the same column headers
             If self.can_be_updated is not True
         """
-        conn_handler = SQLConnectionHandler()
+        with TRN:
+            # Clean and validate the metadata template given
+            new_map = self._clean_validate_template(md_template, self.study_id,
+                                                    self.columns_restrictions)
+            # Retrieving current metadata
+            sql = "SELECT * FROM qiita.{0}".format(self._table_name(self.id))
+            TRN.add(sql)
+            current_map = self._transform_to_dict(TRN.execute_fetchindex())
+            current_map = pd.DataFrame.from_dict(current_map, orient='index')
 
-        # Clean and validate the metadata template given
-        new_map = self._clean_validate_template(md_template, self.study_id,
-                                                self.columns_restrictions)
-        # Retrieving current metadata
-        current_map = self._transform_to_dict(conn_handler.execute_fetchall(
-            "SELECT * FROM qiita.{0}".format(self._table_name(self.id))))
-        current_map = pd.DataFrame.from_dict(current_map, orient='index')
+            # simple validations of sample ids and column names
+            samples_diff = set(new_map.index).difference(current_map.index)
+            if samples_diff:
+                raise QiitaDBError(
+                    'The new template differs from what is stored '
+                    'in database by these samples names: %s'
+                    % ', '.join(samples_diff))
+            columns_diff = set(new_map.columns).difference(current_map.columns)
+            if columns_diff:
+                raise QiitaDBError(
+                    'The new template differs from what is stored '
+                    'in database by these columns names: %s'
+                    % ', '.join(columns_diff))
 
-        # simple validations of sample ids and column names
-        samples_diff = set(new_map.index).difference(current_map.index)
-        if samples_diff:
-            raise QiitaDBError('The new template differs from what is stored '
-                               'in database by these samples names: %s'
-                               % ', '.join(samples_diff))
-        columns_diff = set(new_map.columns).difference(current_map.columns)
-        if columns_diff:
-            raise QiitaDBError('The new template differs from what is stored '
-                               'in database by these columns names: %s'
-                               % ', '.join(columns_diff))
+            # here we are comparing two dataframes following:
+            # http://stackoverflow.com/a/17095620/4228285
+            current_map.sort(axis=0, inplace=True)
+            current_map.sort(axis=1, inplace=True)
+            new_map.sort(axis=0, inplace=True)
+            new_map.sort(axis=1, inplace=True)
+            map_diff = (current_map != new_map).stack()
+            map_diff = map_diff[map_diff]
+            map_diff.index.names = ['id', 'column']
+            changed_cols = map_diff.index.get_level_values('column').unique()
 
-        # here we are comparing two dataframes following:
-        # http://stackoverflow.com/a/17095620/4228285
-        current_map.sort(axis=0, inplace=True)
-        current_map.sort(axis=1, inplace=True)
-        new_map.sort(axis=0, inplace=True)
-        new_map.sort(axis=1, inplace=True)
-        map_diff = (current_map != new_map).stack()
-        map_diff = map_diff[map_diff]
-        map_diff.index.names = ['id', 'column']
-        changed_cols = map_diff.index.get_level_values('column').unique()
+            if not self.can_be_updated(columns=set(changed_cols)):
+                raise QiitaDBError(
+                    'The new template is modifying fields that cannot be '
+                    'modified. Try removing the target gene fields or '
+                    'deleting the processed data. You are trying to modify: %s'
+                    % ', '.join(changed_cols))
 
-        if not self.can_be_updated(columns=set(changed_cols)):
-            raise QiitaDBError('The new template is modifying fields that '
-                               'cannot be modified. Try removing the target '
-                               'gene fields or deleting the processed data. '
-                               'You are trying to modify: %s'
-                               % ', '.join(changed_cols))
+            for col in changed_cols:
+                self.update_category(col, new_map[col].to_dict())
 
-        for col in changed_cols:
-            self.update_category(col, new_map[col].to_dict())
-
-        self.generate_files()
+            self.generate_files()
 
     def update_category(self, category, samples_and_values):
         """Update an existing column
@@ -1169,49 +1139,48 @@ class MetadataTemplate(QiitaObject):
             If one of the new values cannot be inserted in the DB due to
             different types
         """
-        if not set(self.keys()).issuperset(samples_and_values):
-            missing = set(self.keys()) - set(samples_and_values)
-            table_name = self._table_name(self._id)
-            raise QiitaDBUnknownIDError(missing, table_name)
+        with TRN:
+            if not set(self.keys()).issuperset(samples_and_values):
+                missing = set(self.keys()) - set(samples_and_values)
+                table_name = self._table_name(self._id)
+                raise QiitaDBUnknownIDError(missing, table_name)
 
-        conn_handler = SQLConnectionHandler()
-        queue_name = "update_category_%s_%s" % (self._id, category)
-        conn_handler.create_queue(queue_name)
+            for k, v in viewitems(samples_and_values):
+                sample = self[k]
+                sample.setitem(category, v)
 
-        for k, v in viewitems(samples_and_values):
-            sample = self[k]
-            sample.add_setitem_queries(category, v, conn_handler, queue_name)
+            try:
+                TRN.execute()
+            except ValueError as e:
+                # catching error so we can check if the error is due to
+                # different column type or something else
 
-        try:
-            conn_handler.execute_queue(queue_name)
-        except ValueError as e:
-            # catching error so we can check if the error is due to different
-            # column type or something else
+                value_types = set(type_lookup(type(value))
+                                  for value in viewvalues(samples_and_values))
 
-            value_types = set(type_lookup(type(value))
-                              for value in viewvalues(samples_and_values))
+                sql = """SELECT udt_name
+                         FROM information_schema.columns
+                         WHERE column_name = %s
+                            AND table_schema = 'qiita'
+                            AND (table_name = %s OR table_name = %s)"""
+                TRN.add(sql,
+                        [category, self._table, self._table_name(self._id)])
+                column_type = TRN.execute_fetchlast()
 
-            sql = """SELECT udt_name
-                     FROM information_schema.columns
-                     WHERE column_name = %s
-                        AND table_schema = 'qiita'
-                        AND (table_name = %s OR table_name = %s)"""
-            column_type = conn_handler.execute_fetchone(
-                sql, (category, self._table, self._table_name(self._id)))
+                if any([column_type != vt for vt in value_types]):
+                    value_str = ', '.join(
+                        [str(value)
+                         for value in viewvalues(samples_and_values)])
+                    value_types_str = ', '.join(value_types)
 
-            if any([column_type != vt for vt in value_types]):
-                value_str = ', '.join(
-                    [str(value) for value in viewvalues(samples_and_values)])
-                value_types_str = ', '.join(value_types)
+                    raise ValueError(
+                        'The new values being added to column: "%s" are "%s" '
+                        '(types: "%s"). However, this column in the DB is of '
+                        'type "%s". Please change the values in your updated '
+                        'template or reprocess your template.'
+                        % (category, value_str, value_types_str, column_type))
 
-                raise ValueError(
-                    'The new values being added to column: "%s" are "%s" '
-                    '(types: "%s"). However, this column in the DB is of '
-                    'type "%s". Please change the values in your updated '
-                    'template or reprocess your template.'
-                    % (category, value_str, value_types_str, column_type))
-
-            raise e
+                raise e
 
     def check_restrictions(self, restrictions):
         """Checks if the template fulfills the restrictions

--- a/qiita_db/metadata_template/prep_template.py
+++ b/qiita_db/metadata_template/prep_template.py
@@ -20,7 +20,7 @@ from qiita_core.exceptions import IncompetentQiitaDeveloperError
 from qiita_db.exceptions import (QiitaDBColumnError, QiitaDBUnknownIDError,
                                  QiitaDBError, QiitaDBExecutionError,
                                  QiitaDBWarning)
-from qiita_db.sql_connection import SQLConnectionHandler
+from qiita_db.sql_connection import TRN
 from qiita_db.ontology import Ontology
 from qiita_db.util import (convert_to_id,
                            convert_from_id, get_mountpoint, infer_status)
@@ -102,77 +102,68 @@ class PrepTemplate(MetadataTemplate):
             If the investigation_type is not valid
             If a required column is missing in md_template
         """
-        # If the investigation_type is supplied, make sure it is one of
-        # the recognized investigation types
-        if investigation_type is not None:
-            cls.validate_investigation_type(investigation_type)
+        with TRN:
+            # If the investigation_type is supplied, make sure it is one of
+            # the recognized investigation types
+            if investigation_type is not None:
+                cls.validate_investigation_type(investigation_type)
 
-        # Get a connection handler
-        conn_handler = SQLConnectionHandler()
-        queue_name = "CREATE_PREP_TEMPLATE_%d_%d" % (study.id, id(md_template))
-        conn_handler.create_queue(queue_name)
+            # Check if the data_type is the id or the string
+            if isinstance(data_type, (int, long)):
+                data_type_id = data_type
+                data_type_str = convert_from_id(data_type, "data_type")
+            else:
+                data_type_id = convert_to_id(data_type, "data_type")
+                data_type_str = data_type
 
-        # Check if the data_type is the id or the string
-        if isinstance(data_type, (int, long)):
-            data_type_id = data_type
-            data_type_str = convert_from_id(data_type, "data_type")
-        else:
-            data_type_id = convert_to_id(data_type, "data_type")
-            data_type_str = data_type
+            pt_cols = PREP_TEMPLATE_COLUMNS
+            if data_type_str in TARGET_GENE_DATA_TYPES:
+                pt_cols = deepcopy(PREP_TEMPLATE_COLUMNS)
+                pt_cols.update(PREP_TEMPLATE_COLUMNS_TARGET_GENE)
 
-        pt_cols = PREP_TEMPLATE_COLUMNS
-        if data_type_str in TARGET_GENE_DATA_TYPES:
-            pt_cols = deepcopy(PREP_TEMPLATE_COLUMNS)
-            pt_cols.update(PREP_TEMPLATE_COLUMNS_TARGET_GENE)
+            md_template = cls._clean_validate_template(md_template, study.id,
+                                                       pt_cols)
 
-        md_template = cls._clean_validate_template(md_template, study.id,
-                                                   pt_cols)
+            # Insert the metadata template
+            sql = """INSERT INTO qiita.prep_template
+                        (data_type_id, investigation_type)
+                     VALUES (%s, %s)
+                     RETURNING prep_template_id"""
+            TRN.add(sql, [data_type_id, investigation_type])
+            prep_id = TRN.execute_fetchlast()
 
-        # Insert the metadata template
-        # We need the prep_id for multiple calls below, which currently is not
-        # supported by the queue system. Thus, executing this outside the queue
-        prep_id = conn_handler.execute_fetchone(
-            "INSERT INTO qiita.prep_template "
-            "(data_type_id, investigation_type) "
-            "VALUES (%s, %s) RETURNING prep_template_id",
-            (data_type_id, investigation_type))[0]
+            try:
+                cls._common_creation_steps(md_template, prep_id)
+            except Exception:
+                # Check if sample IDs present here but not in sample template
+                sql = """SELECT sample_id from qiita.study_sample
+                         WHERE study_id = %s"""
+                # Get list of study sample IDs, prep template study IDs,
+                # and their intersection
+                TRN.add(sql, [study.id])
+                prep_samples = set(md_template.index.values)
+                unknown_samples = prep_samples.difference(
+                    TRN.execute_fetchflatten())
+                if unknown_samples:
+                    raise QiitaDBExecutionError(
+                        'Samples found in prep template but not sample '
+                        'template: %s' % ', '.join(unknown_samples))
 
-        cls._add_common_creation_steps_to_queue(md_template, prep_id,
-                                                conn_handler, queue_name)
+                # some other error we haven't seen before so raise it
+                raise
 
-        # Link the prep template with the study
-        sql = ("INSERT INTO qiita.study_prep_template "
-               "(study_id, prep_template_id) VALUES (%s, %s)")
-        conn_handler.add_to_queue(queue_name, sql, (study.id, prep_id))
+            # Link the prep template with the study
+            sql = """INSERT INTO qiita.study_prep_template
+                        (study_id, prep_template_id)
+                     VALUES (%s, %s)"""
+            TRN.add(sql, [study.id, prep_id])
 
-        try:
-            conn_handler.execute_queue(queue_name)
-        except Exception:
-            # Clean up row from qiita.prep_template
-            conn_handler.execute(
-                "DELETE FROM qiita.prep_template where "
-                "{0} = %s".format(cls._id_column), (prep_id,))
+            TRN.execute()
 
-            # Check if sample IDs present here but not in sample template
-            sql = ("SELECT sample_id from qiita.study_sample WHERE "
-                   "study_id = %s")
-            # Get list of study sample IDs, prep template study IDs,
-            # and their intersection
-            prep_samples = set(md_template.index.values)
-            unknown_samples = prep_samples.difference(
-                s[0] for s in conn_handler.execute_fetchall(sql, [study.id]))
-            if unknown_samples:
-                raise QiitaDBExecutionError(
-                    'Samples found in prep template but not sample template: '
-                    '%s' % ', '.join(unknown_samples))
+            pt = cls(prep_id)
+            pt.generate_files()
 
-            # some other error we haven't seen before so raise it
-            raise
-
-        pt = cls(prep_id)
-        pt.generate_files()
-
-        return pt
+            return pt
 
     @classmethod
     def validate_investigation_type(self, investigation_type):
@@ -188,12 +179,13 @@ class PrepTemplate(MetadataTemplate):
         QiitaDBColumnError
             The investigation type is not in the ENA ontology
         """
-        ontology = Ontology(convert_to_id('ENA', 'ontology'))
-        terms = ontology.terms + ontology.user_defined_terms
-        if investigation_type not in terms:
-            raise QiitaDBColumnError("'%s' is Not a valid investigation_type. "
-                                     "Choose from: %s" % (investigation_type,
-                                                          ', '.join(terms)))
+        with TRN:
+            ontology = Ontology(convert_to_id('ENA', 'ontology'))
+            terms = ontology.terms + ontology.user_defined_terms
+            if investigation_type not in terms:
+                raise QiitaDBColumnError(
+                    "'%s' is Not a valid investigation_type. Choose from: %s"
+                    % (investigation_type, ', '.join(terms)))
 
     @classmethod
     def delete(cls, id_):
@@ -212,62 +204,65 @@ class PrepTemplate(MetadataTemplate):
         QiitaDBUnknownIDError
             If no prep template with id = id_ exists
         """
-        table_name = cls._table_name(id_)
-        conn_handler = SQLConnectionHandler()
+        with TRN:
+            table_name = cls._table_name(id_)
 
-        if not cls.exists(id_):
-            raise QiitaDBUnknownIDError(id_, cls.__name__)
+            if not cls.exists(id_):
+                raise QiitaDBUnknownIDError(id_, cls.__name__)
 
-        preprocessed_data_exists = conn_handler.execute_fetchone(
-            "SELECT EXISTS(SELECT * FROM qiita.prep_template_preprocessed_data"
-            " WHERE prep_template_id=%s)", (id_,))[0]
+            sql = """SELECT EXISTS(
+                        SELECT * FROM qiita.prep_template_preprocessed_data
+                        WHERE prep_template_id=%s)"""
+            args = [id_]
+            TRN.add(sql, args)
+            preprocessed_data_exists = TRN.execute_fetchlast()
 
-        if preprocessed_data_exists:
-            raise QiitaDBExecutionError("Cannot remove prep template %d "
-                                        "because a preprocessed data has been"
-                                        " already generated using it." % id_)
+            if preprocessed_data_exists:
+                raise QiitaDBExecutionError(
+                    "Cannot remove prep template %d because a preprocessed "
+                    "data has been already generated using it." % id_)
 
-        sql = """SELECT (
-                    SELECT raw_data_id
-                    FROM qiita.prep_template
-                    WHERE prep_template_id=%s)
-                IS NOT NULL"""
-        raw_data_attached = conn_handler.execute_fetchone(sql, (id_,))[0]
-        if raw_data_attached:
-            raise QiitaDBExecutionError(
-                "Cannot remove prep template %d because it has raw data "
-                "associated with it" % id_)
+            sql = """SELECT (
+                        SELECT raw_data_id
+                        FROM qiita.prep_template
+                        WHERE prep_template_id=%s)
+                    IS NOT NULL"""
+            TRN.add(sql, args)
+            raw_data_attached = TRN.execute_fetchlast()
+            if raw_data_attached:
+                raise QiitaDBExecutionError(
+                    "Cannot remove prep template %d because it has raw data "
+                    "associated with it" % id_)
 
-        # Delete the prep template filepaths
-        conn_handler.execute(
-            "DELETE FROM qiita.prep_template_filepath WHERE "
-            "prep_template_id = %s", (id_, ))
+            # Delete the prep template filepaths
+            sql = """DELETE FROM qiita.prep_template_filepath
+                     WHERE prep_template_id = %s"""
+            TRN.add(sql, args)
 
-        # Drop the prep_X table
-        conn_handler.execute(
-            "DROP TABLE qiita.{0}".format(table_name))
+            # Drop the prep_X table
+            TRN.add("DROP TABLE qiita.{0}".format(table_name))
 
-        # Remove the rows from prep_template_samples
-        conn_handler.execute(
-            "DELETE FROM qiita.{0} where {1} = %s".format(cls._table,
-                                                          cls._id_column),
-            (id_,))
+            # Remove the rows from prep_template_samples
+            sql = "DELETE FROM qiita.{0} WHERE {1} = %s".format(
+                cls._table, cls._id_column)
+            TRN.add(sql, args)
 
-        # Remove the rows from prep_columns
-        conn_handler.execute(
-            "DELETE FROM qiita.{0} where {1} = %s".format(cls._column_table,
-                                                          cls._id_column),
-            (id_,))
+            # Remove the rows from prep_columns
+            sql = "DELETE FROM qiita.{0} where {1} = %s".format(
+                cls._column_table, cls._id_column)
+            TRN.add(sql, args)
 
-        # Remove the row from study_prep_template
-        conn_handler.execute(
-            "DELETE FROM qiita.study_prep_template "
-            "WHERE {0} = %s".format(cls._id_column), (id_,))
+            # Remove the row from study_prep_template
+            sql = """DELETE FROM qiita.study_prep_template
+                     WHERE {0} = %s""".format(cls._id_column)
+            TRN.add(sql, args)
 
-        # Remove the row from prep_template
-        conn_handler.execute(
-            "DELETE FROM qiita.prep_template where "
-            "{0} = %s".format(cls._id_column), (id_,))
+            # Remove the row from prep_template
+            sql = "DELETE FROM qiita.prep_template WHERE {0} = %s".format(
+                cls._id_column)
+            TRN.add(sql, args)
+
+            TRN.execute()
 
     def data_type(self, ret_id=False):
         """Returns the data_type or the data_type id
@@ -282,12 +277,15 @@ class PrepTemplate(MetadataTemplate):
         str or int
             string value of data_type or data_type_id if ret_id is True
         """
-        ret = "_id" if ret_id else ""
-        conn_handler = SQLConnectionHandler()
-        return conn_handler.execute_fetchone(
-            "SELECT d.data_type{0} FROM qiita.data_type d JOIN "
-            "qiita.prep_template p ON p.data_type_id = d.data_type_id WHERE "
-            "p.prep_template_id=%s".format(ret), (self.id,))[0]
+        with TRN:
+            ret = "_id" if ret_id else ""
+            sql = """SELECT d.data_type{0}
+                     FROM qiita.data_type d
+                        JOIN qiita.prep_template p
+                            ON p.data_type_id = d.data_type_id
+                     WHERE p.prep_template_id=%s""".format(ret)
+            TRN.add(sql, [self.id])
+            return TRN.execute_fetchlast()
 
     @property
     def columns_restrictions(self):
@@ -325,55 +323,61 @@ class PrepTemplate(MetadataTemplate):
         the columns being updated are not part of
         PREP_TEMPLATE_COLUMNS_TARGET_GENE
         """
-        if (not self.preprocessed_data or
-           self.data_type() not in TARGET_GENE_DATA_TYPES):
-            return True
+        with TRN:
+            if (not self.preprocessed_data or
+               self.data_type() not in TARGET_GENE_DATA_TYPES):
+                return True
 
-        tg_columns = set(chain.from_iterable(
-            [v.columns for v in
-             viewvalues(PREP_TEMPLATE_COLUMNS_TARGET_GENE)]))
+            tg_columns = set(chain.from_iterable(
+                [v.columns for v in
+                 viewvalues(PREP_TEMPLATE_COLUMNS_TARGET_GENE)]))
 
-        if not columns & tg_columns:
-            return True
+            if not columns & tg_columns:
+                return True
 
-        return False
+            return False
 
     @property
     def raw_data(self):
-        conn_handler = SQLConnectionHandler()
-        result = conn_handler.execute_fetchone(
-            "SELECT raw_data_id FROM qiita.prep_template "
-            "WHERE prep_template_id=%s", (self.id,))
-        if result:
-            return result[0]
-        return None
+        with TRN:
+            sql = """SELECT raw_data_id FROM qiita.prep_template
+                     WHERE prep_template_id=%s"""
+            TRN.add(sql, [self.id])
+            result = TRN.execute_fetchindex()
+            if result:
+                # If there is any result, it will be in the first row
+                # and in the first element of that row, thus [0][0]
+                return result[0][0]
+            return None
 
     @raw_data.setter
     def raw_data(self, raw_data):
-        conn_handler = SQLConnectionHandler()
-        sql = """SELECT (
-                    SELECT raw_data_id
-                    FROM qiita.prep_template
-                    WHERE prep_template_id=%s)
-                IS NOT NULL"""
-        exists = conn_handler.execute_fetchone(sql, (self.id,))[0]
-        if exists:
-            raise QiitaDBError(
-                "Prep template %d already has a raw data associated"
-                % self.id)
-        sql = """UPDATE qiita.prep_template
-                 SET raw_data_id = %s
-                 WHERE prep_template_id = %s"""
-        conn_handler.execute(sql, (raw_data.id, self.id))
+        with TRN:
+            sql = """SELECT (
+                        SELECT raw_data_id
+                        FROM qiita.prep_template
+                        WHERE prep_template_id=%s)
+                    IS NOT NULL"""
+            TRN.add(sql, [self.id])
+            exists = TRN.execute_fetchlast()
+            if exists:
+                raise QiitaDBError(
+                    "Prep template %d already has a raw data associated"
+                    % self.id)
+            sql = """UPDATE qiita.prep_template
+                     SET raw_data_id = %s
+                     WHERE prep_template_id = %s"""
+            TRN.add(sql, [raw_data.id, self.id])
+            TRN.execute()
 
     @property
     def preprocessed_data(self):
-        conn_handler = SQLConnectionHandler()
-        prep_datas = conn_handler.execute_fetchall(
-            "SELECT preprocessed_data_id FROM "
-            "qiita.prep_template_preprocessed_data WHERE prep_template_id=%s",
-            (self.id,))
-        return [x[0] for x in prep_datas]
+        with TRN:
+            sql = """SELECT preprocessed_data_id
+                     FROM qiita.prep_template_preprocessed_data
+                     WHERE prep_template_id=%s"""
+            TRN.add(sql, [self.id])
+            return TRN.execute_fetchflatten()
 
     @property
     def preprocessing_status(self):
@@ -384,10 +388,11 @@ class PrepTemplate(MetadataTemplate):
         str
             One of {'not_preprocessed', 'preprocessing', 'success', 'failed'}
         """
-        conn_handler = SQLConnectionHandler()
-        return conn_handler.execute_fetchone(
-            "SELECT preprocessing_status FROM qiita.prep_template "
-            "WHERE {0}=%s".format(self._id_column), (self.id,))[0]
+        with TRN:
+            sql = """SELECT preprocessing_status FROM qiita.prep_template
+                     WHERE {0}=%s""".format(self._id_column)
+            TRN.add(sql, [self.id])
+            return TRN.execute_fetchlast()
 
     @preprocessing_status.setter
     def preprocessing_status(self, state):
@@ -406,20 +411,19 @@ class PrepTemplate(MetadataTemplate):
         if (state not in ('not_preprocessed', 'preprocessing', 'success') and
                 not state.startswith('failed:')):
             raise ValueError('Unknown state: %s' % state)
-
-        conn_handler = SQLConnectionHandler()
-
-        conn_handler.execute(
-            "UPDATE qiita.prep_template SET preprocessing_status = %s "
-            "WHERE {0} = %s".format(self._id_column),
-            (state, self.id))
+        with TRN:
+            sql = """UPDATE qiita.prep_template SET preprocessing_status = %s
+                     WHERE {0} = %s""".format(self._id_column)
+            TRN.add(sql, [state, self.id])
+            TRN.execute()
 
     @property
     def investigation_type(self):
-        conn_handler = SQLConnectionHandler()
-        sql = ("SELECT investigation_type FROM qiita.prep_template "
-               "WHERE {0} = %s".format(self._id_column))
-        return conn_handler.execute_fetchone(sql, [self._id])[0]
+        with TRN:
+            sql = """SELECT investigation_type FROM qiita.prep_template
+                     WHERE {0} = %s""".format(self._id_column)
+            TRN.add(sql, [self._id])
+            return TRN.execute_fetchlast()
 
     @investigation_type.setter
     def investigation_type(self, investigation_type):
@@ -435,15 +439,14 @@ class PrepTemplate(MetadataTemplate):
         QiitaDBColumnError
             If the investigation type is not a valid ENA ontology
         """
-        if investigation_type is not None:
-            self.validate_investigation_type(investigation_type)
+        with TRN:
+            if investigation_type is not None:
+                self.validate_investigation_type(investigation_type)
 
-        conn_handler = SQLConnectionHandler()
-
-        conn_handler.execute(
-            "UPDATE qiita.prep_template SET investigation_type = %s "
-            "WHERE {0} = %s".format(self._id_column),
-            (investigation_type, self.id))
+            sql = """UPDATE qiita.prep_template SET investigation_type = %s
+                     WHERE {0} = %s""".format(self._id_column)
+            TRN.add(sql, [investigation_type, self.id])
+            TRN.execute()
 
     @property
     def study_id(self):
@@ -454,31 +457,28 @@ class PrepTemplate(MetadataTemplate):
         int
             The ID of the study with which this prep template is associated
         """
-        conn = SQLConnectionHandler()
-        sql = ("SELECT study_id FROM qiita.study_prep_template "
-               "WHERE prep_template_id=%s")
-        study_id = conn.execute_fetchone(sql, (self.id,))
-        if study_id:
-            return study_id[0]
-        else:
-            raise QiitaDBError("No studies found associated with prep "
-                               "template ID %d" % self._id)
+        with TRN:
+            sql = """SELECT study_id FROM qiita.study_prep_template
+                     WHERE prep_template_id=%s"""
+            TRN.add(sql, [self.id])
+            return TRN.execute_fetchlast()
 
     def generate_files(self):
         r"""Generates all the files that contain data from this template
         """
-        # figuring out the filepath of the prep template
-        _id, fp = get_mountpoint('templates')[0]
-        fp = join(fp, '%d_prep_%d_%s.txt' % (self.study_id, self._id,
-                  strftime("%Y%m%d-%H%M%S")))
-        # storing the template
-        self.to_file(fp)
+        with TRN:
+            # figuring out the filepath of the prep template
+            _id, fp = get_mountpoint('templates')[0]
+            fp = join(fp, '%d_prep_%d_%s.txt' % (self.study_id, self._id,
+                      strftime("%Y%m%d-%H%M%S")))
+            # storing the template
+            self.to_file(fp)
 
-        # adding the fp to the object
-        self.add_filepath(fp)
+            # adding the fp to the object
+            self.add_filepath(fp)
 
-        # creating QIIME mapping file
-        self.create_qiime_mapping_file()
+            # creating QIIME mapping file
+            self.create_qiime_mapping_file()
 
     def create_qiime_mapping_file(self):
         """This creates the QIIME mapping file and links it in the db.
@@ -503,91 +503,93 @@ class PrepTemplate(MetadataTemplate):
         QIIME-required columns, we are going to create them and
         populate them with the value XXQIITAXX.
         """
-        rename_cols = {
-            'barcode': 'BarcodeSequence',
-            'primer': 'LinkerPrimerSequence',
-            'description': 'Description',
-        }
+        with TRN:
+            rename_cols = {
+                'barcode': 'BarcodeSequence',
+                'primer': 'LinkerPrimerSequence',
+                'description': 'Description',
+            }
 
-        if 'reverselinkerprimer' in self.categories():
-            rename_cols['reverselinkerprimer'] = 'ReverseLinkerPrimer'
-            new_cols = ['BarcodeSequence', 'LinkerPrimerSequence',
-                        'ReverseLinkerPrimer']
-        else:
-            new_cols = ['BarcodeSequence', 'LinkerPrimerSequence']
+            if 'reverselinkerprimer' in self.categories():
+                rename_cols['reverselinkerprimer'] = 'ReverseLinkerPrimer'
+                new_cols = ['BarcodeSequence', 'LinkerPrimerSequence',
+                            'ReverseLinkerPrimer']
+            else:
+                new_cols = ['BarcodeSequence', 'LinkerPrimerSequence']
 
-        # getting the latest sample template
-        conn_handler = SQLConnectionHandler()
-        sql = """SELECT filepath_id, filepath
-                 FROM qiita.filepath
-                    JOIN qiita.sample_template_filepath
-                    USING (filepath_id)
-                 WHERE study_id=%s
-                 ORDER BY filepath_id DESC"""
-        sample_template_fname = conn_handler.execute_fetchall(
-            sql, (self.study_id,))[0][1]
-        _, fp = get_mountpoint('templates')[0]
-        sample_template_fp = join(fp, sample_template_fname)
+            # getting the latest sample template
+            sql = """SELECT filepath_id, filepath
+                     FROM qiita.filepath
+                        JOIN qiita.sample_template_filepath
+                        USING (filepath_id)
+                     WHERE study_id=%s
+                     ORDER BY filepath_id DESC"""
+            TRN.add(sql, [self.study_id])
+            # We know that the good filepath is the one in the first row
+            # because we sorted them in the SQL query
+            sample_template_fname = TRN.execute_fetchindex()[0][1]
+            _, fp = get_mountpoint('templates')[0]
+            sample_template_fp = join(fp, sample_template_fname)
 
-        # reading files via pandas
-        st = load_template_to_dataframe(sample_template_fp)
-        pt = self.to_dataframe()
+            # reading files via pandas
+            st = load_template_to_dataframe(sample_template_fp)
+            pt = self.to_dataframe()
 
-        st_sample_names = set(st.index)
-        pt_sample_names = set(pt.index)
+            st_sample_names = set(st.index)
+            pt_sample_names = set(pt.index)
 
-        if not pt_sample_names.issubset(st_sample_names):
-            raise ValueError(
-                "Prep template is not a sub set of the sample template, files"
-                "%s - samples: %s"
-                % (sample_template_fp,
-                   ', '.join(pt_sample_names-st_sample_names)))
+            if not pt_sample_names.issubset(st_sample_names):
+                raise ValueError(
+                    "Prep template is not a sub set of the sample template, "
+                    "file: %s - samples: %s"
+                    % (sample_template_fp,
+                       ', '.join(pt_sample_names-st_sample_names)))
 
-        mapping = pt.join(st, lsuffix="_prep")
-        mapping.rename(columns=rename_cols, inplace=True)
+            mapping = pt.join(st, lsuffix="_prep")
+            mapping.rename(columns=rename_cols, inplace=True)
 
-        # Pre-populate the QIIME-required columns with the value XXQIITAXX
-        index = mapping.index
-        placeholder = ['XXQIITAXX'] * len(index)
-        missing = []
-        for val in viewvalues(rename_cols):
-            if val not in mapping:
-                missing.append(val)
-                mapping[val] = pd.Series(placeholder, index=index)
+            # Pre-populate the QIIME-required columns with the value XXQIITAXX
+            index = mapping.index
+            placeholder = ['XXQIITAXX'] * len(index)
+            missing = []
+            for val in viewvalues(rename_cols):
+                if val not in mapping:
+                    missing.append(val)
+                    mapping[val] = pd.Series(placeholder, index=index)
 
-        if missing:
-            warnings.warn(
-                "Some columns required to generate a QIIME-compliant mapping "
-                "file are not present in the template. A placeholder value "
-                "(XXQIITAXX) has been used to populate these columns. Missing "
-                "columns: %s" % ', '.join(missing),
-                QiitaDBWarning)
+            if missing:
+                warnings.warn(
+                    "Some columns required to generate a QIIME-compliant "
+                    "mapping file are not present in the template. A "
+                    "placeholder value (XXQIITAXX) has been used to populate "
+                    "these columns. Missing columns: %s" % ', '.join(missing),
+                    QiitaDBWarning)
 
-        # Gets the orginal mapping columns and readjust the order to comply
-        # with QIIME requirements
-        cols = mapping.columns.values.tolist()
-        cols.remove('BarcodeSequence')
-        cols.remove('LinkerPrimerSequence')
-        cols.remove('Description')
-        new_cols.extend(cols)
-        new_cols.append('Description')
-        mapping = mapping[new_cols]
+            # Gets the orginal mapping columns and readjust the order to comply
+            # with QIIME requirements
+            cols = mapping.columns.values.tolist()
+            cols.remove('BarcodeSequence')
+            cols.remove('LinkerPrimerSequence')
+            cols.remove('Description')
+            new_cols.extend(cols)
+            new_cols.append('Description')
+            mapping = mapping[new_cols]
 
-        # figuring out the filepath for the QIIME map file
-        _id, fp = get_mountpoint('templates')[0]
-        filepath = join(fp, '%d_prep_%d_qiime_%s.txt' % (self.study_id,
-                        self.id, strftime("%Y%m%d-%H%M%S")))
+            # figuring out the filepath for the QIIME map file
+            _id, fp = get_mountpoint('templates')[0]
+            filepath = join(fp, '%d_prep_%d_qiime_%s.txt' % (self.study_id,
+                            self.id, strftime("%Y%m%d-%H%M%S")))
 
-        # Save the mapping file
-        mapping.to_csv(filepath, index_label='#SampleID', na_rep='',
-                       sep='\t')
+            # Save the mapping file
+            mapping.to_csv(filepath, index_label='#SampleID', na_rep='',
+                           sep='\t', encoding='utf-8')
 
-        # adding the fp to the object
-        self.add_filepath(
-            filepath,
-            fp_id=convert_to_id("qiime_map", "filepath_type"))
+            # adding the fp to the object
+            self.add_filepath(
+                filepath,
+                fp_id=convert_to_id("qiime_map", "filepath_type"))
 
-        return filepath
+            return filepath
 
     @property
     def status(self):
@@ -605,19 +607,19 @@ class PrepTemplate(MetadataTemplate):
         data has been generated with this prep template; then the status
         is 'sandbox'.
         """
-        conn_handler = SQLConnectionHandler()
-        sql = """SELECT processed_data_status
-                FROM qiita.processed_data_status pds
-                  JOIN qiita.processed_data pd
-                    USING (processed_data_status_id)
-                  JOIN qiita.preprocessed_processed_data ppd_pd
-                    USING (processed_data_id)
-                  JOIN qiita.prep_template_preprocessed_data pt_ppd
-                    USING (preprocessed_data_id)
-                WHERE pt_ppd.prep_template_id=%s"""
-        pd_statuses = conn_handler.execute_fetchall(sql, (self._id,))
+        with TRN:
+            sql = """SELECT processed_data_status
+                    FROM qiita.processed_data_status pds
+                      JOIN qiita.processed_data pd
+                        USING (processed_data_status_id)
+                      JOIN qiita.preprocessed_processed_data ppd_pd
+                        USING (processed_data_id)
+                      JOIN qiita.prep_template_preprocessed_data pt_ppd
+                        USING (preprocessed_data_id)
+                    WHERE pt_ppd.prep_template_id=%s"""
+            TRN.add(sql, [self._id])
 
-        return infer_status(pd_statuses)
+            return infer_status(TRN.execute_fetchindex())
 
     @property
     def qiime_map_fp(self):
@@ -628,15 +630,17 @@ class PrepTemplate(MetadataTemplate):
         str
             The filepath of the QIIME mapping file
         """
-        conn_handler = SQLConnectionHandler()
-
-        sql = """SELECT filepath_id, filepath
-                 FROM qiita.filepath
-                    JOIN qiita.{0} USING (filepath_id)
-                    JOIN qiita.filepath_type USING (filepath_type_id)
-                 WHERE {1} = %s AND filepath_type = 'qiime_map'
-                 ORDER BY filepath_id DESC""".format(self._filepath_table,
-                                                     self._id_column)
-        fn = conn_handler.execute_fetchall(sql, (self._id,))[0][1]
-        base_dir = get_mountpoint('templates')[0][1]
-        return join(base_dir, fn)
+        with TRN:
+            sql = """SELECT filepath_id, filepath
+                     FROM qiita.filepath
+                        JOIN qiita.{0} USING (filepath_id)
+                        JOIN qiita.filepath_type USING (filepath_type_id)
+                     WHERE {1} = %s AND filepath_type = 'qiime_map'
+                     ORDER BY filepath_id DESC""".format(self._filepath_table,
+                                                         self._id_column)
+            TRN.add(sql, [self._id])
+            # We know that the good filepath is the one in the first row
+            # because we sorted them in the SQL query
+            fn = TRN.execute_fetchindex()[0][1]
+            base_dir = get_mountpoint('templates')[0][1]
+            return join(base_dir, fn)

--- a/qiita_db/metadata_template/test/test_base_metadata_template.py
+++ b/qiita_db/metadata_template/test/test_base_metadata_template.py
@@ -50,12 +50,11 @@ class TestMetadataTemplateReadOnly(TestCase):
         with self.assertRaises(IncompetentQiitaDeveloperError):
             MetadataTemplate._table_name(self.study)
 
-    def test_add_common_creation_steps_to_queue(self):
-        """_add_common_creation_steps_to_queue raises an error from base class
+    def test_common_creation_steps(self):
+        """common_creation_steps raises an error from base class
         """
         with self.assertRaises(IncompetentQiitaDeveloperError):
-            MetadataTemplate._add_common_creation_steps_to_queue(
-                None, 1, None, "")
+            MetadataTemplate._common_creation_steps(None, 1)
 
     def test_clean_validate_template(self):
         """_clean_validate_template raises an error from base class"""

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -27,7 +27,6 @@ from qiita_db.exceptions import (QiitaDBUnknownIDError,
                                  QiitaDBColumnError,
                                  QiitaDBWarning,
                                  QiitaDBError)
-from qiita_db.sql_connection import SQLConnectionHandler
 from qiita_db.study import Study
 from qiita_db.data import RawData, ProcessedData
 from qiita_db.util import exists_table, get_mountpoint, get_count

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -55,45 +55,6 @@ class BaseTestPrepSample(TestCase):
 
 
 class TestPrepSampleReadOnly(BaseTestPrepSample):
-    def test_add_setitem_queries_error(self):
-        conn_handler = SQLConnectionHandler()
-        queue = "test_queue"
-        conn_handler.create_queue(queue)
-
-        with self.assertRaises(QiitaDBColumnError):
-            self.tester.add_setitem_queries(
-                'COL_DOES_NOT_EXIST', 'Foo', conn_handler, queue)
-
-    def test_add_setitem_queries_required(self):
-        conn_handler = SQLConnectionHandler()
-        queue = "test_queue"
-        conn_handler.create_queue(queue)
-
-        self.tester.add_setitem_queries(
-            'center_name', 'FOO', conn_handler, queue)
-
-        obs = conn_handler.queues[queue]
-        sql = """UPDATE qiita.prep_1
-                 SET center_name=%s
-                 WHERE sample_id=%s"""
-        exp = [(sql, ('FOO', '1.SKB8.640193'))]
-        self.assertEqual(obs, exp)
-
-    def test_add_setitem_queries_dynamic(self):
-        conn_handler = SQLConnectionHandler()
-        queue = "test_queue"
-        conn_handler.create_queue(queue)
-
-        self.tester.add_setitem_queries(
-            'barcode', 'AAAAAAAAAAAA', conn_handler, queue)
-
-        obs = conn_handler.queues[queue]
-        sql = """UPDATE qiita.prep_1
-                 SET barcode=%s
-                 WHERE sample_id=%s"""
-        exp = [(sql, ('AAAAAAAAAAAA', '1.SKB8.640193'))]
-        self.assertEqual(obs, exp)
-
     def test_init_unknown_error(self):
         """Init errors if the PrepSample id is not found in the template"""
         with self.assertRaises(QiitaDBUnknownIDError):
@@ -418,8 +379,7 @@ class TestPrepTemplateReadOnly(BaseTestPrepTemplate):
 
     def test_get_sample_ids(self):
         """get_sample_ids returns the correct set of sample ids"""
-        conn_handler = SQLConnectionHandler()
-        obs = self.tester._get_sample_ids(conn_handler)
+        obs = self.tester._get_sample_ids()
         self.assertEqual(obs, self.exp_sample_ids)
 
     def test_len(self):
@@ -583,99 +543,6 @@ class TestPrepTemplateReadOnly(BaseTestPrepTemplate):
             u'experiment_design_description', u'experiment_title', u'platform',
             u'samp_size', u'sequencing_meth', u'illumina_technology',
             u'sample_center', u'pcr_primers', u'study_center'})
-
-    def test_add_common_creation_steps_to_queue(self):
-        """add_common_creation_steps_to_queue adds the correct sql statements
-        """
-        metadata_dict = {
-            '2.SKB8.640193': {'center_name': 'ANL',
-                              'center_project_name': 'Test Project',
-                              'emp_status': 'EMP',
-                              'str_column': 'Value for sample 1',
-                              'linkerprimersequence': 'GTGCCAGCMGCCGCGGTAA',
-                              'barcodesequence': 'GTCCGCAAGTTA',
-                              'run_prefix': "s_G1_L001_sequences",
-                              'platform': 'ILLUMINA',
-                              'library_construction_protocol': 'AAAA',
-                              'experiment_design_description': 'BBBB'},
-            '2.SKD8.640184': {'center_name': 'ANL',
-                              'center_project_name': 'Test Project',
-                              'emp_status': 'EMP',
-                              'str_column': 'Value for sample 2',
-                              'linkerprimersequence': 'GTGCCAGCMGCCGCGGTAA',
-                              'barcodesequence': 'CGTAGAGCTCTC',
-                              'run_prefix': "s_G1_L001_sequences",
-                              'platform': 'ILLUMINA',
-                              'library_construction_protocol': 'AAAA',
-                              'experiment_design_description': 'BBBB'},
-            }
-        metadata = pd.DataFrame.from_dict(metadata_dict, orient='index')
-
-        conn_handler = SQLConnectionHandler()
-        queue_name = "TEST_QUEUE"
-        conn_handler.create_queue(queue_name)
-        PrepTemplate._add_common_creation_steps_to_queue(
-            metadata, 2, conn_handler, queue_name)
-
-        sql_insert_common = (
-            'INSERT INTO qiita.prep_template_sample '
-            '(prep_template_id, sample_id) VALUES (%s, %s)')
-        sql_insert_common_params_1 = (2, '2.SKB8.640193')
-        sql_insert_common_params_2 = (2, '2.SKD8.640184')
-
-        sql_insert_prep_columns = (
-            'INSERT INTO qiita.prep_columns '
-            '(prep_template_id, column_name, column_type) '
-            'VALUES (%s, %s, %s)')
-
-        sql_create_table = (
-            'CREATE TABLE qiita.prep_2 '
-            '(sample_id varchar NOT NULL, barcodesequence varchar, '
-            'center_name varchar, center_project_name varchar, '
-            'emp_status varchar, experiment_design_description varchar, '
-            'library_construction_protocol varchar, '
-            'linkerprimersequence varchar, platform varchar, '
-            'run_prefix varchar, str_column varchar, '
-            'CONSTRAINT fk_prep_2 FOREIGN KEY (sample_id) REFERENCES '
-            'qiita.study_sample (sample_id) ON UPDATE CASCADE)')
-
-        sql_insert_dynamic = (
-            'INSERT INTO qiita.prep_2 '
-            '(sample_id, barcodesequence, center_name, center_project_name, '
-            'emp_status, experiment_design_description, '
-            'library_construction_protocol, linkerprimersequence, platform, '
-            'run_prefix, str_column) '
-            'VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)')
-
-        sql_insert_dynamic_params_1 = (
-            '2.SKB8.640193', 'GTCCGCAAGTTA', 'ANL', 'Test Project', 'EMP',
-            'BBBB', 'AAAA', 'GTGCCAGCMGCCGCGGTAA', 'ILLUMINA',
-            's_G1_L001_sequences', 'Value for sample 1')
-        sql_insert_dynamic_params_2 = (
-            '2.SKD8.640184', 'CGTAGAGCTCTC', 'ANL', 'Test Project', 'EMP',
-            'BBBB', 'AAAA', 'GTGCCAGCMGCCGCGGTAA', 'ILLUMINA',
-            's_G1_L001_sequences', 'Value for sample 2')
-
-        exp = [
-            (sql_insert_common, sql_insert_common_params_1),
-            (sql_insert_common, sql_insert_common_params_2),
-            (sql_insert_prep_columns, (2, 'barcodesequence', 'varchar')),
-            (sql_insert_prep_columns, (2, 'center_name', 'varchar')),
-            (sql_insert_prep_columns, (2, 'center_project_name', 'varchar')),
-            (sql_insert_prep_columns, (2, 'emp_status', 'varchar')),
-            (sql_insert_prep_columns,
-                (2, 'experiment_design_description', 'varchar')),
-            (sql_insert_prep_columns,
-                (2, 'library_construction_protocol', 'varchar')),
-            (sql_insert_prep_columns, (2, 'linkerprimersequence', 'varchar')),
-            (sql_insert_prep_columns, (2, 'platform', 'varchar')),
-            (sql_insert_prep_columns, (2, 'run_prefix', 'varchar')),
-            (sql_insert_prep_columns, (2, 'str_column', 'varchar')),
-            (sql_create_table, None),
-            (sql_insert_dynamic, sql_insert_dynamic_params_1),
-            (sql_insert_dynamic, sql_insert_dynamic_params_2)]
-
-        self.assertEqual(conn_handler.queues[queue_name], exp)
 
     def test_clean_validate_template_error_bad_chars(self):
         """Raises an error if there are invalid characters in the sample names

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -139,8 +139,7 @@ class TestPrepSampleReadOnly(BaseTestPrepSample):
 
     def test_get_categories(self):
         """Correctly returns the set of category headers"""
-        conn_handler = SQLConnectionHandler()
-        obs = self.tester._get_categories(conn_handler)
+        obs = self.tester._get_categories()
         self.assertEqual(obs, self.exp_categories)
 
     def test_len(self):

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -24,7 +24,6 @@ from qiita_db.exceptions import (QiitaDBDuplicateError, QiitaDBUnknownIDError,
                                  QiitaDBDuplicateHeaderError,
                                  QiitaDBColumnError, QiitaDBError,
                                  QiitaDBWarning)
-from qiita_db.sql_connection import SQLConnectionHandler
 from qiita_db.study import Study, StudyPerson
 from qiita_db.user import User
 from qiita_db.util import exists_table, get_count

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -138,8 +138,7 @@ class TestSampleReadOnly(BaseTestSample):
 
     def test_get_categories(self):
         """Correctly returns the set of category headers"""
-        conn_handler = SQLConnectionHandler()
-        obs = self.tester._get_categories(conn_handler)
+        obs = self.tester._get_categories()
         self.assertEqual(obs, self.exp_categories)
 
     def test_len(self):

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -53,45 +53,6 @@ class BaseTestSample(TestCase):
 
 
 class TestSampleReadOnly(BaseTestSample):
-    def test_add_setitem_queries_error(self):
-        conn_handler = SQLConnectionHandler()
-        queue = "test_queue"
-        conn_handler.create_queue(queue)
-
-        with self.assertRaises(QiitaDBColumnError):
-            self.tester.add_setitem_queries(
-                'COL_DOES_NOT_EXIST', 0.30, conn_handler, queue)
-
-    def test_add_setitem_queries_required(self):
-        conn_handler = SQLConnectionHandler()
-        queue = "test_queue"
-        conn_handler.create_queue(queue)
-
-        self.tester.add_setitem_queries(
-            'physical_specimen_remaining', True, conn_handler, queue)
-
-        obs = conn_handler.queues[queue]
-        sql = """UPDATE qiita.sample_1
-                 SET physical_specimen_remaining=%s
-                 WHERE sample_id=%s"""
-        exp = [(sql, (True, '1.SKB8.640193'))]
-        self.assertEqual(obs, exp)
-
-    def test_add_setitem_queries_dynamic(self):
-        conn_handler = SQLConnectionHandler()
-        queue = "test_queue"
-        conn_handler.create_queue(queue)
-
-        self.tester.add_setitem_queries(
-            'tot_nitro', '1234.5', conn_handler, queue)
-
-        obs = conn_handler.queues[queue]
-        sql = """UPDATE qiita.sample_1
-                 SET tot_nitro=%s
-                 WHERE sample_id=%s"""
-        exp = [(sql, ('1234.5', '1.SKB8.640193'))]
-        self.assertEqual(obs, exp)
-
     def test_init_unknown_error(self):
         """Init raises an error if the sample id is not found in the template
         """
@@ -555,8 +516,7 @@ class TestSampleTemplateReadOnly(BaseTestSampleTemplate):
 
     def test_get_sample_ids(self):
         """get_sample_ids returns the correct set of sample ids"""
-        conn_handler = SQLConnectionHandler()
-        obs = self.tester._get_sample_ids(conn_handler)
+        obs = self.tester._get_sample_ids()
         self.assertEqual(obs, self.exp_sample_ids)
 
     def test_len(self):
@@ -690,118 +650,6 @@ class TestSampleTemplateReadOnly(BaseTestSampleTemplate):
     def test_get_none(self):
         """get returns none if the sample id is not present"""
         self.assertTrue(self.tester.get('Not_a_Sample') is None)
-
-    def test_add_common_creation_steps_to_queue(self):
-        """add_common_creation_steps_to_queue adds the correct sql statements
-        """
-        metadata_dict = {
-            '2.Sample1': {'physical_specimen_location': 'location1',
-                          'physical_specimen_remaining': True,
-                          'dna_extracted': True,
-                          'sample_type': 'type1',
-                          'collection_timestamp':
-                          datetime(2014, 5, 29, 12, 24, 51),
-                          'host_subject_id': 'NotIdentified',
-                          'description': 'Test Sample 1',
-                          'str_column': 'Value for sample 1',
-                          'int_column': 1,
-                          'latitude': 42.42,
-                          'longitude': 41.41},
-            '2.Sample2': {'physical_specimen_location': 'location1',
-                          'physical_specimen_remaining': True,
-                          'dna_extracted': True,
-                          'sample_type': 'type1',
-                          'int_column': 2,
-                          'collection_timestamp':
-                          datetime(2014, 5, 29, 12, 24, 51),
-                          'host_subject_id': 'NotIdentified',
-                          'description': 'Test Sample 2',
-                          'str_column': 'Value for sample 2',
-                          'latitude': 4.2,
-                          'longitude': 1.1},
-            '2.Sample3': {'physical_specimen_location': 'location1',
-                          'physical_specimen_remaining': True,
-                          'dna_extracted': True,
-                          'sample_type': 'type1',
-                          'collection_timestamp':
-                          datetime(2014, 5, 29, 12, 24, 51),
-                          'host_subject_id': 'NotIdentified',
-                          'description': 'Test Sample 3',
-                          'str_column': 'Value for sample 3',
-                          'int_column': 3,
-                          'latitude': 4.8,
-                          'longitude': 4.41},
-            }
-        metadata = pd.DataFrame.from_dict(metadata_dict, orient='index')
-
-        conn_handler = SQLConnectionHandler()
-        queue_name = "TEST_QUEUE"
-        conn_handler.create_queue(queue_name)
-        SampleTemplate._add_common_creation_steps_to_queue(
-            metadata, 2, conn_handler, queue_name)
-
-        sql_insert_required = (
-            'INSERT INTO qiita.study_sample (study_id, sample_id) '
-            'VALUES (%s, %s)')
-
-        sql_insert_sample_cols = (
-            'INSERT INTO qiita.study_sample_columns '
-            '(study_id, column_name, column_type) '
-            'VALUES (%s, %s, %s)')
-
-        sql_crate_table = (
-            'CREATE TABLE qiita.sample_2 (sample_id varchar NOT NULL, '
-            'collection_timestamp timestamp, description varchar, '
-            'dna_extracted bool, host_subject_id varchar, int_column integer, '
-            'latitude float8, longitude float8, '
-            'physical_specimen_location varchar, '
-            'physical_specimen_remaining bool, sample_type varchar, '
-            'str_column varchar, '
-            'CONSTRAINT fk_sample_2 FOREIGN KEY (sample_id) REFERENCES '
-            'qiita.study_sample (sample_id) ON UPDATE CASCADE)')
-
-        sql_insert_dynamic = (
-            'INSERT INTO qiita.sample_2 '
-            '(sample_id, collection_timestamp, description, dna_extracted, '
-            'host_subject_id, int_column, latitude, longitude, '
-            'physical_specimen_location, physical_specimen_remaining, '
-            'sample_type, str_column) '
-            'VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)')
-        sql_insert_dynamic_params_1 = (
-            '2.Sample1', datetime(2014, 5, 29, 12, 24, 51), 'Test Sample 1',
-            True, 'NotIdentified', 1, 42.42, 41.41, 'location1', True, 'type1',
-            'Value for sample 1')
-        sql_insert_dynamic_params_2 = (
-            '2.Sample2', datetime(2014, 5, 29, 12, 24, 51), 'Test Sample 2',
-            True, 'NotIdentified', 2, 4.2, 1.1, 'location1', True, 'type1',
-            'Value for sample 2')
-        sql_insert_dynamic_params_3 = (
-            '2.Sample3', datetime(2014, 5, 29, 12, 24, 51), 'Test Sample 3',
-            True, 'NotIdentified', 3, 4.8, 4.41, 'location1', True, 'type1',
-            'Value for sample 3')
-
-        exp = [
-            (sql_insert_required, (2, '2.Sample1')),
-            (sql_insert_required, (2, '2.Sample2')),
-            (sql_insert_required, (2, '2.Sample3')),
-            (sql_insert_sample_cols, (2, 'collection_timestamp', 'timestamp')),
-            (sql_insert_sample_cols, (2, 'description', 'varchar')),
-            (sql_insert_sample_cols, (2, 'dna_extracted', 'bool')),
-            (sql_insert_sample_cols, (2, 'host_subject_id', 'varchar')),
-            (sql_insert_sample_cols, (2, 'int_column', 'integer')),
-            (sql_insert_sample_cols, (2, 'latitude', 'float8')),
-            (sql_insert_sample_cols, (2, 'longitude', 'float8')),
-            (sql_insert_sample_cols,
-                (2, 'physical_specimen_location', 'varchar')),
-            (sql_insert_sample_cols,
-                (2, 'physical_specimen_remaining', 'bool')),
-            (sql_insert_sample_cols, (2, 'sample_type', 'varchar')),
-            (sql_insert_sample_cols, (2, 'str_column', 'varchar')),
-            (sql_crate_table, None),
-            (sql_insert_dynamic, sql_insert_dynamic_params_1),
-            (sql_insert_dynamic, sql_insert_dynamic_params_2),
-            (sql_insert_dynamic, sql_insert_dynamic_params_3)]
-        self.assertEqual(conn_handler.queues[queue_name], exp)
 
     def test_clean_validate_template_error_bad_chars(self):
         """Raises an error if there are invalid characters in the sample names

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -454,7 +454,7 @@ class TestDelete(TestHandlerBase):
 
         # checking that the action was sent
         self.assertIn("Sample template can not be erased because there are "
-                      "raw datas", response.body)
+                      "prep templates", response.body)
 
     def test_delete_raw_data(self):
         response = self.post('/study/description/1',

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -465,7 +465,7 @@ class TestDelete(TestHandlerBase):
 
         # checking that the action was sent
         self.assertIn("Couldn't remove raw data 1: Raw data (1) can't be "
-                      "remove because it has linked files", response.body)
+                      "removed because it has linked files", response.body)
 
     def test_delete_prep_template(self):
         response = self.post('/study/description/1',


### PR DESCRIPTION
This PR fixes the files under `qiita_db/metadata_template`

Few comments:
 - The functions `to_file` and `create_qiime_mapping_file` were missing the `encoding` parameter for `to_csv`
 - The `SampleTemplate.delete` function was checking for `RawData` to allow deletion of the Sample Template. This is incorrect as it should be checking for `PrepTemplate`.