### PR TITLE
Improve names in the interface for bdiv results

### DIFF
--- a/qiita_pet/handlers/analysis_handlers.py
+++ b/qiita_pet/handlers/analysis_handlers.py
@@ -12,7 +12,7 @@ Qitta analysis handlers for the Tornado webserver.
 from __future__ import division
 from future.utils import viewitems
 from collections import defaultdict
-from os.path import join, sep, commonprefix
+from os.path import join, sep, commonprefix, basename, dirname
 from json import dumps
 
 from tornado.web import authenticated, HTTPError, StaticFileHandler
@@ -147,8 +147,14 @@ class AnalysisResultsHandler(BaseHandler):
         jobres = defaultdict(list)
         for job in analysis.jobs:
             jobject = Job(job)
+            results = []
+            for res in jobject.results:
+                name = basename(res)
+                if name.startswith('index'):
+                    name = basename(dirname(res)).replace('_', ' ')
+                results.append((res, name))
             jobres[jobject.datatype].append((jobject.command[0],
-                                             jobject.results))
+                                             results))
 
         dropped_samples = analysis.dropped_samples
         dropped = defaultdict(list)

--- a/qiita_pet/templates/analysis_results.html
+++ b/qiita_pet/templates/analysis_results.html
@@ -6,7 +6,6 @@
 {%end%}
 
 {%block content%}
-{% from os.path import basename %}
 {% from future.utils import viewitems %}
 
 
@@ -69,8 +68,8 @@
                 {% if len(results) == 0 %}
                   <h3 style="color:red">ERROR</h3>
                 {% end %}
-                {%for result in results%}
-                  <a href='{{"/results/%s" % result}}' target="resframe">{{basename(result)}}</a><br />
+                {%for result, result_name in results%}
+                  <a href='{{"/results/%s" % result}}' target="resframe">{{result_name}}</a><br />
                 {% end %}
               </div>
             {% end %}


### PR DESCRIPTION
Fixes https://github.com/biocore/qiita/issues/1369

I agree that this is not the best solution, but we need to refactor the analysis pipeline to improve a lot of different points, so I don't think it is worth to spend more time on the current code.

This modifies the name on the result page, so instead of showing index.html for both un/weighted unifrac, it shows the folder name:

<img width="348" alt="screen shot 2015-07-10 at 6 48 24 pm" src="https://cloud.githubusercontent.com/assets/2501478/8631767/cf69a868-2734-11e5-9556-e550a8691824.png">

The testres.htm and subres.html are test files to check that it actually works as expected, the interesting part is that it does not show index.html but it shows which method was applied.