### PR TITLE
ENH: Add configuration file argument to qiita CLI

### DIFF
--- a/scripts/qiita
+++ b/scripts/qiita
@@ -18,6 +18,8 @@ import tornado.ioloop
 from psycopg2 import OperationalError
 from future.utils import viewitems
 from os.path import join, abspath, dirname
+from os import environ
+from imp import reload
 
 from qiita_db.util import (get_filepath_types, get_filetypes,
                            get_data_types,
@@ -39,6 +41,7 @@ from qiita_core.configuration_manager import ConfigurationManager
 from qiita_ware.commands import ebi_actions, submit_EBI as _submit_EBI
 from qiita_ware.processing_pipeline import generate_demux_file
 from qiita_ware.context import system_call, ComputeError
+from qiita_core import qiita_settings
 from moi import r_client
 
 
@@ -54,8 +57,18 @@ else:
 
 
 @click.group()
-def qiita():
-    pass
+@click.option('--config-fp', default=ConfigurationManager().conf_fp,
+              show_default=True,
+              type=click.Path(exists=True, dir_okay=False, readable=True,
+                              resolve_path=True),
+              help="Qiita configuration file to use globally.")
+def qiita(config_fp):
+    """Command line utility to interact with Qiita and its main components"""
+
+    # with the updated envrionment variable, reload the config files
+    if config_fp != ConfigurationManager().conf_fp:
+        environ['QIITA_CONFIG_FP'] = config_fp
+        reload(qiita_settings)
 
 
 @qiita.group()


### PR DESCRIPTION
With the portals merged in master, changing the desired configuration file for
the webserver is a bit cumbersome, with this proposed change we should be able
to just pass the configuration file as part of the command call, for example:

```bash
qiita --config-fp=portal_A.cfg pet webserver start

qiita --config-fp=portal_B.cfg pet webserver start
```

I believe this is somewhat common in other command line interfaces and it feels
more natural than having to change an environment variable before calling a
command. However I'm unsure about the unintended sideffects that reloading a
module might cause.