### PR TITLE
Transactionaize patches and environment mgr

### DIFF
--- a/qiita_db/environment_manager.py
+++ b/qiita_db/environment_manager.py
@@ -386,5 +386,6 @@ def patch(patches_dir=PATCHES_DIR, verbose=False):
 
             if exists(py_patch_fp):
                 if verbose:
-                    print('\t\tApplying python patch %s...' % py_patch_filename)
+                    print('\t\tApplying python patch %s...'
+                          % py_patch_filename)
                 execfile(py_patch_fp)

--- a/qiita_db/support_files/patches/python_patches/14.py
+++ b/qiita_db/support_files/patches/python_patches/14.py
@@ -6,69 +6,57 @@
 
 from os.path import basename
 
-from skbio.util import flatten
-
-from qiita_db.sql_connection import SQLConnectionHandler
+from qiita_db.sql_connection import TRN
 from qiita_db.metadata_template import PrepTemplate
 
-conn_handler = SQLConnectionHandler()
+with TRN:
+    sql = "SELECT prep_template_id FROM qiita.prep_template"
+    TRN.add(sql)
+    all_ids = TRN.execute_fetchflatten()
 
-sql = "SELECT prep_template_id FROM qiita.prep_template"
-all_ids = conn_handler.execute_fetchall(sql)
+    # remove all the bad mapping files
+    for prep_template_id in all_ids:
+        pt = PrepTemplate(prep_template_id)
+        fps = pt.get_filepaths()
 
-q_name = 'unlink-bad-mapping-files'
-conn_handler.create_queue(q_name)
+        # get the QIIME mapping file, note that the way to figure out what is
+        # and what's not a qiime mapping file is to check for the existance of
+        # the word qiime in the basename of the file path, hacky but that's
+        # the way it is being done in qiita_pet/uimodules/raw_data_tab.py
+        mapping_files = [f for f in fps if '_qiime_' in basename(f[1])]
 
-# remove all the bad mapping files
-for prep_template_id in all_ids:
+        table = 'prep_template_filepath'
+        column = 'prep_template_id'
 
-    prep_template_id = prep_template_id[0]
-    pt = PrepTemplate(prep_template_id)
-    fps = pt.get_filepaths()
+        # unlink all the qiime mapping files for this prep template object
+        for mf in mapping_files:
 
-    # get the QIIME mapping file, note that the way to figure out what is and
-    # what's not a qiime mapping file is to check for the existance of the
-    # word qiime in the basename of the file path, hacky but that's the way
-    # it is being done in qiita_pet/uimodules/raw_data_tab.py
-    mapping_files = [f for f in fps if '_qiime_' in basename(f[1])]
+            # (1) get the ids that we are going to delete.
+            # because of the FK restriction, we cannot just delete the ids
+            sql = """SELECT filepath_id
+                     FROM qiita.{0}
+                     WHERE {1}=%s AND filepath_id=%s""".format(table, column)
+            TRN.add(sql, [pt.id, mf[0]])
+            ids = TRN.execute_fetchflatten()
 
-    table = 'prep_template_filepath'
-    column = 'prep_template_id'
+            # (2) delete the entries from the prep_template_filepath table
+            sql = """DELETE FROM qiita.{0}
+                     WHERE {1}=%s and filepath_id=%s""".format(table, column)
+            TRN.add(sql, [pt.id, mf[0]])
 
-    # unlink all the qiime mapping files for this prep template object
-    for mf in mapping_files:
+            # (3) delete the entries from the filepath table
+            sql = "DELETE FROM qiita.filepath WHERE filepath_id IN %s"
+            TRN.add(sql, [tuple(ids)])
 
-        # (1) get the ids that we are going to delete.
-        # because of the FK restriction, we cannot just delete the ids
-        ids = conn_handler.execute_fetchall(
-            'SELECT filepath_id FROM qiita.{0} WHERE '
-            '{1}=%s and filepath_id=%s'.format(table, column), (pt.id, mf[0]))
-        ids = flatten(ids)
+    TRN.execute()
 
-        # (2) delete the entries from the prep_template_filepath table
-        conn_handler.add_to_queue(
-            q_name, "DELETE FROM qiita.{0} "
-            "WHERE {1}=%s and filepath_id=%s;".format(table, column),
-            (pt.id, mf[0]))
+    # create correct versions of the mapping files
+    for prep_template_id in all_ids:
 
-        # (3) delete the entries from the filepath table
-        conn_handler.add_to_queue(
-            q_name,
-            "DELETE FROM qiita.filepath WHERE "
-            "filepath_id IN ({0});".format(', '.join(map(str, ids))))
+        prep_template_id = prep_template_id[0]
+        pt = PrepTemplate(prep_template_id)
 
