### PR TITLE
Log file creation

### DIFF
--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -150,7 +150,7 @@ class ConfigurationManager(object):
         self.base_data_dir = config.get('main', 'BASE_DATA_DIR') or \
             default_base_data_dir
 
-        self.base_url = config.get('main', 'LOG_PATH')
+        self.log_path = config.get('main', 'LOG_PATH')
         self.base_url = config.get('main', 'BASE_URL')
 
         if not isdir(self.base_data_dir):

--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -150,6 +150,7 @@ class ConfigurationManager(object):
         self.base_data_dir = config.get('main', 'BASE_DATA_DIR') or \
             default_base_data_dir
 
+        self.base_url = config.get('main', 'LOG_PATH')
         self.base_url = config.get('main', 'BASE_URL')
 
         if not isdir(self.base_data_dir):

--- a/qiita_core/support_files/config_test.cfg
+++ b/qiita_core/support_files/config_test.cfg
@@ -15,6 +15,9 @@
 # Change to FALSE in a production system
 TEST_ENVIRONMENT = TRUE
 
+# Absolute path to write log file to. If not given, no log file will be created
+LOG_PATH =
+
 # Whether studies require admin approval to be made available
 REQUIRE_APPROVAL = True
 

--- a/qiita_pet/handlers/base_handlers.py
+++ b/qiita_pet/handlers/base_handlers.py
@@ -22,7 +22,7 @@ class BaseHandler(RequestHandler):
             self.render("404.html")
             return
 
-        if status_code == 403:
+        if status_code in {403, 405}:
             # We don't need to log this failues in the logging table
             return
 

--- a/scripts/qiita
+++ b/scripts/qiita
@@ -454,8 +454,8 @@ def start(port):
     from qiita_pet.webserver import Application
     from tornado.options import options, parse_command_line
 
-    if _CONFIG.write_log_file:
-        options.log_file_prefix = _CONFIG.log_file
+    if _CONFIG.log_path:
+        options.log_file_prefix = _CONFIG.log_path
         options.logging = 'warning'
         parse_command_line()
     http_server = tornado.httpserver.HTTPServer(Application())

--- a/scripts/qiita
+++ b/scripts/qiita
@@ -35,14 +35,12 @@ from qiita_db.sql_connection import SQLConnectionHandler
 from qiita_db.exceptions import QiitaDBConnectionError, QiitaDBError
 from qiita_db.reference import Reference
 from qiita_db.logger import LogEntry
-from qiita_core.configuration_manager import ConfigurationManager
+from qiita_core.settings import qiita_config
 from qiita_ware.commands import ebi_actions, submit_EBI as _submit_EBI
 from qiita_ware.processing_pipeline import generate_demux_file
 from qiita_ware.context import system_call, ComputeError
 from moi import r_client
 
-
-_CONFIG = ConfigurationManager()
 
 try:
     conn = SQLConnectionHandler()
@@ -454,8 +452,8 @@ def start(port):
     from qiita_pet.webserver import Application
     from tornado.options import options, parse_command_line
 
-    if _CONFIG.log_path:
-        options.log_file_prefix = _CONFIG.log_path
+    if qiita_config.log_path:
+        options.log_file_prefix = qiita_config.log_path
         options.logging = 'warning'
         parse_command_line()
     http_server = tornado.httpserver.HTTPServer(Application())

--- a/scripts/qiita
+++ b/scripts/qiita
@@ -35,7 +35,7 @@ from qiita_db.sql_connection import SQLConnectionHandler
 from qiita_db.exceptions import QiitaDBConnectionError, QiitaDBError
 from qiita_db.reference import Reference
 from qiita_db.logger import LogEntry
-from qiita_core.settings import qiita_config
+from qiita_core.qiita_settings import qiita_config
 from qiita_ware.commands import ebi_actions, submit_EBI as _submit_EBI
 from qiita_ware.processing_pipeline import generate_demux_file
 from qiita_ware.context import system_call, ComputeError

--- a/scripts/qiita
+++ b/scripts/qiita
@@ -452,7 +452,12 @@ def start(port):
     # having to do that. The solution will (perhaps) be to move this subcommand
     # into an entirely different script.
     from qiita_pet.webserver import Application
+    from tornado.options import options, parse_command_line
 
+    if _CONFIG.write_log_file:
+        options.log_file_prefix = _CONFIG.log_file
+        options.logging = 'warning'
+        parse_command_line()
     http_server = tornado.httpserver.HTTPServer(Application())
 
     try:


### PR DESCRIPTION
Fixes #1380

Creates a log file if a log file path is given, using the tornado standard logging at `warning` settings.