### PR TITLE
Unify extend update gui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Version 0.2.0-dev (Changes since version 0.2.0 go here)
 -------------------------------------------------------
 
+* Users can now update and extend the templates at once using the "Update" button, rather than in two steps.
+
 Version 0.2.0 (2015-08-25)
 --------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,7 @@
 Version 0.2.0-dev (Changes since version 0.2.0 go here)
 -------------------------------------------------------
 
-* Users can now update and extend sample templates by using the "Update sample templates" button, rather than having to do 2 steps with the previous design.
-* Users can now update and extend prep templates, using the "Update prep template" button in the prep template tab.
-* The 'extend' functionality has been moved from the sample template to the base metadata template object, so now both sample and prep templates can be extended.
+* Users can now change values and add samples and/or columns to sample and prep templates using the <kbd>Update</kbd> button (see the prep template and sample template tabs).
 
 Version 0.2.0 (2015-08-25)
 --------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 Version 0.2.0-dev (Changes since version 0.2.0 go here)
 -------------------------------------------------------
 
-* Users can now update and extend the templates at once using the "Update" button, rather than in two steps.
+* Users can now update and extend sample templates by using the "Update sample templates" button, rather than having to do 2 steps with the previous design.
+* Users can now update and extend prep templates, using the "Update prep template" button in the prep template tab.
+* The 'extend' functionality has been moved from the sample template to the base metadata template object, so now both sample and prep templates can be extended.
 
 Version 0.2.0 (2015-08-25)
 --------------------------

--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -1057,6 +1057,20 @@ class MetadataTemplate(QiitaObject):
 
         return cols
 
