### PR TITLE
Fixing error in 1497

### DIFF
--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -506,7 +506,8 @@ class MetadataTemplate(QiitaObject):
         return "%s%d" % (cls._table_prefix, obj_id)
 
     @classmethod
-    def _clean_validate_template(cls, md_template, study_id, restriction_dict):
+    def _clean_validate_template(cls, md_template, study_id, restriction_dict,
+                                 current_columns=None):
         """Takes care of all validation and cleaning of metadata templates
 
         Parameters
@@ -517,6 +518,8 @@ class MetadataTemplate(QiitaObject):
             The study to which the metadata template belongs to.
         restriction_dict : dict of {str: Restriction}
             A dictionary with the restrictions that apply to the metadata
+        current_columns : iterable of str, optional
+            The current list of metadata columns
 
         Returns
         -------
@@ -560,8 +563,11 @@ class MetadataTemplate(QiitaObject):
 
         # Check if we have the columns required for some functionality
         warning_msg = []
+        columns = set(md_template.columns)
+        if current_columns:
+            columns.update(current_columns)
         for key, restriction in viewitems(restriction_dict):
-            missing = set(restriction.columns).difference(md_template)
+            missing = set(restriction.columns).difference(columns)
 
             if missing:
                 warning_msg.append(
@@ -1115,7 +1121,8 @@ class MetadataTemplate(QiitaObject):
         """
         with TRN:
             md_template = self._clean_validate_template(
-                md_template, self.study_id, self.columns_restrictions)
+                md_template, self.study_id, self.columns_restrictions,
+                current_columns=self.categories())
             self._common_extend_steps(md_template)
             self.generate_files()
 
@@ -1139,8 +1146,9 @@ class MetadataTemplate(QiitaObject):
         """
         with TRN:
             # Clean and validate the metadata template given
-            new_map = self._clean_validate_template(md_template, self.study_id,
-                                                    self.columns_restrictions)
+            new_map = self._clean_validate_template(
+                md_template, self.study_id, self.columns_restrictions,
+                current_columns=self.categories())
             # Retrieving current metadata
             current_map = self.to_dataframe()
 

--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -1185,6 +1185,8 @@ class MetadataTemplate(QiitaObject):
                     "There are no differences between the data stored in the "
                     "DB and the new data provided",
                     QiitaDBWarning)
+                return
+
             changed.index.names = ['sample_name', 'column']
             # the combination of np.where and boolean indexing produces
             # a numpy array with only the values that actually changed

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -716,6 +716,38 @@ class TestSampleTemplateReadOnly(BaseTestSampleTemplate):
         exp.sort_index(axis=1, inplace=True)
         assert_frame_equal(obs, exp)
 
+    def test_clean_validate_template_columns(self):
+        metadata_dict = {
+            'Sample1': {'physical_specimen_location': 'location1',
+                        'physical_specimen_remaining': True,
+                        'dna_extracted': True,
+                        'sample_type': 'type1',
+                        'host_subject_id': 'NotIdentified',
+                        'Description': 'Test Sample 1',
+                        'latitude': 42.42,
+                        'longitude': 41.41}
+            }
+        metadata = pd.DataFrame.from_dict(metadata_dict, orient='index')
+        cols = ['collection_timestamp', 'taxon_id', 'scientific_name']
+        obs = SampleTemplate._clean_validate_template(
+            metadata, 2, SAMPLE_TEMPLATE_COLUMNS, current_columns=cols)
+        metadata_dict = {
+            '2.Sample1': {'physical_specimen_location': 'location1',
+                          'physical_specimen_remaining': True,
+                          'dna_extracted': True,
+                          'sample_type': 'type1',
+                          'host_subject_id': 'NotIdentified',
+                          'description': 'Test Sample 1',
+                          'latitude': 42.42,
+                          'longitude': 41.41}
+            }
+        exp = pd.DataFrame.from_dict(metadata_dict, orient='index')
+        obs.sort_index(axis=0, inplace=True)
+        obs.sort_index(axis=1, inplace=True)
+        exp.sort_index(axis=0, inplace=True)
+        exp.sort_index(axis=1, inplace=True)
+        assert_frame_equal(obs, exp)
+
     def test_clean_validate_template(self):
         obs = SampleTemplate._clean_validate_template(self.metadata, 2,
                                                       SAMPLE_TEMPLATE_COLUMNS)
@@ -1247,7 +1279,7 @@ class TestSampleTemplateReadWrite(BaseTestSampleTemplate):
         exp = {s_id: st[s_id]._to_dict() for s_id in st}
         s_id = '%d.Sample1' % self.new_study.id
         exp[s_id]['physical_specimen_location'] = 'CHANGE'
-        npt.assert_warns(QiitaDBWarning, st.update, new_metadata)
+        st.update(new_metadata)
         obs = {s_id: st[s_id]._to_dict() for s_id in st}
         self.assertEqual(obs, exp)
 

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -1201,6 +1201,17 @@ class TestSampleTemplateReadWrite(BaseTestSampleTemplate):
 
         self.assertEqual(before, after)
 
+    def test_update_equal(self):
+        """It doesn't fail with the exact same template"""
+        # Create a new sample tempalte
+        st = SampleTemplate.create(self.metadata, self.new_study)
+        exp = {s_id: st[s_id]._to_dict() for s_id in st}
+        # Try to update the sample template with the same values
+        npt.assert_warns(QiitaDBWarning, st.update, self.metadata)
+        # Check that no values have been changed
+        obs = {s_id: st[s_id]._to_dict() for s_id in st}
+        self.assertEqual(obs, exp)
+
     def test_update(self):
         """Updates values in existing mapping file"""
         # creating a new sample template


### PR DESCRIPTION
Fixes the error described in https://github.com/biocore/qiita/issues/1497.

The warning require more thought since the problem is that for creation and update/extend we are using the same function, but the functionality of such method for update/extend is slightly different (i.e. it should warn if the data is not in the DB already). Doing this efficiently and w/o code duplication is a bit more tricky.