### PR TITLE
Portals convert to/from id

### DIFF
--- a/qiita_db/exceptions.py
+++ b/qiita_db/exceptions.py
@@ -37,6 +37,11 @@ class QiitaDBColumnError(QiitaDBError):
     pass
 
 
+class QiitaDBLookupError(QiitaDBError, LookupError):
+    """Exception when converting or getting non-existant values in DB"""
+    pass
+
+
 class QiitaDBDuplicateError(QiitaDBError):
     """Exception when duplicating something in the database"""
     def __init__(self, obj_name, attributes):

--- a/qiita_db/portal.py
+++ b/qiita_db/portal.py
@@ -10,8 +10,8 @@ import warnings
 from .sql_connection import SQLConnectionHandler
 from .util import convert_to_id
 from .base import QiitaObject
-from .exceptions import QiitaDBError, QiitaDBDuplicateError, QiitaDBWarning
-from qiita_core.exceptions import IncompetentQiitaDeveloperError
+from .exceptions import (QiitaDBError, QiitaDBDuplicateError, QiitaDBWarning,
+                         QiitaDBLookupError)
 
 
 class Portal(QiitaObject):
@@ -184,7 +184,7 @@ class Portal(QiitaObject):
         """
         try:
             convert_to_id(portal, 'portal_type', 'portal')
-        except IncompetentQiitaDeveloperError:
+        except QiitaDBLookupError:
             return False
         else:
             return True

--- a/qiita_db/test/test_data.py
+++ b/qiita_db/test/test_data.py
@@ -19,7 +19,7 @@ import pandas as pd
 from qiita_core.util import qiita_test_checker
 from qiita_core.exceptions import IncompetentQiitaDeveloperError
 from qiita_db.exceptions import (QiitaDBError, QiitaDBUnknownIDError,
-                                 QiitaDBStatusError)
+                                 QiitaDBStatusError, QiitaDBLookupError)
 from qiita_db.study import Study, StudyPerson
 from qiita_db.user import User
 from qiita_db.util import get_mountpoint, get_count
@@ -527,7 +527,7 @@ class PreprocessedDataTests(TestCase):
                                     data_type="18S")
 
     def test_create_error_data_type(self):
-        with self.assertRaises(IncompetentQiitaDeveloperError):
+        with self.assertRaises(QiitaDBLookupError):
             PreprocessedData.create(self.study,
                                     "preprocessed_sequence_illumina_params",
                                     self.params_id, self.filepaths,
@@ -1036,7 +1036,7 @@ class ProcessedDataTests(TestCase):
 
     def test_status_setter_error_not_existant(self):
         pd = ProcessedData(1)
-        with self.assertRaises(IncompetentQiitaDeveloperError):
+        with self.assertRaises(QiitaDBLookupError):
             pd.status = 'does-not-exist'
 
     def test_get_by_status(self):

--- a/qiita_db/test/test_logger.py
+++ b/qiita_db/test/test_logger.py
@@ -9,7 +9,7 @@
 from unittest import TestCase, main
 
 from qiita_core.util import qiita_test_checker
-from qiita_core.exceptions import IncompetentQiitaDeveloperError
+from qiita_db.exceptions import QiitaDBLookupError
 from qiita_db.logger import LogEntry
 
 
@@ -20,7 +20,7 @@ class LoggerTests(TestCase):
         LogEntry.create('Runtime', 'runtime message')
         LogEntry.create('Fatal', 'fatal message', info={1: 2})
         LogEntry.create('Warning', 'warning message', info={9: 0})
-        with self.assertRaises(IncompetentQiitaDeveloperError):
+        with self.assertRaises(QiitaDBLookupError):
             # This severity level does not exist in the test schema
             LogEntry.create('Chicken', 'warning message',
                             info={9: 0})

--- a/qiita_db/test/test_portal.py
+++ b/qiita_db/test/test_portal.py
@@ -3,13 +3,12 @@ from unittest import TestCase, main
 import numpy.testing as npt
 
 from qiita_core.util import qiita_test_checker
-from qiita_core.exceptions import IncompetentQiitaDeveloperError
 from qiita_db.portal import Portal
 from qiita_db.study import Study, StudyPerson
 from qiita_db.user import User
 from qiita_db.analysis import Analysis
 from qiita_db.exceptions import (QiitaDBError, QiitaDBDuplicateError,
-                                 QiitaDBWarning)
+                                 QiitaDBWarning, QiitaDBLookupError)
 from qiita_core.qiita_settings import qiita_config
 
 
@@ -71,7 +70,7 @@ class TestPortal(TestCase):
                [9, 2], [10, 2]]
         self.assertItemsEqual(obs, exp)
 
-        with self.assertRaises(IncompetentQiitaDeveloperError):
+        with self.assertRaises(QiitaDBLookupError):
             Portal.delete("NOEXISTPORTAL")
         with self.assertRaises(QiitaDBError):
             Portal.delete("QIITA")

--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -15,8 +15,8 @@ from shutil import rmtree
 import pandas as pd
 
 from qiita_core.util import qiita_test_checker
-from qiita_core.exceptions import IncompetentQiitaDeveloperError
-from qiita_db.exceptions import QiitaDBColumnError, QiitaDBError
+from qiita_db.exceptions import (QiitaDBColumnError, QiitaDBError,
+                                 QiitaDBLookupError)
 from qiita_db.data import RawData
 from qiita_db.study import Study
 from qiita_db.reference import Reference
@@ -187,7 +187,7 @@ class DBUtilTests(TestCase):
 
     def test_convert_to_id_bad_value(self):
         """Tests that ids are returned correctly"""
-        with self.assertRaises(IncompetentQiitaDeveloperError):
+        with self.assertRaises(QiitaDBLookupError):
             convert_to_id("FAKE", "filepath_type")
 
     def test_get_filetypes(self):

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -53,7 +53,7 @@ from json import dumps
 from datetime import datetime
 
 from qiita_core.exceptions import IncompetentQiitaDeveloperError
-from .exceptions import QiitaDBColumnError, QiitaDBError
+from .exceptions import QiitaDBColumnError, QiitaDBError, QiitaDBLookupError
 from .sql_connection import SQLConnectionHandler
 
 
@@ -828,7 +828,7 @@ def convert_to_id(value, table, text_col=None):
 
     Raises
     ------
-    IncompetentQiitaDeveloperError
+    QiitaDBLookupError
         The passed string has no associated id
     """
     text_col = table if text_col is None else text_col
