### PR TITLE
Portals add/delete checks

### DIFF
--- a/qiita_db/portal.py
+++ b/qiita_db/portal.py
@@ -265,6 +265,7 @@ class Portal(QiitaObject):
             Trying to delete from QIITA portal
         QiitaDBError
             Some studies given do not exist in the system
+            Some studies are already used in an analysis on the portal
         QiitaDBWarning
             Some studies already do not exist in the given portal
         """
@@ -274,7 +275,7 @@ class Portal(QiitaObject):
 
         conn_handler = SQLConnectionHandler()
         # Make sure study not used in analysis in portal
-        sql = """SELECT DISTINCT study_id from qiita.study_processed_data
+        sql = """SELECT DISTINCT study_id FROM qiita.study_processed_data
                  JOIN qiita.analysis_sample USING (processed_data_id)
                  JOIN qiita.analysis_portal USING (analysis_id)
                  WHERE portal_type_id = %s AND study_id IN %s"""

--- a/qiita_db/portal.py
+++ b/qiita_db/portal.py
@@ -278,12 +278,12 @@ class Portal(QiitaObject):
                  JOIN qiita.analysis_sample USING (processed_data_id)
                  JOIN qiita.analysis_portal USING (analysis_id)
                  WHERE portal_type_id = %s AND study_id IN %s"""
-        analysed = [x[0] for x in conn_handler.execute_fetchall(sql,
-                                                                [self.id])]
+        analysed = [x[0] for x in conn_handler.execute_fetchall(
+            sql, [self.id, tuple(studies)])]
         if analysed:
             raise QiitaDBError("The following studies are used in an analysis "
                                "on portal %s and can't be removed: %s" %
-                               (self.portal, ", ".join(analysed)))
+                               (self.portal, ", ".join(map(str, analysed))))
 
         # Clean list of studies down to ones associated with portal already
         sql = """SELECT study_id from qiita.study_portal
@@ -369,7 +369,8 @@ class Portal(QiitaObject):
         if missing_info:
             raise QiitaDBError("Portal %s is mising studies used in the "
                                "following analyses: %s" %
-                               (self.portal, ", ".join(missing_info)))
+                               (self.portal,
+                                ", ".join(map(str, missing_info))))
 
         # Clean list of analyses to ones not already associated with portal
         sql = """SELECT analysis_id from qiita.analysis_portal

--- a/qiita_db/portal.py
+++ b/qiita_db/portal.py
@@ -357,20 +357,21 @@ class Portal(QiitaObject):
         self._check_analyses(analyses)
 
         conn_handler = SQLConnectionHandler()
-        # Make sure new portal has access to all studies in analysis
-        sql = """SELECT DISTINCT analysis_id from qiita.analysis_sample
-                 JOIN qiita.study_processed_data USING (processed_data_id)
-                 WHERE study_id NOT IN (
-                    SELECT study_id from qiita.study_portal
-                    WHERE portal_type_id = %s)
-                AND analysis_id IN %s ORDER BY analysis_id"""
-        missing_info = [x[0] for x in conn_handler.execute_fetchall(
-                        sql, [self._id, tuple(analyses)])]
-        if missing_info:
-            raise QiitaDBError("Portal %s is mising studies used in the "
-                               "following analyses: %s" %
-                               (self.portal,
-                                ", ".join(map(str, missing_info))))
+        if self.portal != "QIITA":
+            # Make sure new portal has access to all studies in analysis
+            sql = """SELECT DISTINCT analysis_id from qiita.analysis_sample
+                     JOIN qiita.study_processed_data USING (processed_data_id)
+                     WHERE study_id NOT IN (
+                        SELECT study_id from qiita.study_portal
+                        WHERE portal_type_id = %s)
+                    AND analysis_id IN %s ORDER BY analysis_id"""
+            missing_info = [x[0] for x in conn_handler.execute_fetchall(
+                            sql, [self._id, tuple(analyses)])]
+            if missing_info:
+                raise QiitaDBError("Portal %s is mising studies used in the "
+                                   "following analyses: %s" %
+                                   (self.portal,
+                                    ", ".join(map(str, missing_info))))
 
         # Clean list of analyses to ones not already associated with portal
         sql = """SELECT analysis_id from qiita.analysis_portal

