### PR TITLE
Fix nan and bool values

### DIFF
--- a/qiita_db/metadata_template/constants.py
+++ b/qiita_db/metadata_template/constants.py
@@ -71,13 +71,14 @@ ALL_RESTRICTIONS = [SAMPLE_TEMPLATE_COLUMNS, PREP_TEMPLATE_COLUMNS,
                     PREP_TEMPLATE_COLUMNS_TARGET_GENE]
 
 # This is what we consider as "NaN" cell values on metadata import
-NA_VALS = ['', 'no_data', 'unknown', 'Unspecified', 'unspecified']
+NA_VALUES = ['', 'no_data', 'unknown', 'Unspecified', 'unspecified']
 
 # These are what will be considered 'True' bool values on metadata import
-META_TRUE = ['Yes', 'yes', 'YES', 'Y', 'y', 'True', 'true', 'TRUE', 't', 'T']
+TRUE_VALUES = ['Yes', 'yes', 'YES', 'Y', 'y', 'True', 'true', 'TRUE', 't', 'T']
 
 # These are what will be considered 'False' bool values on metadata import
-META_FALSE = ['No', 'no', 'NO', 'N', 'n', 'False', 'false', 'FALSE', 'f', 'F']
+FALSE_VALUES = ['No', 'no', 'NO', 'N', 'n', 'False', 'false', 'FALSE',
+                'f', 'F']
 
 
 # A set holding all the controlled columns, useful to avoid recalculating it

--- a/qiita_db/metadata_template/constants.py
+++ b/qiita_db/metadata_template/constants.py
@@ -71,7 +71,7 @@ ALL_RESTRICTIONS = [SAMPLE_TEMPLATE_COLUMNS, PREP_TEMPLATE_COLUMNS,
                     PREP_TEMPLATE_COLUMNS_TARGET_GENE]
 
 # This is what we consider as "NaN" cell values on metadata import
-NA_VALS = ['', 'no_data', 'unknown', 'Unspecified']
+NA_VALS = ['', 'no_data', 'unknown', 'Unspecified', 'unspecified']
 
 # These are what will be considered 'True' bool values on metadata import
 META_TRUE = ['Yes', 'yes', 'YES', 'Y', 'y', 'True', 'true', 'TRUE', 't', 'T']

--- a/qiita_db/metadata_template/constants.py
+++ b/qiita_db/metadata_template/constants.py
@@ -74,10 +74,10 @@ ALL_RESTRICTIONS = [SAMPLE_TEMPLATE_COLUMNS, PREP_TEMPLATE_COLUMNS,
 NA_VALS = ['', 'no_data', 'unknown', 'Unspecified']
 
 # These are what will be considered 'True' bool values on metadata import
-META_TRUE = ['Yes', 'yes', 'YES', 'Y', 'y', 'True', 'true', 't']
+META_TRUE = ['Yes', 'yes', 'YES', 'Y', 'y', 'True', 'true', 'TRUE', 't', 'T']
 
 # These are what will be considered 'False' bool values on metadata import
-META_FALSE = ['No', 'no', 'NO', 'N', 'n', 'False', 'false', 'f']
+META_FALSE = ['No', 'no', 'NO', 'N', 'n', 'False', 'false', 'FALSE', 'f', 'F']
 
 
 # A set holding all the controlled columns, useful to avoid recalculating it

--- a/qiita_db/metadata_template/constants.py
+++ b/qiita_db/metadata_template/constants.py
@@ -70,6 +70,15 @@ PREP_TEMPLATE_COLUMNS_TARGET_GENE = {
 ALL_RESTRICTIONS = [SAMPLE_TEMPLATE_COLUMNS, PREP_TEMPLATE_COLUMNS,
                     PREP_TEMPLATE_COLUMNS_TARGET_GENE]
 
+# This is what we consider as "NaN" cell values on metadata import
+NA_VALS = ['', 'no_data', 'unknown', 'Unspecified']
+
+# These are what will be considered 'True' bool values on metadata import
+META_TRUE = ['Yes', 'yes', 'YES', 'Y', 'y', 'True', 'true', 't']
+
+# These are what will be considered 'False' bool values on metadata import
+META_FALSE = ['No', 'no', 'NO', 'N', 'n', 'False', 'false', 'f']
+
 
 # A set holding all the controlled columns, useful to avoid recalculating it
 def _col_iterator():

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -33,6 +33,7 @@ from qiita_db.data import RawData, ProcessedData
 from qiita_db.util import exists_table, get_mountpoint, get_count
 from qiita_db.metadata_template.prep_template import PrepTemplate, PrepSample
 from qiita_db.metadata_template.sample_template import SampleTemplate, Sample
+from qiita_db.metadata_template.constants import META_FALSE, META_TRUE, NA_VALS
 from qiita_db.metadata_template import (PREP_TEMPLATE_COLUMNS,
                                         PREP_TEMPLATE_COLUMNS_TARGET_GENE)
 
@@ -900,7 +901,9 @@ class TestPrepTemplateReadWrite(BaseTestPrepTemplate):
         obs = pd.read_csv(obs_fp, sep='\t', infer_datetime_format=True,
                           parse_dates=True, index_col=False, comment='\t')
         exp = pd.read_csv(exp_fp, sep='\t', infer_datetime_format=True,
-                          parse_dates=True, index_col=False, comment='\t')
+                          parse_dates=True, index_col=False, comment='\t',
+                          na_values=NA_VALS, true_values=META_TRUE,
+                          false_values=META_FALSE)
 
         assert_frame_equal(obs, exp)
 

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -33,7 +33,8 @@ from qiita_db.data import RawData, ProcessedData
 from qiita_db.util import exists_table, get_mountpoint, get_count
 from qiita_db.metadata_template.prep_template import PrepTemplate, PrepSample
 from qiita_db.metadata_template.sample_template import SampleTemplate, Sample
-from qiita_db.metadata_template.constants import META_FALSE, META_TRUE, NA_VALS
+from qiita_db.metadata_template.constants import (FALSE_VALUES, TRUE_VALUES,
+                                                  NA_VALUES)
 from qiita_db.metadata_template import (PREP_TEMPLATE_COLUMNS,
                                         PREP_TEMPLATE_COLUMNS_TARGET_GENE)
 
@@ -902,8 +903,8 @@ class TestPrepTemplateReadWrite(BaseTestPrepTemplate):
                           parse_dates=True, index_col=False, comment='\t')
         exp = pd.read_csv(exp_fp, sep='\t', infer_datetime_format=True,
                           parse_dates=True, index_col=False, comment='\t',
-                          na_values=NA_VALS, true_values=META_TRUE,
-                          false_values=META_FALSE)
+                          na_values=NA_VALUES, true_values=TRUE_VALUES,
+                          false_values=FALSE_VALUES)
 
         assert_frame_equal(obs, exp)
 

