### PR TITLE
Fixing update code

### DIFF
--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -1160,19 +1160,15 @@ class MetadataTemplate(QiitaObject):
                     % ', '.join(columns_diff))
 
             # In order to speed up some computation, let's compare only the
-            # common columns. current_map.columns is a superset of
-            # new_map.columns, so this will not fail
-            current_map = current_map[new_map.columns]
+            # common columns and rows. current_map.columns and
+            # current_map.index are supersets of new_map.columns and
+            # new_map.index, respectivelly, so this will not fail
+            current_map = current_map[new_map.columns].loc[new_map.index]
 
             # Get the values that we need to change
             # diff_map is a DataFrame that hold boolean values. If a cell is
             # True, means that the new_map is different from the current_map
             # while False means that the cell has the same value
-            # In order to compare them, they've to be identically labeled, so
-            # we need to sort the 'index' axis to be identically labeled. The
-            # 'column' axis is already the same given the previous line of code
-            current_map.sort_index(axis='index', inplace=True)
-            new_map.sort_index(axis='index', inplace=True)
             diff_map = current_map != new_map
             # ne_stacked holds a MultiIndexed DataFrame in which the first
             # level of indexing is the sample_name and the second one is the

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -1301,6 +1301,19 @@ class TestSampleTemplateReadWrite(BaseTestSampleTemplate):
         with self.assertRaises(QiitaDBError):
             st.update(self.metadata_dict_updated_column_error)
 
+    def test_update_fewer_samples(self):
+        """Updates using a dataframe with less samples that in the DB"""
+        st = SampleTemplate.create(self.metadata, self.new_study)
+        new_metadata = pd.DataFrame.from_dict(
+            {'Sample1': {'physical_specimen_location': 'CHANGE'}},
+            orient='index')
+        exp = {s_id: st[s_id]._to_dict() for s_id in st}
+        s_id = '%d.Sample1' % self.new_study.id
+        exp[s_id]['physical_specimen_location'] = 'CHANGE'
+        npt.assert_warns(QiitaDBWarning, st.update, new_metadata)
+        obs = {s_id: st[s_id]._to_dict() for s_id in st}
+        self.assertEqual(obs, exp)
+
     def test_update_numpy(self):
         """Update values in existing mapping file with numpy values"""
         metadata_dict = {


### PR DESCRIPTION
There is an error in the update code: if you try to update the sample template with a dataframe (i.e. a new sample template) that has less samples that the one in the database, the current system will fail with the lovely error: `Can only compare identically-labeled DataFrame objects`

However, this should be allowed: if I submit a new sample template with only one row and one column, because I want to update only such value, I should be able to do it. This can minimize the errors introduced during sample template updates.

Another advantage of this, is that then I can use the interface to extend the current sample template by adding only the new samples (and leave the old ones as they're). Since the interface performs the extend and update at the same time, this was failing, but now this is possible.

@antgonza @ElDeveloper possible a quick review here? This will be needed for the AG work