### PR TITLE
Solving np.nan problems

### DIFF
--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -40,7 +40,6 @@ from future.utils import viewitems, viewvalues
 from future.builtins import zip
 from os.path import join
 from functools import partial
-from copy import deepcopy
 
 import pandas as pd
 import numpy as np
@@ -544,7 +543,7 @@ class MetadataTemplate(QiitaObject):
 
         # We are going to modify the md_template. We create a copy so
         # we don't modify the user one
-        md_template = deepcopy(md_template)
+        md_template = md_template.copy(deep=True)
 
         # Prefix the sample names with the study_id
         prefix_sample_names_with_id(md_template, study_id)

--- a/qiita_db/metadata_template/constants.py
+++ b/qiita_db/metadata_template/constants.py
@@ -71,7 +71,7 @@ ALL_RESTRICTIONS = [SAMPLE_TEMPLATE_COLUMNS, PREP_TEMPLATE_COLUMNS,
                     PREP_TEMPLATE_COLUMNS_TARGET_GENE]
 
 # This is what we consider as "NaN" cell values on metadata import
-NA_VALUES = ['', 'no_data', 'unknown', 'Unspecified', 'unspecified']
+NA_VALUES = ['', 'no_data', 'unknown', 'Unknown', 'Unspecified', 'unspecified']
 
 # These are what will be considered 'True' bool values on metadata import
 TRUE_VALUES = ['Yes', 'yes', 'YES', 'Y', 'y', 'True', 'true', 'TRUE', 't', 'T']

--- a/qiita_db/metadata_template/test/test_util.py
+++ b/qiita_db/metadata_template/test/test_util.py
@@ -87,8 +87,7 @@ class TestUtil(TestCase):
 
     def test_load_template_to_dataframe_duplicate_cols(self):
         with self.assertRaises(QiitaDBDuplicateHeaderError):
-            obs = load_template_to_dataframe(
-                StringIO(EXP_SAMPLE_TEMPLATE_DUPE_COLS))
+            load_template_to_dataframe(StringIO(EXP_SAMPLE_TEMPLATE_DUPE_COLS))
 
     def test_load_template_to_dataframe_scrubbing(self):
         obs = load_template_to_dataframe(StringIO(EXP_SAMPLE_TEMPLATE_SPACES))

--- a/qiita_db/metadata_template/test/test_util.py
+++ b/qiita_db/metadata_template/test/test_util.py
@@ -190,6 +190,12 @@ class TestUtil(TestCase):
         exp.index.name = 'sample_name'
         assert_frame_equal(obs, exp)
 
+    def test_load_template_to_dataframe_with_nulls(self):
+        obs = load_template_to_dataframe(StringIO(EXP_SAMPLE_TEMPLATE_NULLS))
+        exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_NULLS_DICT)
+        exp.index.name = 'sample_name'
+        assert_frame_equal(obs, exp)
+
     def test_get_invalid_sample_names(self):
         all_valid = ['2.sample.1', 'foo.bar.baz', 'roses', 'are', 'red',
                      'v10l3t5', '4r3', '81u3']
@@ -520,6 +526,30 @@ SAMPLE_TEMPLATE_INVALID_LONGITUDE_COLUMNS = (
     "True\1\t4.8\t4.XXXXX41\tlocation1\treceived\ttype1\t"
     "Value for sample 3\n")
 
