### PR TITLE
Update raw data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 0.2.0-dev (Changes since version 0.2.0 go here)
 -------------------------------------------------------
 
 * Users can now change values and add samples and/or columns to sample and prep templates using the <kbd>Update</kbd> button (see the prep template and sample template tabs).
+* The raw files of a RawData can be now updated using the `qiita db update_raw_data` CLI command.
 
 Version 0.2.0 (2015-08-25)
 --------------------------

--- a/qiita_db/commands.py
+++ b/qiita_db/commands.py
@@ -18,7 +18,7 @@ from shutil import move
 from .study import Study, StudyPerson
 from .user import User
 from .util import (get_filetypes, get_filepath_types, compute_checksum,
-                   convert_to_id)
+                   convert_to_id, move_filepaths_to_upload_folder)
 from .data import RawData, PreprocessedData, ProcessedData
 from .metadata_template import (SampleTemplate, PrepTemplate,
                                 load_template_to_dataframe)
@@ -355,7 +355,12 @@ def update_raw_data_from_cmd(filepaths, filepath_types, study_id, rd_id=None):
         filepath_types_dict = get_filepath_types()
         filepath_types = [filepath_types_dict[x] for x in filepath_types]
 
-        raw_data.clear_filepaths()
+        fps = raw_data.get_filepaths()
+        sql = "DELETE FROM qiita.raw_filepath WHERE raw_data_id = %s"
+        TRN.add(sql, [raw_data.id])
+        TRN.execute()
+        move_filepaths_to_upload_folder(study_id, fps)
+
         raw_data.add_filepaths(list(zip(filepaths, filepath_types)))
 
     return raw_data

