### PR TITLE
Showing a better message when there are no samples available

### DIFF
--- a/qiita_pet/templates/show_analyses.html
+++ b/qiita_pet/templates/show_analyses.html
@@ -1,47 +1,66 @@
 {% extends sitebase.html %}
-{%block content %}
-<table class="table">
-  <tr>
-    <th>Analysis Name</th>
-    <th>Analysis Description</th>
-    <th>Status</th>
-    <th>Timestamp</th>
-  </tr>
-  {% for analysis in analyses %}
-    {% set status = analysis.status %}
-    {% if status == "in_construction"%}
-      <tr>
-        <td>
-          <a href="/analysis/{{analysis.step}}?aid={{analysis.id}}">{{analysis.name}}</a>
-    {% elif status == "running" %}
-      <tr class="active">
-        <td>
-          <a href="/analysis/wait/{{analysis.id}}">{{analysis.name}}</a>
-    {% elif status == "completed" %}
-      <tr class="success">
-        <td>
-          <a href="/analysis/results/{{analysis.id}}">{{analysis.name}}</a>
-    {% elif status == "error" %}
-      <tr class="danger">
-        <td>
-          <a href="/analysis/results/{{analysis.id}}">{{analysis.name}}</a>
-    {% else %}
-      <tr class="active">
-        <td>
-          {{analysis.name}}
+
+{% block head %}
+<script type="text/javascript">
+  $(document).ready(function(){
+    {% if analyses %}
+      $('#no-analyses').hide()
     {% end %}
-      </td>
-      <td>
-       {{analysis.description}}
-     </td>
-      <td>
-       {{status}}
-     </td>
-      <td>
-       {{ analysis.timestamp.strftime("%m/%d/%y %H:%M:%S")}}
-      </td>
+  });
+</script>
+{% end %}
+
+{%block content %}
+
+<div id='no-analyses' class='jumbotron'>
+  <h1>No Analyses available</h1>
+  <h3><a href="/study/list/">Create an analysis</a></h3>
+</div>
+
+{% if analyses %}
+  <table class="table">
+    <tr>
+      <th>Analysis Name</th>
+      <th>Analysis Description</th>
+      <th>Status</th>
+      <th>Timestamp</th>
     </tr>
-  {% end %}
-</table>
+    {% for analysis in analyses %}
+      {% set status = analysis.status %}
+      {% if status == "in_construction"%}
+        <tr>
+          <td>
+            <a href="/analysis/{{analysis.step}}?aid={{analysis.id}}">{{analysis.name}}</a>
+      {% elif status == "running" %}
+        <tr class="active">
+          <td>
+            <a href="/analysis/wait/{{analysis.id}}">{{analysis.name}}</a>
+      {% elif status == "completed" %}
+        <tr class="success">
+          <td>
+            <a href="/analysis/results/{{analysis.id}}">{{analysis.name}}</a>
+      {% elif status == "error" %}
+        <tr class="danger">
+          <td>
+            <a href="/analysis/results/{{analysis.id}}">{{analysis.name}}</a>
+      {% else %}
+        <tr class="active">
+          <td>
+            {{analysis.name}}
+      {% end %}
+        </td>
+        <td>
+         {{analysis.description}}
+       </td>
+        <td>
+         {{status}}
+       </td>
+        <td>
+         {{ analysis.timestamp.strftime("%m/%d/%y %H:%M:%S")}}
+        </td>
+      </tr>
+    {% end %}
+  </table>
+{% end %}
 
 {% end %}


### PR DESCRIPTION
When there are no analyses available it shows a message rather than empty table:

<img width="1653" alt="screen shot 2015-07-10 at 7 15 59 pm" src="https://cloud.githubusercontent.com/assets/2501478/8631871/44cc1188-2738-11e5-91d2-76f21a725596.png">

The link "create analysis" goes to the study listing page.

Fixes https://github.com/biocore/qiita/issues/1368