### PR TITLE
EBI modify

### DIFF
--- a/qiita_ware/commands.py
+++ b/qiita_ware/commands.py
@@ -71,7 +71,8 @@ def submit_EBI(preprocessed_data_id, action, send):
                         stdout = ''
                         stderr = str(e)
                         le = LogEntry.create(
-                            'Fatal', "Command: %s\nError: %s\n" % (cmd, str(e)),
+                            'Fatal', "Command: %s\nError: %s\n" % (cmd,
+                                                                   str(e)),
                             info={'ebi_submission': preprocessed_data_id})
                         ebi_submission.study.ebi_submission_status = (
                             "failed: ASCP submission, log id: %d" % le.id)

--- a/qiita_ware/ebi.py
+++ b/qiita_ware/ebi.py
@@ -695,7 +695,8 @@ class EBISubmission(object):
             i = 0
             while True:
                 self.sample_xml_fp = get_output_fp('sample_%d.xml' % i)
-                if not exists(self.sample_xml_fp): break
+                if not exists(self.sample_xml_fp):
+                    break
                 i = i + 1
             self.write_xml_file(self.generate_sample_xml(samples),
                                 self.sample_xml_fp)
@@ -704,7 +705,8 @@ class EBISubmission(object):
             i = 0
             while True:
                 self.experiment_xml_fp = get_output_fp('experiment_%d.xml' % i)
-                if not exists(self.experiment_xml_fp): break
+                if not exists(self.experiment_xml_fp):
+                    break
                 i = i + 1
             self.write_xml_file(self.generate_experiment_xml(samples),
                                 self.experiment_xml_fp)
@@ -713,7 +715,8 @@ class EBISubmission(object):
             i = 0
             while True:
                 self.submission_xml_fp = get_output_fp('submission_%d.xml' % i)
-                if not exists(self.submission_xml_fp): break
+                if not exists(self.submission_xml_fp):
+                    break
                 i = i + 1
 
         # The submission.xml is always generated

--- a/qiita_ware/ebi.py
+++ b/qiita_ware/ebi.py
@@ -278,6 +278,8 @@ class EBISubmission(object):
                                      data_dict):
         """Format key/value data using a common EBI XML motif"""
         for attr, val in sorted(data_dict.items()):
+            if val is None:
+                val = "Unknown"
             attribute_element = ET.SubElement(parent_node,
                                               attribute_element_name)
             tag = ET.SubElement(attribute_element, 'TAG')
@@ -711,7 +713,7 @@ class EBISubmission(object):
             self.write_xml_file(self.generate_experiment_xml(samples),
                                 self.experiment_xml_fp)
 
-            # finding unique name for experiment xml
+            # finding unique name for run xml
             i = 0
             while True:
                 self.submission_xml_fp = get_output_fp('submission_%d.xml' % i)

--- a/qiita_ware/test/test_ebi.py
+++ b/qiita_ware/test/test_ebi.py
@@ -131,7 +131,9 @@ class TestEBISubmissionReadOnly(TestEBISubmission):
         e = EBISubmission(2, 'ADD')
         elm = ET.Element('TESTING', {'foo': 'bar'})
 
-        e._add_dict_as_tags_and_values(elm, 'foo', {'x': 'y', '>x': '<y'})
+        e._add_dict_as_tags_and_values(elm, 'foo', {'x': 'y',
+                                                    '>x': '<y',
+                                                    'none': None})
         obs = ET.tostring(elm)
         exp = ''.join([v.strip() for v in ADDDICTTEST.splitlines()])
         self.assertEqual(obs, exp)
@@ -315,7 +317,8 @@ class TestEBISubmissionWriteRead(TestEBISubmission):
                                 'experiment_design_description':
                                     'microbiome of soil and rhizosphere',
                                 'library_construction_protocol':
-                                    'PMID: 22402401'},
+                                    'PMID: 22402401',
+                                'extra_value': 1.2},
                 'SKD9.640182': {'center_name': 'ANL',
                                 'center_project_name': 'Test Project',
                                 'platform': 'ILLUMINA',
@@ -324,7 +327,8 @@ class TestEBISubmissionWriteRead(TestEBISubmission):
                                 'experiment_design_description':
                                     'microbiome of soil and rhizosphere',
                                 'library_construction_protocol':
-                                    'PMID: 22402401'}
+                                    'PMID: 22402401',
+                                'extra_value': 'Unspecified'}
             }
             investigation_type = "Metagenomics"
         metadata = pd.DataFrame.from_dict(metadata_dict, orient='index')
@@ -1158,7 +1162,7 @@ sequencer adapter regions.
         <TAG>center_name</TAG><VALUE>ANL</VALUE>
       </EXPERIMENT_ATTRIBUTE>
       <EXPERIMENT_ATTRIBUTE>
-        <TAG>center_project_name</TAG><VALUE>None</VALUE>
+        <TAG>center_project_name</TAG><VALUE>Unknown</VALUE>
       </EXPERIMENT_ATTRIBUTE>
       <EXPERIMENT_ATTRIBUTE>
         <TAG>emp_status</TAG><VALUE>EMP</VALUE>
@@ -1246,7 +1250,7 @@ sequencer adapter regions.
         <TAG>center_name</TAG><VALUE>ANL</VALUE>
       </EXPERIMENT_ATTRIBUTE>
       <EXPERIMENT_ATTRIBUTE>
-        <TAG>center_project_name</TAG><VALUE>None</VALUE>
+        <TAG>center_project_name</TAG><VALUE>Unknown</VALUE>
       </EXPERIMENT_ATTRIBUTE>
       <EXPERIMENT_ATTRIBUTE>
         <TAG>emp_status</TAG><VALUE>EMP</VALUE>
@@ -1426,6 +1430,10 @@ ADDDICTTEST = """<TESTING foo="bar">
     <foo>
         <TAG>&gt;x</TAG>
         <VALUE>&lt;y</VALUE>
+    </foo>
+    <foo>
+        <TAG>none</TAG>
+        <VALUE>Unknown</VALUE>
     </foo>
     <foo>
         <TAG>x</TAG>


### PR DESCRIPTION
Sends modified sample/prep template to EBI.

Notes
- sample template == sample xml, prep template == experiment xml
- This could be done via GUI or CLI but GUI doesn't show the button as I think this should be a CLI only option. Additionally, this simplifies the code as we don't need to keep tract of changes between EBI and prep/sample.
- EBI uses the submission name and the sample names to know which samples are being submitted. Thus, we can simply regenerate the sample/prep templates and resubmit and don't need to add the EBI generated names
- I tested the code against the test server and it works and expected.
- Surprisingly, perhaps based on what previous devs tolds, EBI actually can receive both sample/prep templates and it recognizes if the new xml is the same or not, which allows us to always submit the sample/prep templates.  