-try:
-    conn_handler.execute_queue(q_name)
-except Exception as e:
-    raise
-
-# create correct versions of the mapping files
-for prep_template_id in all_ids:
-
-    prep_template_id = prep_template_id[0]
-    pt = PrepTemplate(prep_template_id)
-
-    # we can guarantee that all the filepaths will be prep templates so
-    # we can just generate the qiime mapping files
-    for _, fpt in pt.get_filepaths():
-        pt.create_qiime_mapping_file(fpt)
+        # we can guarantee that all the filepaths will be prep templates so
+        # we can just generate the qiime mapping files
+        for _, fpt in pt.get_filepaths():
+            pt.create_qiime_mapping_file(fpt)

--- a/qiita_db/support_files/patches/python_patches/15.py
+++ b/qiita_db/support_files/patches/python_patches/15.py
@@ -4,23 +4,26 @@
 from os.path import basename, dirname
 
 from qiita_db.util import get_mountpoint
-from qiita_db.sql_connection import SQLConnectionHandler
+from qiita_db.sql_connection import TRN
 
-conn_handler = SQLConnectionHandler()
+with TRN:
+    sql = """SELECT f.*
+             FROM qiita.filepath f
+                JOIN qiita.analysis_filepath afp
+                    ON f.filepath_id = afp.filepath_id"""
+    TRN.add(sql)
+    filepaths = TRN.execute_fetchindex()
 
-filepaths = conn_handler.execute_fetchall(
-    'SELECT f.* from qiita.filepath f JOIN qiita.analysis_filepath afp ON '
-    'f.filepath_id = afp.filepath_id')
+    # retrieve relative filepaths as dictionary for matching
+    mountpoints = {m[1].rstrip('/\\'): m[0] for m in get_mountpoint(
+        'analysis', retrieve_all=True)}
 
-# retrieve relative filepaths as dictionary for matching
-mountpoints = {m[1].rstrip('/\\'): m[0] for m in get_mountpoint(
-    'analysis', retrieve_all=True)}
+    sql = """UPDATE qiita.filepath SET filepath = %s, data_directory_id = %s
+             WHERE filepath_id = %s"""
+    for filepath in filepaths:
+        filename = basename(filepath['filepath'])
+        # find the ID of the analysis filepath used
+        mp_id = mountpoints[dirname(filepath['filepath']).rstrip('/\\')]
+        TRN.add(sql, [filename, mp_id, filepath['filepath_id']])
 
-for filepath in filepaths:
-    filename = basename(filepath['filepath'])
-    # find the ID of the analysis filepath used
-    mp_id = mountpoints[dirname(filepath['filepath']).rstrip('/\\')]
-    conn_handler.execute(
-        'UPDATE qiita.filepath SET filepath = %s, data_directory_id = %s WHERE'
-        ' filepath_id = %s',
-        [filename, mp_id, filepath['filepath_id']])
+    TRN.execute()

--- a/qiita_db/support_files/patches/python_patches/23.py
+++ b/qiita_db/support_files/patches/python_patches/23.py
@@ -1,20 +1,19 @@
 # Mar 27, 2015
 # Need to re-generate the files, given that some headers have changed
 
-from qiita_db.sql_connection import SQLConnectionHandler
+from qiita_db.sql_connection import TRN
 from qiita_db.metadata_template import SampleTemplate, PrepTemplate
 
-conn_handler = SQLConnectionHandler()
+with TRN:
+    # Get all the sample templates
+    TRN.add("SELECT DISTINCT study_id from qiita.study_sample")
+    study_ids = TRN.execute_fetchflatten()
 
-# Get all the sample templates
-sql = """SELECT DISTINCT study_id from qiita.study_sample"""
-study_ids = {s[0] for s in conn_handler.execute_fetchall(sql)}
+    for s_id in study_ids:
+        SampleTemplate(s_id).generate_files()
 
-for s_id in study_ids:
-    SampleTemplate(s_id).generate_files()
-
-# Get all the prep templates
-sql = """SELECT prep_template_id from qiita.prep_template"""
-prep_ids = {p[0] for p in conn_handler.execute_fetchall(sql)}
-for prep_id in prep_ids:
-    PrepTemplate(prep_id).generate_files()
+    # Get all the prep templates
+    TRN.add("SELECT DISTINCT prep_template_id from qiita.prep_template")
+    prep_ids = TRN.execute_fetchflatten()
+    for prep_id in prep_ids:
+        PrepTemplate(prep_id).generate_files()