@@ -836,8 +836,7 @@ def convert_to_id(value, table, text_col=None):
     sql = "SELECT {0}_id FROM qiita.{0} WHERE {1} = %s".format(table, text_col)
     _id = conn_handler.execute_fetchone(sql, (value, ))
     if _id is None:
-        raise IncompetentQiitaDeveloperError("%s not valid for table %s"
-                                             % (value, table))
+        raise QiitaDBLookupError("%s not valid for table %s" % (value, table))
     return _id[0]
 
 
@@ -858,7 +857,7 @@ def convert_from_id(value, table):
 
     Raises
     ------
-    ValueError
+    QiitaDBLookupError
         The passed id has no associated string
     """
     conn_handler = SQLConnectionHandler()
@@ -866,7 +865,7 @@ def convert_from_id(value, table):
         "SELECT {0} FROM qiita.{0} WHERE {0}_id = %s".format(table),
         (value, ))
     if string is None:
-        raise ValueError("%s not valid for table %s" % (value, table))
+        raise QiitaDBLookupError("%s not valid for table %s" % (value, table))
     return string[0]
 
 

--- a/scripts/qiita-env
+++ b/scripts/qiita-env
@@ -16,12 +16,12 @@ from qiita_db.environment_manager import (
     make_environment, drop_environment, clean_test_environment,
     patch as _patch)
 from qiita_db.portal import Portal
-from qiita_db.exceptions import QiitaDBError, QiitaDBDuplicateError
+from qiita_db.exceptions import (QiitaDBError, QiitaDBDuplicateError,
+                                 QiitaDBLookupError)
 from qiita_core.environment_manager import (
     start_cluster as _start_cluster, stop_cluster as _stop_cluster,
     test as _test, TEST_RUNNERS)
 from qiita_core.configuration_manager import ConfigurationManager
-from qiita_core.exceptions import IncompetentQiitaDeveloperError
 
 _CONFIG = ConfigurationManager()
 
@@ -176,7 +176,7 @@ def rem_portal(portal):
         Portal.delete(portal)
     except QiitaDBError as e:
         raise click.BadParameter(str(e))
-    except IncompetentQiitaDeveloperError:
+    except QiitaDBLookupError:
         raise click.BadParameter("Portal name does not exist!")
 
 if __name__ == '__main__':


### PR DESCRIPTION
Change the behavior of the convert functions. This is needed because they are now being used to see if portals, and possibly other things in the future, actually exist in the table. Since this is no longer an `IncompetentQiitaDeveloperError`, a new `QiitaDBLookupError` was created for this case.