### PR TITLE
Adding extend checks

### DIFF
--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -635,6 +635,49 @@ class MetadataTemplate(QiitaObject):
             # Execute all the steps
             TRN.execute()
 
+    def can_be_extended(self, new_samples, new_cols):
+        """Whether the template can be updated or not
+
+        Parameters
+        ----------
+        new_samples : list of str
+            The new samples to be added
+        new_cols : list of str
+            The new columns to be added
+
+        Returns
+        -------
+        bool
+            Whether the template can be extended or not
+        str
+            The error message in case that it can't be extended
+
+        Raises
+        ------
+        QiitaDBNotImplementedError
+            This method should be implemented in the subclasses
+        """
+        raise QiitaDBNotImplementedError(
+            "The method 'can_be_extended' should be implemented in "
+            "the subclasses")
+
+    def can_be_updated(self, **kwargs):
+        """Whether the template can be updated or not
+
+        Returns
+        -------
+        bool
+            Whether the template can be updated or not
+
+        Raises
+        ------
+        QiitaDBNotImplementedError
+            This method should be implemented in the subclasses
+        """
+        raise QiitaDBNotImplementedError(
+            "The method 'can_be_updated' should be implemented in "
+            "the subclasses")
+
     def _common_extend_steps(self, md_template):
         r"""executes the common extend steps
 

--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -657,6 +657,12 @@ class MetadataTemplate(QiitaObject):
             if not new_cols and not new_samples:
                 return
 
+            is_extendable, error_msg = self.can_be_extended(new_samples,
+                                                            new_cols)
+
+            if not is_extendable:
+                raise QiitaDBError(error_msg)
+
             table_name = self._table_name(self._id)
             if new_cols:
                 warnings.warn(

--- a/qiita_db/metadata_template/prep_template.py
+++ b/qiita_db/metadata_template/prep_template.py
@@ -337,6 +337,34 @@ class PrepTemplate(MetadataTemplate):
 
             return False
 
+    def can_be_extended(self, new_samples, new_columns):
+        """Gets if the template can be can_be_extended
+
+        Parameters
+        ----------
+        new_samples : list of str
+            The new samples to be added to the template
+        new_columns : list of str
+            The new columns to be added to the template
+
+        Returns
+        -------
+        (bool, str)
+            Whether the template can be extended or not, and the error message
+            in case that it can't be extended.
+
+        Notes
+        -----
+        New samples can't be added to the prep template if a preprocessed
+        data has been already generated.
+        """
+        ppd_data = self.preprocessed_data
+        if new_samples and ppd_data:
+            return False, ("Preprocessed data have been already generated "
+                           "(%s). No new samples can be added to the prep "
+                           "template." % ', '.join(map(str, ppd_data)))
+        return True, ""
+
     @property
     def raw_data(self):
         with TRN:

--- a/qiita_db/metadata_template/prep_template.py
+++ b/qiita_db/metadata_template/prep_template.py
@@ -303,7 +303,7 @@ class PrepTemplate(MetadataTemplate):
         return pt_cols
 
     def can_be_updated(self, columns):
-        """Gets if the template can be updated
+        """Whether the template can be updated or not
 
         Parameters
         ----------
@@ -338,7 +338,7 @@ class PrepTemplate(MetadataTemplate):
             return False
 
     def can_be_extended(self, new_samples, new_columns):
-        """Gets if the template can be can_be_extended
+        """Whether the template can be extended or not
 
         Parameters
         ----------
@@ -349,9 +349,10 @@ class PrepTemplate(MetadataTemplate):
 
         Returns
         -------
-        (bool, str)
-            Whether the template can be extended or not, and the error message
-            in case that it can't be extended.
+        bool
+            Whether the template can be extended or not
+        str
+            The error message in case that it can't be extended
 
         Notes
         -----
@@ -360,7 +361,7 @@ class PrepTemplate(MetadataTemplate):
         """
         ppd_data = self.preprocessed_data
         if new_samples and ppd_data:
-            return False, ("Preprocessed data have been already generated "
+            return False, ("Preprocessed data have already been generated "
                            "(%s). No new samples can be added to the prep "
                            "template." % ', '.join(map(str, ppd_data)))
         return True, ""

--- a/qiita_db/metadata_template/sample_template.py
+++ b/qiita_db/metadata_template/sample_template.py
@@ -201,13 +201,39 @@ class SampleTemplate(MetadataTemplate):
 
         Notes
         -----
-            The prep template can't be updated in certain situations, see the
-            its documentation for more info. However, the sample template
-            doesn't have those restrictions. Thus, to be able to use the same
-            update code in the base class, we need to have this method and it
-            should always return True.
+        The prep template can't be updated in certain situations, see the
+        its documentation for more info. However, the sample template
+        doesn't have those restrictions. Thus, to be able to use the same
+        update code in the base class, we need to have this method and it
+        should always return True.
         """
         return True
+
+    def can_be_extended(self, new_samples, new_columns):
+        """Gets if the template can be can_be_extended
+
+        Parameters
+        ----------
+        new_samples : list of str
+            The new samples to be added to the template
+        new_columns : list of str
+            The new columns to be added to the template
+
+        Returns
+        -------
+        (bool, str)
+            Whether the template can be extended or not, and the error message
+            in case that it can't be extended.
+
+        Notes
+        -----
+        The prep template can't be extended in certain situations, see the
+        its documentation for more info. However, the sample template
+        doesn't have those restrictions. Thus, to be able to use the same
+        extend code in the base class, we need to have this method and it
+        should always return True.
+        """
+        return True, ""
 
     def generate_files(self):
         r"""Generates all the files that contain data from this template

--- a/qiita_db/metadata_template/sample_template.py
+++ b/qiita_db/metadata_template/sample_template.py
@@ -186,7 +186,7 @@ class SampleTemplate(MetadataTemplate):
         return SAMPLE_TEMPLATE_COLUMNS
 
     def can_be_updated(self, **kwargs):
-        """Gets if the template can be updated
+        """Whether the template can be updated or not
 
         Parameters
         ----------
@@ -210,7 +210,7 @@ class SampleTemplate(MetadataTemplate):
         return True
 
     def can_be_extended(self, new_samples, new_columns):
-        """Gets if the template can be can_be_extended
+        """Whether the template can be updated or not
 
         Parameters
         ----------
@@ -221,9 +221,10 @@ class SampleTemplate(MetadataTemplate):
 
         Returns
         -------
-        (bool, str)
-            Whether the template can be extended or not, and the error message
-            in case that it can't be extended.
+        bool
+            Whether the template can be extended or not
+        str
+            The error message in case that it can't be extended
 
         Notes
         -----

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -238,12 +238,11 @@ class TestPrepSampleReadOnly(BaseTestPrepSample):
         self.assertTrue(obs_bool)
         self.assertEqual(obs_msg, "")
         # You can't add samples if there are preprocessed data generated
-
         obs_bool, obs_msg = self.prep_template.can_be_extended(
             ["NEW_SAMPLE"], [])
         self.assertFalse(obs_bool)
         self.assertEqual(obs_msg,
-                         "Preprocessed data have been already generated (%s). "
+                         "Preprocessed data have already been generated (%s). "
                          "No new samples can be added to the prep template."
                          % ', '.join(
                              map(str, self.prep_template.preprocessed_data)))

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -231,6 +231,23 @@ class TestPrepSampleReadOnly(BaseTestPrepSample):
         # but you can if not restricted
         self.assertTrue(self.prep_template.can_be_updated({'center_name'}))
 
+    def test_can_be_extended(self):
+        """test if the template can be extended"""
+        # You can always add columns
+        obs_bool, obs_msg = self.prep_template.can_be_extended([], ["NEW_COL"])
+        self.assertTrue(obs_bool)
+        self.assertEqual(obs_msg, "")
+        # You can't add samples if there are preprocessed data generated
+
+        obs_bool, obs_msg = self.prep_template.can_be_extended(
+            ["NEW_SAMPLE"], [])
+        self.assertFalse(obs_bool)
+        self.assertEqual(obs_msg,
+                         "Preprocessed data have been already generated (%s). "
+                         "No new samples can be added to the prep template."
+                         % ', '.join(
+                             map(str, self.prep_template.preprocessed_data)))
+
 
 @qiita_test_checker()
 class TestPrepSampleReadWrite(BaseTestPrepSample):
@@ -1258,6 +1275,14 @@ class TestPrepTemplateReadWrite(BaseTestPrepTemplate):
                {'prep_template_id': 2, 'sample_id': '1.SKD8.640184'},
                {'prep_template_id': 2, 'sample_id': '1.SKB7.640196'}]
         self.assertItemsEqual(obs, exp)
+
+    def test_extend_add_samples_error(self):
+        """extend fails adding samples to an already preprocessed template"""
+        df = pd.DataFrame.from_dict(
+            {'new_sample': {'barcode': 'CCTCTGAGAGCT'}},
+            orient='index')
+        with self.assertRaises(QiitaDBError):
+            PrepTemplate(1).extend(df)
 
     def test_extend_add_cols(self):
         """extend correctly adds a new columns"""

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -203,7 +203,13 @@ class TestSampleReadOnly(BaseTestSample):
 
     def test_can_be_updated(self):
         """test if the template can be updated"""
-        self.assertTrue(self.sample_template.can_be_updated)
+        self.assertTrue(self.sample_template.can_be_updated())
+
+    def test_can_be_extended(self):
+        """test if the template can be extended"""
+        obs_bool, obs_msg = self.sample_template.can_be_extended([], [])
+        self.assertTrue(obs_bool)
+        self.assertEqual(obs_msg, "")
 
 
 @qiita_test_checker()


### PR DESCRIPTION
This PR doesn't allow to add new samples to a prep template if it has been already preprocessed. This was an oversight on my previous PR and it will be great if I can have this review/merged so I can deploy this change tomorrow at 4pm (time scheduled for the upgrade).

While doing this PR, I noticed that there are no checks in terms of not allowing update/extend if the template has been submitted to EBI. I think this is a bigger discussion as I can see arguments for limiting it and not limiting it.

@antgonza @ElDeveloper @squirrelo can you review?