--- a/qiita_db/support_files/patches/python_patches/25.py
+++ b/qiita_db/support_files/patches/python_patches/25.py
@@ -4,121 +4,101 @@
 # make the RawData to be effectively just a container for the raw files,
 # which is how it was acting previously.
 
-from qiita_db.sql_connection import SQLConnectionHandler
+from qiita_db.sql_connection import TRN
 from qiita_db.data import RawData
 from qiita_db.util import move_filepaths_to_upload_folder
 
-conn_handler = SQLConnectionHandler()
-queue = "PATCH_25"
-conn_handler.create_queue(queue)
+with TRN:
+    # the system may contain raw data with no prep template associated to it.
+    # Retrieve all those raw data ids
+    sql = """SELECT raw_data_id
+             FROM qiita.raw_data
+             WHERE raw_data_id NOT IN (
+                SELECT DISTINCT raw_data_id FROM qiita.prep_template);"""
+    TRN.add(sql)
+    rd_ids = TRN.execute_fetchflatten()
 
-# the system may contain raw data with no prep template associated to it.
-# Retrieve all those raw data ids
-sql = """SELECT raw_data_id
-         FROM qiita.raw_data
-         WHERE raw_data_id NOT IN (
-            SELECT DISTINCT raw_data_id FROM qiita.prep_template);"""
-rd_ids = [x[0] for x in conn_handler.execute_fetchall(sql)]
+    # We will delete those RawData. However, if they have files attached, we
+    # should move them to the uploads folder of the study
+    sql_detach = """DELETE FROM qiita.study_raw_data
+                    WHERE raw_data_id = %s AND study_id = %s"""
+    sql_unlink = "DELETE FROM qiita.raw_filepath WHERE raw_data_id = %s"
+    sql_delete = "DELETE FROM qiita.raw_data WHERE raw_data_id = %s"
+    sql_studies = """SELECT study_id FROM qiita.study_raw_data
+                     WHERE raw_data_id = %s"""
+    move_files = []
+    for rd_id in rd_ids:
+        rd = RawData(rd_id)
+        filepaths = rd.get_filepaths()
+        TRN.add(sql_studies, [rd_id])
+        studies = TRN.execute_fetchflatten()
+        if filepaths:
+            # we need to move the files to a study. We chose the one with lower
+            # study id. Currently there is no case in the live database in
+            # which a RawData with no prep templates is attached to more than
+            # one study, but I think it is better to normalize this just
+            # in case
+            move_filepaths_to_upload_folder(min(studies), filepaths)
 
-# We will delete those RawData. However, if they have files attached, we should
-# move them to the uploads folder of the study
-sql_detach = """DELETE FROM qiita.study_raw_data
-                WHERE raw_data_id = %s AND study_id = %s"""
-sql_unlink = "DELETE FROM qiita.raw_filepath WHERE raw_data_id = %s"
-sql_delete = "DELETE FROM qiita.raw_data WHERE raw_data_id = %s"
-sql_studies = """SELECT study_id FROM qiita.study_raw_data
-                 WHERE raw_data_id = %s"""
-move_files = []
-for rd_id in rd_ids:
-    rd = RawData(rd_id)
-    filepaths = rd.get_filepaths()
-    studies = [s[0] for s in conn_handler.execute_fetchall(sql_studies,
-                                                           (rd_id,))]
-    if filepaths:
-        # we need to move the files to a study. We chose the one with lower
-        # study id. Currently there is no case in the live database in which a
-        # RawData with no prep templates is attached to more than one study,
-        # but I think it is better to normalize this just in case
-        move_files.append((min(studies), filepaths))
+        # To delete the RawData we first need to unlink all the files
+        TRN.add(sql_unlink, [rd_id])
 
-    # To delete the RawData we first need to unlink all the files
-    conn_handler.add_to_queue(queue, sql_unlink, (rd_id,))
+        # Then, remove the raw data from all the studies
+        for st_id in studies:
+            TRN.add(sql_detach, [rd_id, st_id])
 
-    # Then, remove the raw data from all the studies
-    for st_id in studies:
-        conn_handler.add_to_queue(queue, sql_detach, (rd_id, st_id))
+        TRN.add(sql_delete, [rd_id])
 
