### PR TITLE
BUG: Fix problem with default basedir

### DIFF
--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -144,8 +144,8 @@ class ConfigurationManager(object):
     def _get_main(self, config):
         """Get the configuration of the main section"""
         self.test_environment = config.getboolean('main', 'TEST_ENVIRONMENT')
-        default_base_data_dir = join(dirname(abspath(__file__)),
-                                     '..', 'qiita_db', 'support_files',
+        install_dir = dirname(dirname(abspath(__file__)))
+        default_base_data_dir = join(install_dir, 'qiita_db', 'support_files',
                                      'test_data')
         self.base_data_dir = config.get('main', 'BASE_DATA_DIR') or \
             default_base_data_dir

--- a/qiita_db/support_files/patches/31.sql
+++ b/qiita_db/support_files/patches/31.sql
@@ -1,0 +1,3 @@
+-- August 24, 2015
+-- Delete all occurrences of '..' in the base_data_dir entry
+SELECT 42;

--- a/qiita_db/support_files/patches/python_patches/31.py
+++ b/qiita_db/support_files/patches/python_patches/31.py
@@ -1,0 +1,6 @@
+from os.path import realpath
+from qiita_db.sql_connection import SQLConnectionHandler
+
+conn = SQLConnectionHandler()
+path = conn.execute_fetchone('SELECT base_data_dir FROM settings')[0]
+conn.execute("UPDATE settings SET base_data_dir = %s", (realpath(path),))

--- a/qiita_db/support_files/patches/python_patches/31.py
+++ b/qiita_db/support_files/patches/python_patches/31.py
@@ -1,6 +1,11 @@
 from os.path import realpath
-from qiita_db.sql_connection import SQLConnectionHandler
+from qiita_db.sql_connection import TRN
 
-conn = SQLConnectionHandler()
-path = conn.execute_fetchone('SELECT base_data_dir FROM settings')[0]
-conn.execute("UPDATE settings SET base_data_dir = %s", (realpath(path),))
+with TRN:
+    TRN.add('SELECT base_data_dir FROM settings')
+    path = TRN.execute_fetchlast()
+
+    # if the path is non-canonical (it contains .. or other redundant symbols)
+    # this will update it, else it will leave as is
+    TRN.add("UPDATE settings SET base_data_dir = %s", (realpath(path),))
+    TRN.execute()


### PR DESCRIPTION
If the base data directory was not set, a default one would be selected,
by using '..' to refer to a directory below, which in turn would
inconsistently flag users as lacking permissions:

```
QiitaPetAuthorizationError: User demo@microbio.me is not authorized to
access
/Users/yoshikivazquezbaeza/.virtualenvs/qiita-0.2.0-rc1/lib/python2.7/site-packages/qiita_db/support_files/test_data/job/1_summarize_taxa_through_plots.py_output_dir/taxa_summary_plots/bar_charts.html
```

Although the paths were the same, this is verified through string
matching thus 'lol/foo/../jk' and 'lol/jk' would not match (see example
structure below) even though they refer to the same folder:

lol/
├── foo
│   └── file.txt
├── jk
└── plel