+    def extend(self, md_template):
+        """Adds the given template to the current one
+
+        Parameters
+        ----------
+        md_template : DataFrame
+            The metadata template contents indexed by sample Ids
+        """
+        with TRN:
+            md_template = self._clean_validate_template(
+                md_template, self.study_id, self.columns_restrictions)
+            self._common_extend_steps(md_template)
+            self.generate_files()
+
     def update(self, md_template):
         r"""Update values in the template
 

--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -1133,6 +1133,8 @@ class MetadataTemplate(QiitaObject):
             # by using ne_stacked to index himself, we get only the columns
             # that did change (see boolean indexing in pandas docs)
             changed = ne_stacked[ne_stacked]
+            if changed.empty:
+                return
             changed.index.names = ['sample_name', 'column']
             # the combination of np.where and boolean indexing produces
             # a numpy array with only the values that actually changed

--- a/qiita_db/metadata_template/sample_template.py
+++ b/qiita_db/metadata_template/sample_template.py
@@ -225,19 +225,3 @@ class SampleTemplate(MetadataTemplate):
             # generating all new QIIME mapping files
             for pt_id in Study(self._id).prep_templates():
                 PrepTemplate(pt_id).generate_files()
-
-    def extend(self, md_template):
-        """Adds the given sample template to the current one
-
-        Parameters
-        ----------
-        md_template : DataFrame
-            The metadata template file contents indexed by samples Ids
-        """
-        with TRN:
-            md_template = self._clean_validate_template(
-                md_template, self.study_id, SAMPLE_TEMPLATE_COLUMNS)
-
-            self._common_extend_steps(md_template)
-
-            self.generate_files()

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -1312,6 +1312,60 @@ class TestPrepTemplateReadWrite(BaseTestPrepTemplate):
 
         self.assertItemsEqual(obs, exp)
 
+    def test_extend_update(self):
+        pt = PrepTemplate.create(self.metadata, self.test_study,
+                                 self.data_type)
+        self.metadata['new_col'] = pd.Series(['val1', 'val2', 'val3'],
+                                             index=self.metadata.index)
+        self.metadata['str_column']['SKB7.640196'] = 'NEW VAL'
+
+        npt.assert_warns(QiitaDBWarning, pt.extend, self.metadata)
+        pt.update(self.metadata)
+
+        sql = "SELECT * FROM qiita.prep_{0}".format(pt.id)
+        obs = [dict(o) for o in self.conn_handler.execute_fetchall(sql)]
+        exp = [{'sample_id': '1.SKB7.640196',
+                'barcode': 'CCTCTGAGAGCT',
+                'ebi_submission_accession': None,
+                'experiment_design_description': 'BBBB',
+                'library_construction_protocol': 'AAAA',
+                'primer': 'GTGCCAGCMGCCGCGGTAA',
+                'platform': 'ILLUMINA',
+                'run_prefix': 's_G1_L002_sequences',
+                'str_column': 'NEW VAL',
+                'center_name': 'ANL',
+                'center_project_name': 'Test Project',
+                'emp_status': 'EMP',
+                'new_col': 'val1'},
+               {'sample_id': '1.SKB8.640193',
+                'barcode': 'GTCCGCAAGTTA',
+                'ebi_submission_accession': None,
+                'experiment_design_description': 'BBBB',
+                'library_construction_protocol': 'AAAA',
+                'primer': 'GTGCCAGCMGCCGCGGTAA',
+                'platform': 'ILLUMINA',
+                'run_prefix': 's_G1_L001_sequences',
+                'str_column': 'Value for sample 1',
+                'center_name': 'ANL',
+                'center_project_name': 'Test Project',
+                'emp_status': 'EMP',
+                'new_col': 'val2'},
+               {'sample_id': '1.SKD8.640184',
+                'barcode': 'CGTAGAGCTCTC',
+                'ebi_submission_accession': None,
+                'experiment_design_description': 'BBBB',
+                'library_construction_protocol': 'AAAA',
+                'primer': 'GTGCCAGCMGCCGCGGTAA',
+                'platform': 'ILLUMINA',
+                'run_prefix': 's_G1_L001_sequences',
+                'str_column': 'Value for sample 2',
+                'center_name': 'ANL',
+                'center_project_name': 'Test Project',
+                'emp_status': 'EMP',
+                'new_col': 'val3'}]
+
+        self.assertItemsEqual(obs, exp)
+
 
 EXP_PREP_TEMPLATE = (
     'sample_name\tbarcode\tcenter_name\tcenter_project_name\t'

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -1271,6 +1271,7 @@ class TestPrepTemplateReadWrite(BaseTestPrepTemplate):
         sql = "SELECT * FROM qiita.prep_{0}".format(pt.id)
         obs = [dict(o) for o in self.conn_handler.execute_fetchall(sql)]
         exp = [{'sample_id': '1.SKB7.640196',
+                'barcode': 'CCTCTGAGAGCT',
                 'ebi_submission_accession': None,
                 'experiment_design_description': 'BBBB',
                 'library_construction_protocol': 'AAAA',
@@ -1283,6 +1284,7 @@ class TestPrepTemplateReadWrite(BaseTestPrepTemplate):
                 'emp_status': 'EMP',
                 'new_col': 'val1'},
                {'sample_id': '1.SKB8.640193',
+                'barcode': 'GTCCGCAAGTTA',
                 'ebi_submission_accession': None,
                 'experiment_design_description': 'BBBB',
                 'library_construction_protocol': 'AAAA',
@@ -1295,6 +1297,7 @@ class TestPrepTemplateReadWrite(BaseTestPrepTemplate):
                 'emp_status': 'EMP',
                 'new_col': 'val2'},
                {'sample_id': '1.SKD8.640184',
+                'barcode': 'CGTAGAGCTCTC',
                 'ebi_submission_accession': None,
                 'experiment_design_description': 'BBBB',
                 'library_construction_protocol': 'AAAA',
@@ -1306,6 +1309,8 @@ class TestPrepTemplateReadWrite(BaseTestPrepTemplate):
                 'center_project_name': 'Test Project',
                 'emp_status': 'EMP',
                 'new_col': 'val3'}]
+
+        self.assertItemsEqual(obs, exp)
 
 
 EXP_PREP_TEMPLATE = (

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -1338,12 +1338,6 @@ class TestSampleTemplateReadWrite(BaseTestSampleTemplate):
         st = SampleTemplate.create(self.metadata, self.new_study)
         self.assertEqual(st.get_filepaths()[0][0], exp_id)
 
-    def test_extend_error(self):
-        """extend raises an error if no new columns/samples are added"""
-        st = SampleTemplate.create(self.metadata, self.new_study)
-        with self.assertRaises(QiitaDBError):
-            st.extend(self.metadata)
-
     def test_extend_add_samples(self):
         """extend correctly works adding new samples"""
         st = SampleTemplate.create(self.metadata, self.new_study)

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -1373,7 +1373,7 @@ class TestSampleTemplateReadWrite(BaseTestSampleTemplate):
                         'scientific_name': 'homo sapiens'}}
         md_ext = pd.DataFrame.from_dict(md_dict, orient='index')
 
-        st.extend(md_ext)
+        npt.assert_warns(QiitaDBWarning, st.extend, md_ext)
 
         # Test samples were appended successfully to the required sample info
         # table

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -1774,6 +1774,118 @@ class TestSampleTemplateReadWrite(BaseTestSampleTemplate):
                 'scientific_name': 'homo sapiens'}]
         self.assertItemsEqual(obs, exp)
 
+    def test_extend_update(self):
+        """extend correctly adds new samples and columns at the same time"""
+        st = SampleTemplate.create(self.metadata, self.new_study)
+
+        self.metadata_dict['Sample4'] = {
+            'physical_specimen_location': 'location1',
+            'physical_specimen_remaining': True,
+            'dna_extracted': True,
+            'sample_type': 'type1',
+            'collection_timestamp': datetime(2014, 5, 29, 12, 24, 51),
+            'host_subject_id': 'NotIdentified',
+            'Description': 'Test Sample 4',
+            'str_column': 'Value for sample 4',
+            'int_column': 4,
+            'latitude': 42.42,
+            'longitude': 41.41,
+            'taxon_id': 9606,
+            'scientific_name': 'homo sapiens'}
+
+        self.metadata_dict['Sample1']['Description'] = 'Changed'
+        self.metadata_dict['Sample2']['str_column'] = 'Changed dynamic'
+
+        md_ext = pd.DataFrame.from_dict(self.metadata_dict, orient='index')
+
+        md_ext['NEWCOL'] = pd.Series(['val1', 'val2', 'val3', 'val4'],
+                                     index=md_ext.index)
+
+        npt.assert_warns(QiitaDBWarning, st.extend, md_ext)
+        st.update(md_ext)
+
+        # Make sure the new sample and column have been added and the values
+        # for the existent samples did not change
+        study_id = self.new_study.id
+        sql = """SELECT *
+                 FROM qiita.study_sample
+                 WHERE study_id=%s"""
+        obs = [dict(o)
+               for o in self.conn_handler.execute_fetchall(sql, (study_id,))]
+        exp = [{'sample_id': '%s.Sample1' % study_id,
+                'study_id': 2},
+               {'sample_id': '%s.Sample2' % study_id,
+                'study_id': 2},
+               {'sample_id': '%s.Sample3' % study_id,
+                'study_id': 2},
+               {'sample_id': '%s.Sample4' % study_id,
+                'study_id': 2}]
+        self.assertItemsEqual(obs, exp)
+
+        sql = "SELECT * FROM qiita.sample_{0}".format(study_id)
+        obs = [dict(o) for o in self.conn_handler.execute_fetchall(sql)]
+        exp = [{'sample_id': '%s.Sample1' % study_id,
+                'int_column': 1,
+                'str_column': 'Value for sample 1',
+                'newcol': 'val1',
+                'physical_specimen_location': 'location1',
+                'physical_specimen_remaining': True,
+                'dna_extracted': True,
+                'sample_type': 'type1',
+                'collection_timestamp': datetime(2014, 5, 29, 12, 24, 51),
+                'host_subject_id': 'NotIdentified',
+                'description': 'Changed',
+                'latitude': 42.42,
+                'longitude': 41.41,
+                'taxon_id': 9606,
+                'scientific_name': 'homo sapiens'},
+               {'sample_id': '%s.Sample2' % study_id,
+                'int_column': 2,
+                'str_column': 'Changed dynamic',
+                'newcol': 'val2',
+                'physical_specimen_location': 'location1',
+                'physical_specimen_remaining': True,
+                'dna_extracted': True,
+                'sample_type': 'type1',
+                'collection_timestamp': datetime(2014, 5, 29, 12, 24, 51),
+                'host_subject_id': 'NotIdentified',
+                'description': 'Test Sample 2',
+                'latitude': 4.2,
+                'longitude': 1.1,
+                'taxon_id': 9606,
+                'scientific_name': 'homo sapiens'},
+               {'sample_id': '%s.Sample3' % study_id,
+                'int_column': 3,
+                'str_column': 'Value for sample 3',
+                'newcol': 'val3',
+                'physical_specimen_location': 'location1',
+                'physical_specimen_remaining': True,
+                'dna_extracted': True,
+                'sample_type': 'type1',
+                'collection_timestamp': datetime(2014, 5, 29, 12, 24, 51),
+                'host_subject_id': 'NotIdentified',
+                'description': 'Test Sample 3',
+                'latitude': 4.8,
+                'longitude': 4.41,
+                'taxon_id': 9606,
+                'scientific_name': 'homo sapiens'},
+               {'sample_id': '%s.Sample4' % study_id,
+                'int_column': 4,
+                'str_column': 'Value for sample 4',
+                'newcol': 'val4',
+                'physical_specimen_location': 'location1',
+                'physical_specimen_remaining': True,
+                'dna_extracted': True,
+                'sample_type': 'type1',
+                'collection_timestamp': datetime(2014, 5, 29, 12, 24, 51),
+                'host_subject_id': 'NotIdentified',
+                'description': 'Test Sample 4',
+                'latitude': 42.42,
+                'longitude': 41.41,
+                'taxon_id': 9606,
+                'scientific_name': 'homo sapiens'}]
+        self.assertItemsEqual(obs, exp)
+
     def test_to_dataframe(self):
         st = SampleTemplate.create(self.metadata, self.new_study)
         obs = st.to_dataframe()

--- a/qiita_pet/handlers/study_handlers/description_handlers.py
+++ b/qiita_pet/handlers/study_handlers/description_handlers.py
@@ -428,13 +428,15 @@ class StudyDescriptionHandler(BaseHandler):
         try:
             with warnings.catch_warnings(record=True) as warns:
                 pt = PrepTemplate(pt_id)
-                pt.update(load_template_to_dataframe(fp))
+                df = load_template_to_dataframe(fp)
+                pt.extend(df)
+                pt.update(df)
                 remove(fp)
 
                 # join all the warning messages into one. Note that this info
                 # will be ignored if an exception is raised
                 if warns:
-                    msg = '; '.join([str(w.message) for w in warns])
+                    msg = '\n'.join(set(str(w.message) for w in warns))
                     msg_level = 'warning'
 
         except (TypeError, QiitaDBColumnError, QiitaDBExecutionError,

--- a/qiita_pet/templates/study_description.html
+++ b/qiita_pet/templates/study_description.html
@@ -99,22 +99,6 @@ function update_sample_template() {
   }
 }
 
-function extend_sample_template() {
-  var form = $("<form>")
-    .attr("action", window.location.href)
-    .attr("method", "post")
-    .append($("<input>")
-      .attr("type", "hidden")
-      .attr("name", "sample_template")
-      .attr("value", $("#sample_template").val()))
-    .append($("<input>")
-      .attr("type", "hidden")
-      .attr("name", "action")
-      .attr("value", "extend_sample_template"));
-  $("body").append(form);
-  form.submit();
-}
-
 function get_and_check_raw_data_files(prep_id, filetype){
   var barcodes = [];
   var forward = [];

--- a/qiita_pet/templates/study_description_templates/study_information_tab.html
+++ b/qiita_pet/templates/study_description_templates/study_information_tab.html
@@ -65,10 +65,6 @@
       </td>
       <td>&nbsp; &nbsp;</td>
       <td>
-        <a class="btn btn-primary" onclick="extend_sample_template();">Add samples and/or columns to sample template</a>
-      </td>
-      <td>&nbsp; &nbsp;</td>
-      <td>
         <a class="btn btn-danger glyphicon glyphicon-trash" onclick="delete_sample_template();"></a>
       </td>
       {% end %}


### PR DESCRIPTION
Users can now extend and update the sample template in a single button, rather than having to do it in two steps (first extending, then updating).

The extend functionality was not available for the prep template. This has been added here. The update prep template button in the GUI now also extends the prep template (same behavior as update sample template).

There has been minor improvements in the way the warning messages are shown to the user when updating templates.

I did not see any issue related with the changes here, please point me to any issue if I'm missing any.