### PR TITLE
Allow UTF8 characters in the study title, alias, description and abstract

### DIFF
--- a/qiita_pet/handlers/study_handlers/edit_handlers.py
+++ b/qiita_pet/handlers/study_handlers/edit_handlers.py
@@ -78,11 +78,13 @@ class StudyEditorForm(Form):
         if study:
             study_info = study.info
 
-            self.study_title.data = study.title
-            self.study_alias.data = study_info['study_alias']
+            self.study_title.data = study.title.decode('utf-8')
+            self.study_alias.data = study_info['study_alias'].decode('utf-8')
             self.pubmed_id.data = ",".join(study.pmids)
-            self.study_abstract.data = study_info['study_abstract']
-            self.study_description.data = study_info['study_description']
+            self.study_abstract.data = study_info[
+                'study_abstract'].decode('utf-8')
+            self.study_description.data = study_info[
+                'study_description'].decode('utf-8')
             self.principal_investigator.data = study_info[
                 'principal_investigator_id']
             self.lab_person.data = study_info['lab_person_id']

--- a/qiita_pet/handlers/study_handlers/edit_handlers.py
+++ b/qiita_pet/handlers/study_handlers/edit_handlers.py
@@ -80,7 +80,7 @@ class StudyEditorForm(Form):
 
             self.study_title.data = study.title.decode('utf-8')
             self.study_alias.data = study_info['study_alias'].decode('utf-8')
-            self.pubmed_id.data = ",".join(study.pmids)
+            self.pubmed_id.data = ",".join(study.pmids).decode('utf-8')
             self.study_abstract.data = study_info[
                 'study_abstract'].decode('utf-8')
             self.study_description.data = study_info[

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from unittest import main
 from json import loads
 
@@ -212,6 +214,17 @@ class TestStudyEditHandler(TestHandlerBase):
 
     def test_get_edit(self):
         """Make sure the page loads when we want to edit a study"""
+        response = self.get('/study/edit/1')
+        self.assertEqual(response.code, 200)
+        self.assertNotEqual(str(response.body), "")
+
+    def test_get_edit_utf8(self):
+        """Make sure the page loads when utf8 characters are present"""
+        study = Study(1)
+        study.title = "TEST_ø"
+        study.alias = "TEST_ø"
+        study.description = "TEST_ø"
+        study.abstract = "TEST_ø"
         response = self.get('/study/edit/1')
         self.assertEqual(response.code, 200)
         self.assertNotEqual(str(response.body), "")


### PR DESCRIPTION
Fixes #1300 
the limitations was in WTForms. It was already solved for the PI and Lab Person, but it was not fixed for the rest of the attributes of the study that this character can occur. It also adds a specific test.

Pubmed id should never include non-ascii characters, so I think it is fine leaving it as it is.

![screen shot 2015-08-07 at 12 57 46 pm](https://cloud.githubusercontent.com/assets/2501478/9144900/1805f2b2-3d05-11e5-8820-0f9fba59cd0c.png)
