### PR TITLE
Numpy casting error - again

### DIFF
--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -58,7 +58,7 @@ from qiita_db.util import (exists_table, get_table_cols,
                            get_mountpoint, insert_filepaths)
 from qiita_db.logger import LogEntry
 from .util import (as_python_types, get_datatypes, get_invalid_sample_names,
-                   prefix_sample_names_with_id, type_lookup)
+                   prefix_sample_names_with_id, type_lookup, cast_to_python)
 
 
 class BaseSample(QiitaObject):
@@ -1232,7 +1232,8 @@ class MetadataTemplate(QiitaObject):
                                sql_values, sql_cols)
             sql_args = []
             for sample in samples_to_update:
-                sample_vals = [new_map[col][sample] for col in cols_to_update]
+                sample_vals = [cast_to_python(new_map[col][sample])
+                               for col in cols_to_update]
                 sample_vals.insert(0, sample)
                 sql_args.extend(sample_vals)
 

--- a/qiita_db/metadata_template/test/test_util.py
+++ b/qiita_db/metadata_template/test/test_util.py
@@ -8,7 +8,9 @@
 
 from six import StringIO
 from unittest import TestCase, main
+from datetime import datetime
 
+import numpy as np
 import numpy.testing as npt
 import pandas as pd
 from pandas.util.testing import assert_frame_equal
@@ -18,7 +20,8 @@ from qiita_db.exceptions import (QiitaDBColumnError, QiitaDBWarning,
 from qiita_db.metadata_template.util import (
     get_datatypes, as_python_types, prefix_sample_names_with_id,
     load_template_to_dataframe, get_invalid_sample_names,
-    looks_like_qiime_mapping_file, _parse_mapping_file, type_lookup)
+    looks_like_qiime_mapping_file, _parse_mapping_file, type_lookup,
+    cast_to_python)
 
 
 class TestUtil(TestCase):
@@ -47,6 +50,20 @@ class TestUtil(TestCase):
         obs = get_datatypes(self.metadata_map.ix[:, self.headers])
         exp = ['float8', 'varchar', 'integer']
         self.assertEqual(obs, exp)
+
+    def test_cast_to_python(self):
+        """Correctly returns the value casted"""
+        b = np.bool_(True)
+        obs = cast_to_python(b)
+        self.assertTrue(obs)
+        self.assertFalse(isinstance(obs, np.bool_))
+
+        exp = datetime(2015, 9, 1, 10, 00)
+        dt = np.datetime64(exp)
+        obs = cast_to_python(dt)
+        self.assertEqual(obs, exp)
+        self.assertFalse(isinstance(obs, np.datetime64))
+        self.assertTrue(isinstance(obs, datetime))
 
     def test_as_python_types(self):
         """Correctly returns the columns as python types"""

--- a/qiita_db/metadata_template/test/test_util.py
+++ b/qiita_db/metadata_template/test/test_util.py
@@ -57,6 +57,7 @@ class TestUtil(TestCase):
         obs = cast_to_python(b)
         self.assertTrue(obs)
         self.assertFalse(isinstance(obs, np.bool_))
+        self.assertTrue(isinstance(obs, bool))
 
         exp = datetime(2015, 9, 1, 10, 00)
         dt = np.datetime64(exp)

--- a/qiita_db/metadata_template/util.py
+++ b/qiita_db/metadata_template/util.py
@@ -69,7 +69,7 @@ def get_datatypes(metadata_map):
 
 
 def cast_to_python(value):
-    """Casts the value form numpy types to python types
+    """Casts the value from numpy types to python types
 
     Parameters
     ----------

--- a/qiita_db/metadata_template/util.py
+++ b/qiita_db/metadata_template/util.py
@@ -68,6 +68,24 @@ def get_datatypes(metadata_map):
     return [type_lookup(dtype) for dtype in metadata_map.dtypes]
 
 
+def cast_to_python(value):
+    """Casts the value form numpy types to python types
+
+    Parameters
+    ----------
+    value : object
+        The value to cast
+
+    Returns
+    -------
+    object
+        The input value casted to a python type
+    """
+    if isinstance(value, np.generic):
+        value = np.asscalar(value)
+    return value
+
+
 def as_python_types(metadata_map, headers):
     r"""Converts the values of metadata_map pointed by headers from numpy types
     to python types.


### PR DESCRIPTION
In the last refactor, I forgot to cast numpy values to python values (again) so we're hitting the can't adopt type np.bool_ error again. I added a specific test so we don't hit this error again.