-    conn_handler.add_to_queue(queue, sql_delete, (rd_id,))
+    # We can now perform all changes in the DB. Although these changes can be
+    # done in an SQL patch, they are done here because we need to execute the
+    # previous clean up in the database before we can actually execute the SQL
+    # patch.
+    sql = """CREATE TABLE qiita.study_prep_template (
+        study_id             bigint  NOT NULL,
+        prep_template_id     bigint  NOT NULL,
+        CONSTRAINT idx_study_prep_template
+            PRIMARY KEY ( study_id, prep_template_id )
+     );
 
-# We can now perform all changes in the DB. Although these changes can be
-# done in an SQL patch, they are done here because we need to execute the
-# previous clean up in the database before we can actually execute the SQL
-# patch.
-sql = """CREATE TABLE qiita.study_prep_template (
-    study_id             bigint  NOT NULL,
-    prep_template_id     bigint  NOT NULL,
-    CONSTRAINT idx_study_prep_template
-        PRIMARY KEY ( study_id, prep_template_id )
- );
+    CREATE INDEX idx_study_prep_template_0
+        ON qiita.study_prep_template ( study_id );
 
-CREATE INDEX idx_study_prep_template_0
-    ON qiita.study_prep_template ( study_id );
+    CREATE INDEX idx_study_prep_template_1
+        ON qiita.study_prep_template ( prep_template_id );
 
-CREATE INDEX idx_study_prep_template_1
-    ON qiita.study_prep_template ( prep_template_id );
+    COMMENT ON TABLE qiita.study_prep_template IS
+        'links study to its prep templates';
 
-COMMENT ON TABLE qiita.study_prep_template IS
-    'links study to its prep templates';
+    ALTER TABLE qiita.study_prep_template
+        ADD CONSTRAINT fk_study_prep_template_study
+        FOREIGN KEY ( study_id ) REFERENCES qiita.study( study_id );
 
-ALTER TABLE qiita.study_prep_template
-    ADD CONSTRAINT fk_study_prep_template_study
-    FOREIGN KEY ( study_id ) REFERENCES qiita.study( study_id );
+    ALTER TABLE qiita.study_prep_template
+        ADD CONSTRAINT fk_study_prep_template_pt
+        FOREIGN KEY ( prep_template_id )
+        REFERENCES qiita.prep_template( prep_template_id );
 
-ALTER TABLE qiita.study_prep_template
-    ADD CONSTRAINT fk_study_prep_template_pt
-    FOREIGN KEY ( prep_template_id )
-    REFERENCES qiita.prep_template( prep_template_id );
+    -- Connect the existing prep templates in the system with their studies
+    DO $do$
+    DECLARE
+        vals RECORD;
+    BEGIN
+    FOR vals IN
+        SELECT prep_template_id, study_id
+        FROM qiita.prep_template
+        JOIN qiita.study_raw_data USING (raw_data_id)
+    LOOP
+        INSERT INTO qiita.study_prep_template (study_id, prep_template_id)
+        VALUES (vals.study_id, vals.prep_template_id);
+    END LOOP;
+    END $do$;
 
--- Connect the existing prep templates in the system with their studies
-DO $do$
-DECLARE
-    vals RECORD;
-BEGIN
-FOR vals IN
-    SELECT prep_template_id, study_id
-    FROM qiita.prep_template
-    JOIN qiita.study_raw_data USING (raw_data_id)
-LOOP
-    INSERT INTO qiita.study_prep_template (study_id, prep_template_id)
-    VALUES (vals.study_id, vals.prep_template_id);
-END LOOP;
-END $do$;
+    --- Drop the study_raw__data table as it's not longer used
+    DROP TABLE qiita.study_raw_data;
 
---- Drop the study_raw__data table as it's not longer used
-DROP TABLE qiita.study_raw_data;
-
--- The raw_data_id column now can be nullable
-ALTER TABLE qiita.prep_template
-    ALTER COLUMN raw_data_id DROP NOT NULL;
-"""
-conn_handler.add_to_queue(queue, sql)
-conn_handler.execute_queue(queue)
-
-# After the changes in the database have been performed, move the files
-# to the uploads folder
-errors = []
-for st_id, fps in move_files:
-    try:
-        move_filepaths_to_upload_folder(st_id, fps)
-    except Exception, e:
-        # An error here is unlikely. However, it's possible and there is no
-        # clean way that we can unroll all the previous changes in the DB.
-        errors.append((st_id, fps, str(e)))
-
-# Show the user any error that could have been generated during the files
-# movement
-if errors:
-    print ("The following errors where generated when trying to move files "
-           "to the upload folder")
-    for st_id, fps, e in errors:
-        print "Study: %d, Filepaths: %s, Error: %s" % (st_id, fps, e)
+    -- The raw_data_id column now can be nullable
+    ALTER TABLE qiita.prep_template
+        ALTER COLUMN raw_data_id DROP NOT NULL;
+    """
+    TRN.add(sql)
+    TRN.execute()

