### PR TITLE
Better error message on duplicated samples in the templates

### DIFF
--- a/qiita_db/exceptions.py
+++ b/qiita_db/exceptions.py
@@ -72,6 +72,14 @@ class QiitaDBDuplicateHeaderError(QiitaDBError):
                      "header(s): %s." % ', '.join(repeated_headers),)
 
 
+class QiitaDBDuplicateSamplesError(QiitaDBError):
+    """Exception for error when a MetadataTemplate has duplicate columns"""
+    def __init__(self, repeated_samples):
+        super(QiitaDBDuplicateSamplesError, self).__init__()
+        self.args = ("Duplicate samples found in MetadataTemplate. Repeated "
+                     "sample(s): %s." % ', '.join(repeated_samples),)
+
+
 class QiitaDBIncompatibleDatatypeError(QiitaDBError):
     """When arguments are used with incompatible operators in a query"""
     def __init__(self, operator, argument_type):

--- a/qiita_db/exceptions.py
+++ b/qiita_db/exceptions.py
@@ -76,8 +76,8 @@ class QiitaDBDuplicateSamplesError(QiitaDBError):
     """Exception for error when a MetadataTemplate has duplicate columns"""
     def __init__(self, repeated_samples):
         super(QiitaDBDuplicateSamplesError, self).__init__()
-        self.args = ("Duplicate samples found in MetadataTemplate. Repeated "
-                     "sample(s): %s." % ', '.join(repeated_samples),)
+        self.args = ("Duplicate samples found in MetadataTemplate: %s."
+                     % ', '.join(repeated_samples),)
 
 
 class QiitaDBIncompatibleDatatypeError(QiitaDBError):

--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -50,7 +50,8 @@ from qiita_core.exceptions import IncompetentQiitaDeveloperError
 
 from qiita_db.exceptions import (QiitaDBUnknownIDError, QiitaDBColumnError,
                                  QiitaDBNotImplementedError, QiitaDBError,
-                                 QiitaDBWarning, QiitaDBDuplicateHeaderError)
+                                 QiitaDBWarning, QiitaDBDuplicateHeaderError,
+                                 QiitaDBDuplicateSamplesError)
 from qiita_db.base import QiitaObject
 from qiita_db.sql_connection import TRN
 from qiita_db.util import (exists_table, get_table_cols,
@@ -535,6 +536,10 @@ class MetadataTemplate(QiitaObject):
                                      "(only alphanumeric characters or periods"
                                      " are allowed): %s." %
                                      ", ".join(invalid_ids))
+
+        if len(set(md_template.index)) != len(md_template.index):
+            raise QiitaDBDuplicateSamplesError(
+                find_duplicates(md_template.index))
 
         # We are going to modify the md_template. We create a copy so
         # we don't modify the user one

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -26,7 +26,8 @@ from qiita_db.exceptions import (QiitaDBUnknownIDError,
                                  QiitaDBExecutionError,
                                  QiitaDBColumnError,
                                  QiitaDBWarning,
-                                 QiitaDBError)
+                                 QiitaDBError,
+                                 QiitaDBDuplicateSamplesError)
 from qiita_db.study import Study
 from qiita_db.data import RawData, ProcessedData
 from qiita_db.util import exists_table, get_mountpoint, get_count
@@ -556,6 +557,13 @@ class TestPrepTemplateReadOnly(BaseTestPrepTemplate):
         self.metadata['STR_COLUMN'] = pd.Series(['', '', ''],
                                                 index=self.metadata.index)
         with self.assertRaises(QiitaDBDuplicateHeaderError):
+            PrepTemplate._clean_validate_template(self.metadata, 2,
+                                                  PREP_TEMPLATE_COLUMNS)
+
+    def test_clean_validate_template_error_duplicate_samples(self):
+        """Raises an error if there are duplicated samples in the templates"""
+        self.metadata.index = ['sample.1', 'sample.1', 'sample.3']
+        with self.assertRaises(QiitaDBDuplicateSamplesError):
             PrepTemplate._clean_validate_template(self.metadata, 2,
                                                   PREP_TEMPLATE_COLUMNS)
 

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -23,7 +23,7 @@ from qiita_db.exceptions import (QiitaDBDuplicateError, QiitaDBUnknownIDError,
                                  QiitaDBNotImplementedError,
                                  QiitaDBDuplicateHeaderError,
                                  QiitaDBColumnError, QiitaDBError,
-                                 QiitaDBWarning)
+                                 QiitaDBWarning, QiitaDBDuplicateSamplesError)
 from qiita_db.study import Study, StudyPerson
 from qiita_db.user import User
 from qiita_db.util import exists_table, get_count
@@ -664,6 +664,13 @@ class TestSampleTemplateReadOnly(BaseTestSampleTemplate):
                                                 index=self.metadata.index)
 
         with self.assertRaises(QiitaDBDuplicateHeaderError):
+            SampleTemplate._clean_validate_template(self.metadata, 2,
+                                                    SAMPLE_TEMPLATE_COLUMNS)
+
+    def test_clean_validate_template_error_duplicate_samples(self):
+        """Raises an error if there are duplicated samples in the template"""
+        self.metadata.index = ['sample.1', 'sample.1', 'sample.3']
+        with self.assertRaises(QiitaDBDuplicateSamplesError):
             SampleTemplate._clean_validate_template(self.metadata, 2,
                                                     SAMPLE_TEMPLATE_COLUMNS)
 


### PR DESCRIPTION
Fixes #1341

Example of output:
<img width="1186" alt="screen shot 2015-08-07 at 12 06 54 pm" src="https://cloud.githubusercontent.com/assets/2501478/9143775/2b094ca4-3cfd-11e5-826e-0fa9a4f506e6.png">
