### PR TITLE
Issue 1343 - reformat large UTF-8 error

### DIFF
--- a/qiita_db/metadata_template/util.py
+++ b/qiita_db/metadata_template/util.py
@@ -273,7 +273,7 @@ def load_template_to_dataframe(fn, strip_whitespace=True, index='sample_name'):
                     cell.encode('utf-8')
                 except UnicodeError:
                     errors[headers[col]].append(row)
-        lines = ['%s: row(s) %s' % (header, ', '.join(rows))
+        lines = ['%s: row(s) %s' % (header, ', '.join(map(str, rows)))
                  for header, rows in viewitems(errors)]
         raise QiitaDBError('Non UTF-8 characters found:\n' +
                            '\n'.join(lines))

--- a/qiita_db/metadata_template/util.py
+++ b/qiita_db/metadata_template/util.py
@@ -7,7 +7,8 @@
 # -----------------------------------------------------------------------------
 
 from __future__ import division
-from future.utils import PY3
+from collections import defaultdict
+from future.utils import PY3, viewitems
 from future.utils.six import StringIO
 
 import pandas as pd
@@ -265,15 +266,18 @@ def load_template_to_dataframe(fn, strip_whitespace=True, index='sample_name'):
     except UnicodeDecodeError:
         # Find row number and col number for utf-8 encoding errors
         headers = holdfile[0].strip().split('\t')
-        errors = []
+        errors = defaultdict(list)
         for row, line in enumerate(holdfile, 1):
             for col, cell in enumerate(line.split('\t')):
                 try:
                     cell.encode('utf-8')
                 except UnicodeError:
+                    errors[headers[col]].append(row)
                     errors.append('row %d, header %s' % (row, headers[col]))
-        raise QiitaDBError('Non UTF-8 characters found at ' +
-                           '; '.join(errors))
+        lines = ['%s: %s' % (header, ', '.join(rows))
+                 for header, rows in viewitems(errors)]
+        raise QiitaDBError('Non UTF-8 characters found:<br/>' +
+                           '<br/>'.join(lines))
 
     # let pandas infer the dtypes of these columns, if the inference is
     # not correct, then we have to raise an error

--- a/qiita_db/metadata_template/util.py
+++ b/qiita_db/metadata_template/util.py
@@ -275,7 +275,7 @@ def load_template_to_dataframe(fn, strip_whitespace=True, index='sample_name'):
                     errors[headers[col]].append(row)
         lines = ['%s: row(s) %s' % (header, ', '.join(map(str, rows)))
                  for header, rows in viewitems(errors)]
-        raise QiitaDBError('Non UTF-8 characters found:\n' +
+        raise QiitaDBError('Non UTF-8 characters found in columns:\n' +
                            '\n'.join(lines))
 
     # let pandas infer the dtypes of these columns, if the inference is

--- a/qiita_db/metadata_template/util.py
+++ b/qiita_db/metadata_template/util.py
@@ -273,11 +273,10 @@ def load_template_to_dataframe(fn, strip_whitespace=True, index='sample_name'):
                     cell.encode('utf-8')
                 except UnicodeError:
                     errors[headers[col]].append(row)
-                    errors.append('row %d, header %s' % (row, headers[col]))
-        lines = ['%s: %s' % (header, ', '.join(rows))
+        lines = ['%s: row(s) %s' % (header, ', '.join(rows))
                  for header, rows in viewitems(errors)]
-        raise QiitaDBError('Non UTF-8 characters found:<br/>' +
-                           '<br/>'.join(lines))
+        raise QiitaDBError('Non UTF-8 characters found:\n' +
+                           '\n'.join(lines))
 
     # let pandas infer the dtypes of these columns, if the inference is
     # not correct, then we have to raise an error


### PR DESCRIPTION
This breaks it down into each column and the rows that are an issue:

<img width="947" alt="screen shot 2015-08-06 at 1 33 09 pm" src="https://cloud.githubusercontent.com/assets/3079066/9122780/0c45b86a-3c40-11e5-967e-0d7eca5edab3.png">