--- a/qiita_db/support_files/patches/python_patches/7.py
+++ b/qiita_db/support_files/patches/python_patches/7.py
@@ -3,18 +3,16 @@
 # prep templates
 
 from qiita_db.util import get_mountpoint
-from qiita_db.sql_connection import SQLConnectionHandler
+from qiita_db.sql_connection import TRN
 from qiita_db.metadata_template import PrepTemplate
 
-conn_handler = SQLConnectionHandler()
+with TRN:
+    _id, fp_base = get_mountpoint('templates')[0]
 
-_id, fp_base = get_mountpoint('templates')[0]
+    TRN.add("SELECT prep_template_id FROM qiita.prep_template")
+    for prep_template_id in TRN.execute_fetchflatten():
+        pt = PrepTemplate(prep_template_id)
+        study_id = pt.study_id
 
-for prep_template_id in conn_handler.execute_fetchall(
-        "SELECT prep_template_id FROM qiita.prep_template"):
-    prep_template_id = prep_template_id[0]
-    pt = PrepTemplate(prep_template_id)
-    study_id = pt.study_id
-
-    for _, fpt in pt.get_filepaths():
-        pt.create_qiime_mapping_file(fpt)
+        for _, fpt in pt.get_filepaths():
+            pt.create_qiime_mapping_file(fpt)

--- a/qiita_db/test/test_commands.py
+++ b/qiita_db/test/test_commands.py
@@ -740,11 +740,13 @@ PREP_TEMPLATE = (
 
 PY_PATCH = """
 from qiita_db.study import Study
+from qiita_db.sql_connection import TRN
 study = Study(1)
-conn = SQLConnectionHandler()
-conn.executemany(
-    "INSERT INTO qiita.patchtest10 (testing) VALUES (%s)",
-    [[study.id], [study.id*100]])
+
+with TRN:
+    sql = "INSERT INTO qiita.patchtest10 (testing) VALUES (%s)"
+    TRN.add(sql, [[study.id], [study.id*100]], many=True)
+    TRN.execute()
 """
 
 PARAMETERS = """max_bad_run_length\t3

--- a/qiita_pet/test/tornado_test_base.py
+++ b/qiita_pet/test/tornado_test_base.py
@@ -5,7 +5,6 @@ except ImportError:  # py3
     from urllib.parse import urlencode
 
 from tornado.testing import AsyncHTTPTestCase
-from qiita_core.qiita_settings import qiita_config
 from qiita_pet.webserver import Application
 from qiita_pet.handlers.base_handlers import BaseHandler
 from qiita_db.environment_manager import clean_test_environment

--- a/qiita_pet/test/tornado_test_base.py
+++ b/qiita_pet/test/tornado_test_base.py
@@ -8,14 +8,12 @@ from tornado.testing import AsyncHTTPTestCase
 from qiita_core.qiita_settings import qiita_config
 from qiita_pet.webserver import Application
 from qiita_pet.handlers.base_handlers import BaseHandler
-from qiita_db.sql_connection import SQLConnectionHandler
-from qiita_db.environment_manager import drop_and_rebuild_tst_database
+from qiita_db.environment_manager import clean_test_environment
 from qiita_db.user import User
 
 
 class TestHandlerBase(AsyncHTTPTestCase):
     database = False
-    conn_handler = SQLConnectionHandler()
     app = Application()
 
     def get_app(self):
@@ -25,18 +23,7 @@ class TestHandlerBase(AsyncHTTPTestCase):
 
     def setUp(self):
         if self.database:
-            # First, we check that we are not in a production environment
-            # It is possible that we are connecting to a production database
-            test_db = self.conn_handler.execute_fetchone(
-                "SELECT test FROM settings")[0]
-            # Or the loaded config file belongs to a production environment
-            if not qiita_config.test_environment or not test_db:
-                raise RuntimeError("Working in a production environment. Not "
-                                   "executing the tests to keep the production"
-                                   " database safe.")
-
-            # Drop the schema and rebuild the test database
-            drop_and_rebuild_tst_database(self.conn_handler)
+            clean_test_environment()
 
         super(TestHandlerBase, self).setUp()
 


### PR DESCRIPTION
Modifies the patches and the environment manager to use transactions.

Few notes:
 - the environment manager is tricky. There are a couple of places in which the SQLConnectionHandler should still be used because it is connecting to the DB with admin privileges, and is changing the connection type to set autocommit = True. Since autocommit is true, there is no point of having the transaction so using the old conn handler there. Also the Transaction does not support admin access.
 - in qiita_pet/test/tornado_test_base.py there was a bit of code duplication. I removed that code and used the function from qiita_db.