+EXP_SAMPLE_TEMPLATE_NULLS = (
+    "sample_name\tmy_bool_col\tmy_bool_col_w_nulls\n"
+    "sample.1\tTrue\tFalse\n"
+    "sample.2\tFalse\tUnknown\n"
+    "sample.3\tTrue\tTrue\n"
+    "sample.4\tFalse\t\n"
+    "sample.5\tTrue\tTrue\n"
+    "sample.6\tFalse\tTrue\n")
+
+
+SAMPLE_TEMPLATE_NULLS_DICT = {
+    'my_bool_col': {"sample.1": True,
+                    "sample.2": False,
+                    "sample.3": True,
+                    "sample.4": False,
+                    "sample.5": True,
+                    "sample.6": False},
+    'my_bool_col_w_nulls': {"sample.1": False,
+                            "sample.2": None,
+                            "sample.3": True,
+                            "sample.4": None,
+                            "sample.5": True,
+                            "sample.6": True}
+}
 
 SAMPLE_TEMPLATE_DICT_FORM = {
     'collection_timestamp': {'2.Sample1': '2014-05-29 12:24:51',

--- a/qiita_db/metadata_template/test/test_util.py
+++ b/qiita_db/metadata_template/test/test_util.py
@@ -14,7 +14,7 @@ import pandas as pd
 from pandas.util.testing import assert_frame_equal
 
 from qiita_db.exceptions import (QiitaDBColumnError, QiitaDBWarning,
-                                 QiitaDBError)
+                                 QiitaDBError, QiitaDBDuplicateHeaderError)
 from qiita_db.metadata_template.util import (
     get_datatypes, as_python_types, prefix_sample_names_with_id,
     load_template_to_dataframe, get_invalid_sample_names,
@@ -86,14 +86,9 @@ class TestUtil(TestCase):
         assert_frame_equal(obs, exp)
 
     def test_load_template_to_dataframe_duplicate_cols(self):
-        obs = load_template_to_dataframe(
-            StringIO(EXP_SAMPLE_TEMPLATE_DUPE_COLS))
-        obs = list(obs.columns)
-        exp = ['collection_timestamp', 'description', 'has_extracted_data',
-               'has_physical_specimen', 'host_subject_id', 'latitude',
-               'longitude', 'physical_location', 'required_sample_info_status',
-               'sample_type', 'str_column', 'str_column']
-        self.assertEqual(obs, exp)
+        with self.assertRaises(QiitaDBDuplicateHeaderError):
+            obs = load_template_to_dataframe(
+                StringIO(EXP_SAMPLE_TEMPLATE_DUPE_COLS))
 
     def test_load_template_to_dataframe_scrubbing(self):
         obs = load_template_to_dataframe(StringIO(EXP_SAMPLE_TEMPLATE_SPACES))

--- a/qiita_db/metadata_template/util.py
+++ b/qiita_db/metadata_template/util.py
@@ -321,6 +321,9 @@ def load_template_to_dataframe(fn, strip_whitespace=True, index='sample_name'):
                       'because all their values are empty: '
                       '%s' % ', '.join(dropped_cols), QiitaDBWarning)
 
+    # Pandas represents data with np.nan rather than Nones, change it
+    template = template.where((pd.notnull(template)), None)
+
     return template
 
 

--- a/qiita_db/metadata_template/util.py
+++ b/qiita_db/metadata_template/util.py
@@ -328,7 +328,9 @@ def load_template_to_dataframe(fn, strip_whitespace=True, index='sample_name'):
                       'because all their values are empty: '
                       '%s' % ', '.join(dropped_cols), QiitaDBWarning)
 
-    # Pandas represents data with np.nan rather than Nones, change it
+    # Pandas represents data with np.nan rather than Nones, change it to None
+    # because psycopg2 knows that a None is a Null in SQL, while it doesn't
+    # know what to do with NaN
     template = template.where((pd.notnull(template)), None)
 
     return template


### PR DESCRIPTION
when pandas parses blanks, it always represent them as np.nan. This is a problem since the np.nan are Floats, but we might want to insert them in other data types (e.g. bool or varchar). This PR forces the template to represent all np.nan as None, so they'll be inserted as 'Null' in the DB.

In order to use the `DataFrame.where` function, the DataFrame should not have duplicate columns. We where allowing them in the load function, but raising an error in the `create` step. I think it is ok to already raise an error in the load function, so we execute less work. I've changed that here and updated the relevant test.