--- a/qiita_db/commands.py
+++ b/qiita_db/commands.py
@@ -334,13 +334,13 @@ def update_raw_data_from_cmd(filepaths, filepath_types, study_id, rd_id=None):
         If rd_id is provided and it does not belong to the given study
     """
     if len(filepaths) != len(filepath_types):
-        raise ValueError("Please provide exactly one filepath_type for each"
+        raise ValueError("Please provide exactly one filepath_type for each "
                          "and every filepath")
     with TRN:
         study = Study(study_id)
         raw_data_ids = study.raw_data()
         if not raw_data_ids:
-            raise ValueError("Study %s does not have any raw data" % study_id)
+            raise ValueError("Study %d does not have any raw data" % study_id)
 
         if rd_id:
             if rd_id not in raw_data_ids:

--- a/qiita_db/commands.py
+++ b/qiita_db/commands.py
@@ -353,7 +353,15 @@ def update_raw_data_from_cmd(filepaths, filepath_types, study_id, rd_id=None):
             raw_data = RawData(sorted(raw_data_ids)[0])
 
         filepath_types_dict = get_filepath_types()
-        filepath_types = [filepath_types_dict[x] for x in filepath_types]
+        try:
+            filepath_types = [filepath_types_dict[x] for x in filepath_types]
+        except KeyError:
+            supported_types = filepath_types_dict.keys()
+            unsupported_types = set(filepath_types).difference(supported_types)
+            raise ValueError(
+                "Some filepath types provided are not recognized (%s). "
+                "Please choose from: %s"
+                % (', '.join(unsupported_types), ', '.join(supported_types)))
 
         fps = raw_data.get_filepaths()
         sql = "DELETE FROM qiita.raw_filepath WHERE raw_data_id = %s"

--- a/qiita_db/test/test_commands.py
+++ b/qiita_db/test/test_commands.py
@@ -14,6 +14,7 @@ from unittest import TestCase, main
 from future.utils.six import StringIO
 from future import standard_library
 from functools import partial
+from operator import itemgetter
 
 import pandas as pd
 
@@ -23,13 +24,14 @@ from qiita_db.commands import (load_study_from_cmd, load_raw_data_cmd,
                                load_processed_data_cmd,
                                load_preprocessed_data_from_cmd,
                                load_parameters_from_cmd,
+                               update_raw_data_from_cmd,
                                update_preprocessed_data_from_cmd)
 from qiita_db.environment_manager import patch
 from qiita_db.study import Study, StudyPerson
 from qiita_db.user import User
-from qiita_db.data import PreprocessedData
+from qiita_db.data import PreprocessedData, RawData
 from qiita_db.util import (get_count, check_count, get_db_files_base_dir,
-                           get_mountpoint)
+                           get_mountpoint, compute_checksum)
 from qiita_db.metadata_template import PrepTemplate
 from qiita_core.util import qiita_test_checker
 from qiita_ware.processing_pipeline import generate_demux_file
@@ -450,6 +452,103 @@ class TestPatch(TestCase):
         self.assertEqual(obs, exp)
 
         self._assert_current_patch('10.sql')
+
+
+@qiita_test_checker()
+class TestUpdateRawDataFromCmd(TestCase):
+    def setUp(self):
+        fd, seqs_fp = mkstemp(suffix='_seqs.fastq')
+        close(fd)
+        fd, barcodes_fp = mkstemp(suffix='_barcodes.fastq')
+        close(fd)
+        self.filepaths = [seqs_fp, barcodes_fp]
+        self.checksums = []
+        for fp in sorted(self.filepaths):
+            with open(fp, 'w') as f:
+                f.write("%s\n" % fp)
+            self.checksums.append(compute_checksum(fp))
+        self.filepaths_types = ["raw_forward_seqs", "raw_barcodes"]
+        self._clean_up_files = [seqs_fp, barcodes_fp]
+
+        info = {
+            "timeseries_type_id": 1,
+            "metadata_complete": True,
+            "mixs_compliant": True,
+            "number_samples_collected": 25,
+            "number_samples_promised": 28,
+            "study_alias": "FCM",
+            "study_description": "Microbiome of people who eat nothing but "
+                                 "fried chicken",
+            "study_abstract": "Exploring how a high fat diet changes the "
+                              "gut microbiome",
+            "emp_person_id": StudyPerson(2),
+            "principal_investigator_id": StudyPerson(3),
+            "lab_person_id": StudyPerson(1)
+        }
+        self.new_study = Study.create(User("test@foo.bar"),
+                                      "Update raw data test",
+                                      efo=[1], info=info)
+        self.study = Study(1)
+        # The files for the RawData object attached to study 1 does not exist.
+        # Create them so we can actually perform the tests
+        for _, fp, _ in RawData(1).get_filepaths():
+            with open(fp, 'w') as f:
+                f.write('\n')
+            self._clean_up_files.append(fp)
+
+    def tearDown(self):
+        for f in self._clean_up_files:
+            if exists(f):
+                remove(f)
+
+    def test_update_raw_data_from_cmd_diff_length(self):
+        with self.assertRaises(ValueError):
+            update_raw_data_from_cmd(self.filepaths[1:], self.filepaths_types,
+                                     self.study.id)
+        with self.assertRaises(ValueError):
+            update_raw_data_from_cmd(self.filepaths, self.filepaths_types[1:],
+                                     self.study.id)
+
+    def test_update_raw_data_from_cmd_no_raw_data(self):
+        with self.assertRaises(ValueError):
+            update_raw_data_from_cmd(self.filepaths, self.filepaths_types,
+                                     self.new_study.id)
+
+    def test_update_raw_data_from_cmd_wrong_raw_data_id(self):
+        # Using max(raw_data_ids) + 1 to make sure that the raw data id
+        # passed does not belong to the study
+        with self.assertRaises(ValueError):
+            update_raw_data_from_cmd(self.filepaths, self.filepaths_types,
+                                     self.study.id,
+                                     max(self.study.raw_data()) + 1)
+
+    def test_update_raw_data_from_cmd(self):
+        rd = update_raw_data_from_cmd(self.filepaths, self.filepaths_types,
+                                      self.study.id)
+        # Make sure that we are cleaning the environment
+        for _, fp, _ in rd.get_filepaths():
+            self._clean_up_files.append(fp)
+
+        # The checkums are in filepath order. If we sort the rd.get_filepath()
+        # result by the filepath (itemgetter(1)) we will get them in the same
+        # order, so the checksums will not fail
+        for obs, exp in zip(sorted(rd.get_filepaths(), key=itemgetter(1)),
+                            self.checksums):
+            self.assertEqual(compute_checksum(obs[1]), exp)
+
+    def test_update_raw_data_from_cmd_rd_id(self):
+        rd = update_raw_data_from_cmd(self.filepaths, self.filepaths_types,
+                                      self.study.id, self.study.raw_data()[0])
+        # Make sure that we are cleaning the environment
+        for _, fp, _ in rd.get_filepaths():
+            self._clean_up_files.append(fp)
+
+        # The checkums are in filepath order. If we sort the rd.get_filepath()
+        # result by the filepath (itemgetter(1)) we will get them in the same
+        # order, so the checksums will not fail
+        for obs, exp in zip(sorted(rd.get_filepaths(), key=itemgetter(1)),
+                            self.checksums):
+            self.assertEqual(compute_checksum(obs[1]), exp)
 
 
 @qiita_test_checker()

--- a/qiita_db/test/test_commands.py
+++ b/qiita_db/test/test_commands.py
@@ -31,7 +31,8 @@ from qiita_db.study import Study, StudyPerson
 from qiita_db.user import User
 from qiita_db.data import PreprocessedData, RawData
 from qiita_db.util import (get_count, check_count, get_db_files_base_dir,
-                           get_mountpoint, compute_checksum)
+                           get_mountpoint, compute_checksum,
+                           get_files_from_uploads_folders)
 from qiita_db.metadata_template import PrepTemplate
 from qiita_core.util import qiita_test_checker
 from qiita_ware.processing_pipeline import generate_demux_file
@@ -496,7 +497,15 @@ class TestUpdateRawDataFromCmd(TestCase):
                 f.write('\n')
             self._clean_up_files.append(fp)
 
+        self.uploaded_files = get_files_from_uploads_folders(
+            str(self.study.id))
+
     def tearDown(self):
+        new_uploaded_files = get_files_from_uploads_folders(str(self.study.id))
+        new_files = set(new_uploaded_files).difference(self.uploaded_files)
+        path_builder = partial(join, get_mountpoint("uploads")[0][1], '1')
+        for _, fp in new_files:
+            self._clean_up_files.append(path_builder(fp))
         for f in self._clean_up_files:
             if exists(f):
                 remove(f)

--- a/scripts/qiita
+++ b/scripts/qiita
@@ -30,6 +30,7 @@ from qiita_db.commands import (load_sample_template_from_cmd,
                                load_preprocessed_data_from_cmd,
                                load_prep_template_from_cmd,
                                load_parameters_from_cmd, SUPPORTED_PARAMS,
+                               update_raw_data_from_cmd,
                                update_preprocessed_data_from_cmd)
 from qiita_db.portal import Portal
 from qiita_db.sql_connection import SQLConnectionHandler
@@ -279,6 +280,25 @@ def load_parameters(fp, table, name):
 
 
 @db.command()
+@click.option('--fp', required=True, type=click.Path(resolve_path=True,
+              readable=True, exists=True), multiple=True,
+              help='Path to the raw data file. This option can be used '
+              'multiple times if there are multiple raw data files.')
+@click.option('--fp_type', required=True, multiple=True, help='Describes the '
+              'contents of the file. Pass one fp_type per fp.',
+              type=click.Choice(get_filepath_types().keys()))
+@click.option('--study', required=True, type=int,
+              help='Study whose raw data will be updated')
+@click.option('--raw_data', required=False, type=int,
+              help='Raw data to be updated. If not passed, the raw data with '
+                   'lowest id in the study will be updated.')
+def update_raw_data(fp, fp_type, study, raw_data):
+    """Updates the raw data with the provided raw data files"""
+    rd = update_raw_data_from_cmd(fp, fp_type, study, rd_id=raw_data)
+    click.echo("Raw data %s successfully updated" % rd.id)
+
+
+@db.command()
 @click.argument('sl_out_dir', required=True,
                 type=click.Path(resolve_path=True, readable=True, exists=True,
                                 file_okay=False))
@@ -293,13 +313,6 @@ def update_preprocessed_data(sl_out_dir, study,  preprocessed_data):
     ppd = update_preprocessed_data_from_cmd(sl_out_dir, study,
                                             preprocessed_data)
     click.echo("Preprocessed data %s successfully updated" % ppd.id)
-
-
-@db.command()
-def update_raw_data():
-    """"""
-    rd = update_raw_data_from_cmd()
-    click.echo("Raw data %s successfully updated" % rd.id)
 
 # #############################################################################
 # PORTAL COMMANDS

--- a/scripts/qiita
+++ b/scripts/qiita
@@ -294,6 +294,13 @@ def update_preprocessed_data(sl_out_dir, study,  preprocessed_data):
                                             preprocessed_data)
     click.echo("Preprocessed data %s successfully updated" % ppd.id)
 
+
+@db.command()
+def update_raw_data():
+    """"""
+    rd = update_raw_data_from_cmd()
+    click.echo("Raw data %s successfully updated" % rd.id)
+
 # #############################################################################
 # PORTAL COMMANDS
 # #############################################################################

--- a/scripts/qiita
+++ b/scripts/qiita
@@ -287,9 +287,9 @@ def load_parameters(fp, table, name):
 @click.option('--fp_type', required=True, multiple=True, help='Describes the '
               'contents of the file. Pass one fp_type per fp.',
               type=click.Choice(get_filepath_types().keys()))
-@click.option('--study', required=True, type=int,
+@click.option('--study', required=True, type=click.IntRange(1),
               help='Study whose raw data will be updated')
-@click.option('--raw_data', required=False, type=int,
+@click.option('--raw_data', required=False, type=click.IntRange(1),
               help='Raw data to be updated. If not passed, the raw data with '
                    'lowest id in the study will be updated.')
 def update_raw_data(fp, fp_type, study, raw_data):


### PR DESCRIPTION
Adds a command to be able to update the files attached to a raw data object - similar to what we have for update preprocessed data.

This is needed to update the EMP data uploaded at the beginning of Qiita, and this can be useful for any future problems.

@antgonza able to review?