--- a/qiita_db/metadata_template/util.py
+++ b/qiita_db/metadata_template/util.py
@@ -18,7 +18,7 @@ from skbio.io.util import open_file
 
 from qiita_db.exceptions import (QiitaDBColumnError, QiitaDBWarning,
                                  QiitaDBError)
-from .constants import CONTROLLED_COLS
+from .constants import CONTROLLED_COLS, NA_VALS, META_TRUE, META_FALSE
 
 if PY3:
     from string import ascii_letters as letters, digits
@@ -238,8 +238,11 @@ def load_template_to_dataframe(fn, strip_whitespace=True, index='sample_name'):
     #   is set as False, to avoid inferring empty/NA values with the defaults
     #   that Pandas has.
     # na_values:
-    #   the values that should be considered as empty, in this case only empty
-    #   strings.
+    #   the values that should be considered as empty
+    # true_values:
+    #   the values that should be considered "True" for boolean columns
+    # false_values:
+    #   the values that should be considered "False" for boolean columns
     # converters:
     #   ensure that sample names are not converted into any other types but
     #   strings and remove any trailing spaces. Don't let pandas try to guess
@@ -250,7 +253,8 @@ def load_template_to_dataframe(fn, strip_whitespace=True, index='sample_name'):
     try:
         template = pd.read_csv(StringIO(''.join(holdfile)), sep='\t',
                                encoding='utf-8', infer_datetime_format=True,
-                               keep_default_na=False, na_values=[''],
+                               keep_default_na=False, na_values=NA_VALS,
+                               true_values=META_TRUE, false_values=META_FALSE,
                                parse_dates=True, index_col=False, comment='\t',
                                mangle_dupe_cols=False, converters={
                                    index: lambda x: str(x).strip(),

--- a/qiita_db/metadata_template/util.py
+++ b/qiita_db/metadata_template/util.py
@@ -18,7 +18,7 @@ from skbio.io.util import open_file
 
 from qiita_db.exceptions import (QiitaDBColumnError, QiitaDBWarning,
                                  QiitaDBError)
-from .constants import CONTROLLED_COLS, NA_VALS, META_TRUE, META_FALSE
+from .constants import CONTROLLED_COLS, NA_VALUES, TRUE_VALUES, FALSE_VALUES
 
 if PY3:
     from string import ascii_letters as letters, digits
@@ -253,8 +253,9 @@ def load_template_to_dataframe(fn, strip_whitespace=True, index='sample_name'):
     try:
         template = pd.read_csv(StringIO(''.join(holdfile)), sep='\t',
                                encoding='utf-8', infer_datetime_format=True,
-                               keep_default_na=False, na_values=NA_VALS,
-                               true_values=META_TRUE, false_values=META_FALSE,
+                               keep_default_na=False, na_values=NA_VALUES,
+                               true_values=TRUE_VALUES,
+                               false_values=FALSE_VALUES,
                                parse_dates=True, index_col=False, comment='\t',
                                mangle_dupe_cols=False, converters={
                                    index: lambda x: str(x).strip(),


### PR DESCRIPTION
This is a small pull request that expands what we consider NaN and bool values. This comes after looking at the AG18 load and realizing that everything was considered a string, since the blanks all were 'unknown' for all columns.