### PR TITLE
New user default analysis bug

### DIFF
--- a/qiita_db/support_files/patches/28.sql
+++ b/qiita_db/support_files/patches/28.sql
@@ -2,13 +2,6 @@
 -- Adds the connections between the default analysis from new user and
 -- the portals.
 
-CREATE FUNCTION fetch_analysis (p_id bigint) RETURNS integer AS $$
-    BEGIN
-        
-    END;
-$$ LANGUAGE plpgsql;
-
-
 DO $do$
 DECLARE
     aid bigint;
@@ -25,7 +18,7 @@ LOOP
         WHERE dflt = TRUE
             AND name LIKE CONCAT('%-dflt-', portal)
             AND analysis_id NOT IN (
-                SELECT analysis_id FROM qiita.analysis_portal);
+                SELECT analysis_id FROM qiita.analysis_portal)
     LOOP
         INSERT INTO qiita.analysis_portal (analysis_id, portal_type_id)
         VALUES (aid, portal);

--- a/qiita_db/support_files/patches/28.sql
+++ b/qiita_db/support_files/patches/28.sql
@@ -1,0 +1,34 @@
+-- July 10, 2015
+-- Adds the connections between the default analysis from new user and
+-- the portals.
+
+CREATE FUNCTION fetch_analysis (p_id bigint) RETURNS integer AS $$
+    BEGIN
+        
+    END;
+$$ LANGUAGE plpgsql;
+
+
+DO $do$
+DECLARE
+    aid bigint;
+    portal bigint;
+    rec RECORD;
+BEGIN
+
+FOR portal IN
+    SELECT portal_type_id FROM qiita.portal_type
+LOOP
+    FOR aid IN
+        SELECT analysis_id
+        FROM qiita.analysis
+        WHERE dflt = TRUE
+            AND name LIKE CONCAT('%-dflt-', portal)
+            AND analysis_id NOT IN (
+                SELECT analysis_id FROM qiita.analysis_portal);
+    LOOP
+        INSERT INTO qiita.analysis_portal (analysis_id, portal_type_id)
+        VALUES (aid, portal);
+    END LOOP;
+END LOOP;
+END $do$;

--- a/qiita_db/test/test_user.py
+++ b/qiita_db/test/test_user.py
@@ -294,6 +294,14 @@ class UserTest(TestCase):
                ['new@test.bar', 'new@test.bar-dflt-1', 'dflt', True]]
         self.assertEqual(obs, exp)
 
+        # Make sure default analyses are linked with the portal
+        sql = """SELECT COUNT(1)
+                 FROM qiita.analysis
+                    JOIN qiita.analysis_portal USING (analysis_id)
+                    JOIN qiita.portal_type USING (portal_type_id)
+                 WHERE email = 'new@test.bar' AND dflt = true"""
+        self.assertEqual(self.conn_handler.execute_fetchone(sql)[0], 2)
+
     def _check_pass(self, passwd):
         obspass = self.conn_handler.execute_fetchone(
             "SELECT password FROM qiita.qiita_user WHERE email = %s",


### PR DESCRIPTION
This morning @rob-knight found an issue in which a new created user that goes to the create analysis from selected samples part receives an error and anything else in the system related with analysis works.

The issue is that the default analysis was not linked with the portals.

I've fixed the user creation, added a specific test and added a patch to update any existing case of this in the database.

This is priority super high, I've scheduled a system update for tonight, and I already posted the announcement in the live system.