--- a/qiita_db/test/test_portal.py
+++ b/qiita_db/test/test_portal.py
@@ -153,6 +153,14 @@ class TestPortal(TestCase):
         self.assertEqual(obs, {1, 2, 3, 4, 5, 6})
 
     def test_add_analysis_portals(self):
+        obs = self.analysis._portals
+        self.assertEqual(obs, ['QIITA'])
+        with self.assertRaises(QiitaDBError):
+            self.emp_portal.add_analyses([self.analysis.id])
+        obs = self.analysis._portals
+        self.assertEqual(obs, ['QIITA'])
+
+        self.emp_portal.add_studies([1])
         self.emp_portal.add_analyses([self.analysis.id])
         obs = self.analysis._portals
         self.assertEqual(obs, ['EMP', 'QIITA'])
@@ -164,7 +172,12 @@ class TestPortal(TestCase):
         with self.assertRaises(ValueError):
             self.qiita_portal.remove_analyses([self.analysis.id])
 
+        # set up the analysis in EMP portal
+        self.emp_portal.add_studies([1])
         self.emp_portal.add_analyses([self.analysis.id])
+        obs = self.analysis._portals
+        self.assertItemsEqual(obs, ['QIITA', 'EMP'])
+        # Test removal
         self.emp_portal.remove_analyses([self.analysis.id])
         obs = self.analysis._portals
         self.assertEqual(obs, ['QIITA'])

--- a/qiita_db/test/test_portal.py
+++ b/qiita_db/test/test_portal.py
@@ -137,7 +137,20 @@ class TestPortal(TestCase):
         with self.assertRaises(ValueError):
             self.qiita_portal.remove_studies([self.study.id])
 
-        self.emp_portal.add_studies([self.study.id])
+        self.emp_portal.add_studies([1])
+        # Set up the analysis in EMP portal
+        self.emp_portal.add_analyses([self.analysis.id])
+        obs = self.analysis._portals
+        self.assertItemsEqual(obs, ['QIITA', 'EMP'])
+
+        # Test study removal failure
+        with self.assertRaises(QiitaDBError):
+            self.emp_portal.remove_studies([self.study.id])
+        obs = self.study._portals
+        self.assertItemsEqual(obs, ['QIITA', 'EMP'])
+
+        # Test study removal
+        self.emp_portal.remove_analyses([self.analysis.id])
         self.emp_portal.remove_studies([self.study.id])
         obs = self.study._portals
         self.assertEqual(obs, ['QIITA'])

--- a/qiita_pet/templates/portals_edit.html
+++ b/qiita_pet/templates/portals_edit.html
@@ -14,7 +14,7 @@
   .alert {
     position: fixed;
     top: 55px;
-    left:40%;
+    left:30%;
     z-index:100;
     white-space: nowrap;
   }
@@ -53,8 +53,13 @@ function check_submit(action) {
     $("#add-button").prop('disabled', false);
     $("#remove-button").prop('disabled', false);
     var echo = "?sEcho=" + Math.floor(Math.random()*1001) + "&view-portal=" + $("#view-portal").val();
-    $('#info-table').DataTable().ajax.url("/admin/portals/studiesAJAX/" + echo).load();
-    bootstrapAlert(data, "success", 1900);
+    if(data.indexOf("ERROR") > -1) {
+      bootstrapAlert(data, "danger", 2200);
+    }
+    else {
+      $('#info-table').DataTable().ajax.url("/admin/portals/studiesAJAX/" + echo).load();
+      bootstrapAlert(data, "success", 2200);
+    }
     $("#portal").val('');
   });
 }


### PR DESCRIPTION
This adds a check to make sure a deleted study is not used in an analysis on the portal, and another to make sure an analysis is not added to a portal without access to all data needed in the analysis.