### PR TITLE
Fixing a bunch of tests

### DIFF
--- a/qiita_db/job.py
+++ b/qiita_db/job.py
@@ -129,11 +129,11 @@ class Job(qdb.base.QiitaStatusObject):
                 return False
 
             # build the samples dict as list of samples keyed to
-            # their proc_data_id
-            sql = """SELECT processed_data_id, array_agg(
+            # their artifact_id
+            sql = """SELECT artifact_id, array_agg(
                         sample_id ORDER BY sample_id)
                      FROM qiita.analysis_sample
-                     WHERE analysis_id = %s GROUP BY processed_data_id"""
+                     WHERE analysis_id = %s GROUP BY artifact_id"""
             qdb.sql_connection.TRN.add(sql, [analysis.id])
             samples = dict(qdb.sql_connection.TRN.execute_fetchindex())
 

--- a/qiita_db/test/test_base.py
+++ b/qiita_db/test/test_base.py
@@ -11,11 +11,7 @@ from unittest import TestCase, main
 from qiita_core.exceptions import IncompetentQiitaDeveloperError
 from qiita_core.util import qiita_test_checker
 from qiita_core.qiita_settings import qiita_config
-from qiita_db.base import QiitaObject, QiitaStatusObject
-from qiita_db.exceptions import QiitaDBUnknownIDError
-from qiita_db.data import RawData
-from qiita_db.study import Study, StudyPerson
-from qiita_db.analysis import Analysis
+import qiita_db as qdb
 
 
 @qiita_test_checker()
@@ -24,7 +20,7 @@ class QiitaBaseTest(TestCase):
 
     def setUp(self):
         # We need an actual subclass in order to test the equality functions
-        self.tester = RawData(1)
+        self.tester = qdb.artifact.Artifact(1)
         self.portal = qiita_config.portal
 
     def tearDown(self):
@@ -33,12 +29,12 @@ class QiitaBaseTest(TestCase):
     def test_init_base_error(self):
         """Raises an error when instantiating a base class directly"""
         with self.assertRaises(IncompetentQiitaDeveloperError):
-            QiitaObject(1)
+            qdb.base.QiitaObject(1)
 
     def test_init_error_inexistent(self):
         """Raises an error when instantiating an object that does not exists"""
-        with self.assertRaises(QiitaDBUnknownIDError):
-            RawData(10)
+        with self.assertRaises(qdb.exceptions.QiitaDBUnknownIDError):
+            qdb.artifact.Artifact(10)
 
     def test_check_subclass(self):
         """Nothing happens if check_subclass called from a subclass"""
@@ -48,9 +44,9 @@ class QiitaBaseTest(TestCase):
         """check_subclass raises an error if called from a base class"""
         # Checked through the __init__ call
         with self.assertRaises(IncompetentQiitaDeveloperError):
-            QiitaObject(1)
+            qdb.base.QiitaObject(1)
         with self.assertRaises(IncompetentQiitaDeveloperError):
-            QiitaStatusObject(1)
+            qdb.base.QiitaStatusObject(1)
 
     def test_check_id(self):
         """Correctly checks if an id exists on the database"""
@@ -60,7 +56,7 @@ class QiitaBaseTest(TestCase):
     def test_check_portal(self):
         """Correctly checks if object is accessable in portal given"""
         qiita_config.portal = 'QIITA'
-        tester = Analysis(1)
+        tester = qdb.analysis.Analysis(1)
         self.assertTrue(tester._check_portal(1))
         qiita_config.portal = 'EMP'
         self.assertFalse(tester._check_portal(1))
@@ -73,18 +69,18 @@ class QiitaBaseTest(TestCase):
 
     def test_equal(self):
         """Equality works with two objects pointing to the same instance"""
-        new = RawData(1)
+        new = qdb.artifact.Artifact(1)
         self.assertEqual(self.tester, new)
 
     def test_not_equal(self):
         """Not equals works with object of the same type"""
-        sp1 = StudyPerson(1)
-        sp2 = StudyPerson(2)
+        sp1 = qdb.study.StudyPerson(1)
+        sp2 = qdb.study.StudyPerson(2)
         self.assertNotEqual(sp1, sp2)
 
     def test_not_equal_type(self):
         """Not equals works with object of different type"""
-        new = Study(1)
+        new = qdb.study.Study(1)
         self.assertNotEqual(self.tester, new)
 
 
@@ -94,7 +90,7 @@ class QiitaStatusObjectTest(TestCase):
 
     def setUp(self):
         # We need an actual subclass in order to test the equality functions
-        self.tester = Analysis(1)
+        self.tester = qdb.analysis.Analysis(1)
 
     def test_status(self):
         """Correctly returns the status of the object"""

--- a/qiita_db/test/test_logger.py
+++ b/qiita_db/test/test_logger.py
@@ -9,50 +9,52 @@
 from unittest import TestCase, main
 
 from qiita_core.util import qiita_test_checker
-from qiita_db.exceptions import QiitaDBLookupError
-from qiita_db.logger import LogEntry
+import qiita_db as qdb
 
 
 @qiita_test_checker()
 class LoggerTests(TestCase):
     def test_create_log_entry(self):
         """"""
-        LogEntry.create('Runtime', 'runtime message')
-        LogEntry.create('Fatal', 'fatal message', info={1: 2})
-        LogEntry.create('Warning', 'warning message', info={9: 0})
-        with self.assertRaises(QiitaDBLookupError):
+        qdb.logger.LogEntry.create('Runtime', 'runtime message')
+        qdb.logger.LogEntry.create('Fatal', 'fatal message', info={1: 2})
+        qdb.logger.LogEntry.create('Warning', 'warning message', info={9: 0})
+        with self.assertRaises(qdb.exceptions.QiitaDBLookupError):
             # This severity level does not exist in the test schema
-            LogEntry.create('Chicken', 'warning message',
-                            info={9: 0})
+            qdb.logger.LogEntry.create('Chicken', 'warning message',
+                                       info={9: 0})
 
     def test_severity_property(self):
         """"""
-        log_entry = LogEntry.create('Warning', 'warning test', info=None)
+        log_entry = qdb.logger.LogEntry.create('Warning', 'warning test',
+                                               info=None)
         self.assertEqual(log_entry.severity, 1)
 
     def test_time_property(self):
         """"""
         sql = "SELECT localtimestamp"
         before = self.conn_handler.execute_fetchone(sql)[0]
-        log_entry = LogEntry.create('Warning', 'warning test', info=None)
+        log_entry = qdb.logger.LogEntry.create(
+            'Warning', 'warning test', info=None)
         after = self.conn_handler.execute_fetchone(sql)[0]
         self.assertTrue(before < log_entry.time < after)
 
     def test_info_property(self):
         """"""
-        log_entry = LogEntry.create('Warning', 'warning test',
-                                    info={1: 2, 'test': 'yeah'})
+        log_entry = qdb.logger.LogEntry.create(
+            'Warning', 'warning test', info={1: 2, 'test': 'yeah'})
         self.assertEqual(log_entry.info, [{'1': 2, 'test': 'yeah'}])
 
     def test_message_property(self):
         """"""
-        log_entry = LogEntry.create('Warning', 'warning test', info=None)
+        log_entry = qdb.logger.LogEntry.create(
+            'Warning', 'warning test', info=None)
         self.assertEqual(log_entry.msg, 'warning test')
 
     def test_add_info(self):
         """"""
-        log_entry = LogEntry.create('Warning', 'warning test',
-                                    info={1: 2, 'test': 'yeah'})
+        log_entry = qdb.logger.LogEntry.create(
+            'Warning', 'warning test', info={1: 2, 'test': 'yeah'})
         log_entry.add_info({'another': 'set', 'of': 'entries', 'test': 3})
         self.assertEqual(log_entry.info, [{'1': 2, 'test': 'yeah'},
                                           {'another': 'set', 'of': 'entries',
@@ -60,8 +62,8 @@ class LoggerTests(TestCase):
 
     def test_clear_info(self):
         """"""
-        log_entry = LogEntry.create('Warning', 'warning test',
-                                    info={1: 2, 'test': 'yeah'})
+        log_entry = qdb.logger.LogEntry.create(
+            'Warning', 'warning test', info={1: 2, 'test': 'yeah'})
         log_entry.clear_info()
         self.assertEqual(log_entry.info, [])
 

--- a/qiita_db/test/test_ontology.py
+++ b/qiita_db/test/test_ontology.py
@@ -9,20 +9,20 @@
 from unittest import TestCase, main
 
 from qiita_core.util import qiita_test_checker
-from qiita_db.ontology import Ontology
-from qiita_db.util import convert_from_id, convert_to_id
+import qiita_db as qdb
 
 
 @qiita_test_checker()
 class TestOntology(TestCase):
     def setUp(self):
-        self.ontology = Ontology(999999999)
+        self.ontology = qdb.ontology.Ontology(999999999)
 
     def testConvertToID(self):
-        self.assertEqual(convert_to_id('ENA', 'ontology'), 999999999)
+        self.assertEqual(qdb.util.convert_to_id('ENA', 'ontology'), 999999999)
 
     def testConvertFromID(self):
-        self.assertEqual(convert_from_id(999999999, 'ontology'), 'ENA')
+        self.assertEqual(
+            qdb.util.convert_from_id(999999999, 'ontology'), 'ENA')
 
     def testShortNameProperty(self):
         self.assertEqual(self.ontology.shortname, 'ENA')

--- a/qiita_db/test/test_parameters.py
+++ b/qiita_db/test/test_parameters.py
@@ -11,16 +11,14 @@ from tempfile import mkstemp
 from os import close
 
 from qiita_core.util import qiita_test_checker
-from qiita_db.parameters import (PreprocessedIlluminaParams,
-                                 ProcessedSortmernaParams)
-from qiita_db.exceptions import QiitaDBDuplicateError
+import qiita_db as qdb
 
 
 @qiita_test_checker()
 class PreprocessedIlluminaParamsTests(TestCase):
 
     def test_exists(self):
-        obs = PreprocessedIlluminaParams.exists(
+        obs = qdb.parameters.PreprocessedIlluminaParams.exists(
             max_bad_run_length=3,
             min_per_read_length_fraction=0.75,
             sequence_max_n=0,
@@ -32,7 +30,7 @@ class PreprocessedIlluminaParamsTests(TestCase):
             max_barcode_errors=1.5)
         self.assertTrue(obs)
 
-        obs = PreprocessedIlluminaParams.exists(
+        obs = qdb.parameters.PreprocessedIlluminaParams.exists(
             max_bad_run_length=3,
             min_per_read_length_fraction=0.75,
             sequence_max_n=0,
@@ -47,11 +45,12 @@ class PreprocessedIlluminaParamsTests(TestCase):
     def test_check_columns(self):
         # Check missing columns
         with self.assertRaises(ValueError):
-            PreprocessedIlluminaParams._check_columns(barcode_type=8)
+            qdb.parameters.PreprocessedIlluminaParams._check_columns(
+                barcode_type=8)
 
         # Check extra columns
         with self.assertRaises(ValueError):
-            PreprocessedIlluminaParams._check_columns(
+            qdb.parameters.PreprocessedIlluminaParams._check_columns(
                 max_bad_run_length=3,
                 min_per_read_length_fraction=0.75,
                 sequence_max_n=0,
@@ -64,7 +63,7 @@ class PreprocessedIlluminaParamsTests(TestCase):
                 extra_columns="Foo")
 
         # Does not raise any error
-        PreprocessedIlluminaParams._check_columns(
+        qdb.parameters.PreprocessedIlluminaParams._check_columns(
             max_bad_run_length=3,
             min_per_read_length_fraction=0.75,
             sequence_max_n=0,
@@ -76,7 +75,7 @@ class PreprocessedIlluminaParamsTests(TestCase):
             max_barcode_errors=1.5)
 
     def test_create(self):
-        obs_obj = PreprocessedIlluminaParams.create(
+        obs_obj = qdb.parameters.PreprocessedIlluminaParams.create(
             "test_create",
             max_bad_run_length="3",
             min_per_read_length_fraction="0.75",
@@ -95,8 +94,8 @@ class PreprocessedIlluminaParamsTests(TestCase):
         self.assertEqual(obs, exp)
 
     def test_create_duplicate(self):
-        with self.assertRaises(QiitaDBDuplicateError):
-            PreprocessedIlluminaParams.create(
+        with self.assertRaises(qdb.exceptions.QiitaDBDuplicateError):
+            qdb.parameters.PreprocessedIlluminaParams.create(
                 "test_error",
                 max_bad_run_length=3,
                 min_per_read_length_fraction=0.75,
@@ -109,7 +108,7 @@ class PreprocessedIlluminaParamsTests(TestCase):
                 max_barcode_errors=1.5)
 
     def test_to_str(self):
-        params = PreprocessedIlluminaParams(1)
+        params = qdb.parameters.PreprocessedIlluminaParams(1)
         obs = params.to_str()
         exp = ("--barcode_type golay_12 --max_bad_run_length 3 "
                "--max_barcode_errors 1.5 --min_per_read_length_fraction 0.75 "
@@ -117,18 +116,18 @@ class PreprocessedIlluminaParamsTests(TestCase):
         self.assertEqual(obs, exp)
 
     def test_iter(self):
-        obs = list(PreprocessedIlluminaParams.iter())
-        exp = [PreprocessedIlluminaParams(1)]
+        obs = list(qdb.parameters.PreprocessedIlluminaParams.iter())
+        exp = [qdb.parameters.PreprocessedIlluminaParams(1)]
 
         for o, e in zip(obs, exp):
             self.assertEqual(o.id, e.id)
 
     def test_name(self):
-        obs = PreprocessedIlluminaParams(1).name
+        obs = qdb.parameters.PreprocessedIlluminaParams(1).name
         self.assertEqual(obs, "Defaults")
 
     def test_values(self):
-        obs = PreprocessedIlluminaParams(1).values
+        obs = qdb.parameters.PreprocessedIlluminaParams(1).values
         exp = {'max_barcode_errors': 1.5, 'sequence_max_n': 0,
                'max_bad_run_length': 3, 'rev_comp': False,
                'phred_quality_threshold': 3, 'rev_comp_barcode': False,
@@ -141,14 +140,14 @@ class PreprocessedIlluminaParamsTests(TestCase):
 @qiita_test_checker()
 class ProcessedSortmernaParamsTests(TestCase):
     def test_to_str(self):
-        params = ProcessedSortmernaParams(1)
+        params = qdb.parameters.ProcessedSortmernaParams(1)
         obs = params.to_str()
         exp = ("--similarity 0.97 --sortmerna_coverage 0.97 "
                "--sortmerna_e_value 1.0 --sortmerna_max_pos 10000 --threads 1")
         self.assertEqual(obs, exp)
 
     def test_to_file(self):
-        params = ProcessedSortmernaParams(1)
+        params = qdb.parameters.ProcessedSortmernaParams(1)
         fd, fp = mkstemp()
         close(fd)
         with open(fp, 'w') as f:

--- a/qiita_db/test/test_reference.py
+++ b/qiita_db/test/test_reference.py
@@ -12,8 +12,7 @@ from os.path import basename, join
 from tempfile import mkstemp
 
 from qiita_core.util import qiita_test_checker
-from qiita_db.reference import Reference
-from qiita_db.util import get_mountpoint, get_count
+import qiita_db as qdb
 
 
 @qiita_test_checker()
@@ -29,7 +28,7 @@ class ReferenceTests(TestCase):
         fd, self.tree_fp = mkstemp(suffix="_tree.tre")
         close(fd)
 
-        _, self.db_dir = get_mountpoint('reference')[0]
+        _, self.db_dir = qdb.util.get_mountpoint('reference')[0]
 
         self._clean_up_files = []
 
@@ -39,10 +38,10 @@ class ReferenceTests(TestCase):
 
     def test_create(self):
         """Correctly creates the rows in the DB for the reference"""
-        fp_count = get_count('qiita.filepath')
+        fp_count = qdb.util.get_count('qiita.filepath')
         # Check that the returned object has the correct id
-        obs = Reference.create(self.name, self.version, self.seqs_fp,
-                               self.tax_fp, self.tree_fp)
+        obs = qdb.reference.Reference.create(
+            self.name, self.version, self.seqs_fp, self.tax_fp, self.tree_fp)
         self.assertEqual(obs.id, 2)
 
         seqs_id = fp_count + 1
@@ -71,17 +70,17 @@ class ReferenceTests(TestCase):
         self.assertEqual(obs, exp)
 
     def test_sequence_fp(self):
-        ref = Reference(1)
+        ref = qdb.reference.Reference(1)
         exp = join(self.db_dir, "GreenGenes_13_8_97_otus.fasta")
         self.assertEqual(ref.sequence_fp, exp)
 
     def test_taxonomy_fp(self):
-        ref = Reference(1)
+        ref = qdb.reference.Reference(1)
         exp = join(self.db_dir, "GreenGenes_13_8_97_otu_taxonomy.txt")
         self.assertEqual(ref.taxonomy_fp, exp)
 
     def test_tree_fp(self):
-        ref = Reference(1)
+        ref = qdb.reference.Reference(1)
         exp = join(self.db_dir, "GreenGenes_13_8_97_otus.tree")
         self.assertEqual(ref.tree_fp, exp)
 

--- a/qiita_db/test/test_setup.py
+++ b/qiita_db/test/test_setup.py
@@ -35,20 +35,11 @@ class SetupTest(TestCase):
     def test_study_experimental_factor(self):
         self.assertEqual(get_count("qiita.study_experimental_factor"), 1)
 
-    def test_processed_data_status(self):
-        self.assertEqual(get_count("qiita.processed_data_status"), 4)
-
     def test_filepath(self):
         self.assertEqual(get_count("qiita.filepath"), 16)
 
     def test_filepath_type(self):
         self.assertEqual(get_count("qiita.filepath_type"), 19)
-
-    def test_raw_data(self):
-        self.assertEqual(get_count("qiita.raw_data"), 1)
-
-    def test_raw_filepath(self):
-        self.assertEqual(get_count("qiita.raw_filepath"), 2)
 
     def test_study_prep_template(self):
         self.assertEqual(get_count("qiita.study_prep_template"), 1)
@@ -74,36 +65,15 @@ class SetupTest(TestCase):
     def test_prep_1(self):
         self.assertEqual(get_count("qiita.prep_1"), 27)
 
-    def test_preprocessed_data(self):
-        self.assertEqual(get_count("qiita.preprocessed_data"), 2)
-
-    def test_prep_template_preprocessed_data(self):
-        self.assertEqual(get_count("qiita.prep_template_preprocessed_data"), 2)
-
-    def test_study_preprocessed_data(self):
-        self.assertEqual(get_count("qiita.study_preprocessed_data"), 2)
-
-    def test_preprocessed_filepath(self):
-        self.assertEqual(get_count("qiita.preprocessed_filepath"), 3)
-
     def test_preprocessed_sequence_illumina_params(self):
         self.assertEqual(
             get_count("qiita.preprocessed_sequence_illumina_params"), 7)
-
-    def test_processed_data(self):
-        self.assertEqual(get_count("qiita.processed_data"), 1)
-
-    def test_preprocessed_processed_data(self):
-        self.assertEqual(get_count("qiita.preprocessed_processed_data"), 1)
 
     def test_reference(self):
         self.assertEqual(get_count("qiita.reference"), 1)
 
     def test_processed_params_uclust(self):
         self.assertEqual(get_count("qiita.processed_params_uclust"), 1)
-
-    def test_processed_filepath(self):
-        self.assertEqual(get_count("qiita.processed_filepath"), 1)
 
     def test_job(self):
         self.assertEqual(get_count("qiita.job"), 3)

--- a/qiita_db/test/test_sql_connection.py
+++ b/qiita_db/test/test_sql_connection.py
@@ -10,9 +10,9 @@ from psycopg2.extensions import (ISOLATION_LEVEL_AUTOCOMMIT,
                                  ISOLATION_LEVEL_READ_COMMITTED,
                                  TRANSACTION_STATUS_IDLE)
 
-from qiita_db.sql_connection import SQLConnectionHandler, Transaction, TRN
 from qiita_core.util import qiita_test_checker
 from qiita_core.qiita_settings import qiita_config
+import qiita_db as qdb
 
 
 DB_TEST_TABLE = """CREATE TABLE qiita.test_table (
@@ -66,7 +66,7 @@ class TestBase(TestCase):
 
 class TestConnHandler(TestBase):
     def test_init(self):
-        obs = SQLConnectionHandler()
+        obs = qdb.sql_connection.SQLConnectionHandler()
         self.assertEqual(obs.admin, 'no_admin')
         self.assertEqual(obs.queues, {})
         self.assertTrue(isinstance(obs._connection, connection))
@@ -74,22 +74,22 @@ class TestConnHandler(TestBase):
 
         # Let's close the connection and make sure that it gets reopened
         obs.close()
-        obs = SQLConnectionHandler()
+        obs = qdb.sql_connection.SQLConnectionHandler()
         self.assertEqual(self.conn_handler._user_conn.closed, 0)
 
     def test_init_admin_error(self):
         with self.assertRaises(ValueError):
-            SQLConnectionHandler(admin='not a valid value')
+            qdb.sql_connection.SQLConnectionHandler(admin='not a valid value')
 
     def test_init_admin_with_database(self):
-        obs = SQLConnectionHandler(admin='admin_with_database')
+        obs = qdb.sql_connection.SQLConnectionHandler(admin='admin_with_database')
         self.assertEqual(obs.admin, 'admin_with_database')
         self.assertEqual(obs.queues, {})
         self.assertTrue(isinstance(obs._connection, connection))
         self.assertEqual(self.conn_handler._user_conn.closed, 0)
 
     def test_init_admin_without_database(self):
-        obs = SQLConnectionHandler(admin='admin_without_database')
+        obs = qdb.sql_connection.SQLConnectionHandler(admin='admin_without_database')
         self.assertEqual(obs.admin, 'admin_without_database')
         self.assertEqual(obs.queues, {})
         self.assertTrue(isinstance(obs._connection, connection))
@@ -208,7 +208,7 @@ class TestConnHandler(TestBase):
 
 class TestTransaction(TestBase):
     def test_init(self):
-        obs = Transaction()
+        obs = qdb.sql_connection.Transaction()
         self.assertEqual(obs._queries, [])
         self.assertEqual(obs._results, [])
         self.assertEqual(obs._connection, None)
@@ -218,74 +218,74 @@ class TestTransaction(TestBase):
         self.assertTrue(isinstance(obs._connection, connection))
 
     def test_add(self):
-        with TRN:
-            self.assertEqual(TRN._queries, [])
+        with qdb.sql_connection.TRN:
+            self.assertEqual(qdb.sql_connection.TRN._queries, [])
 
             sql1 = "INSERT INTO qiita.test_table (bool_column) VALUES (%s)"
             args1 = [True]
-            TRN.add(sql1, args1)
+            qdb.sql_connection.TRN.add(sql1, args1)
             sql2 = "INSERT INTO qiita.test_table (int_column) VALUES (1)"
-            TRN.add(sql2)
+            qdb.sql_connection.TRN.add(sql2)
             args3 = (False,)
-            TRN.add(sql1, args3)
+            qdb.sql_connection.TRN.add(sql1, args3)
             sql3 = "INSERT INTO qiita.test_table (int_column) VALEUS (%(foo)s)"
             args4 = {'foo': 1}
-            TRN.add(sql3, args4)
+            qdb.sql_connection.TRN.add(sql3, args4)
 
             exp = [(sql1, args1), (sql2, None), (sql1, args3), (sql3, args4)]
-            self.assertEqual(TRN._queries, exp)
+            self.assertEqual(qdb.sql_connection.TRN._queries, exp)
 
             # Remove queries so __exit__ doesn't try to execute it
-            TRN._queries = []
+            qdb.sql_connection.TRN._queries = []
 
     def test_add_many(self):
-        with TRN:
-            self.assertEqual(TRN._queries, [])
+        with qdb.sql_connection.TRN:
+            self.assertEqual(qdb.sql_connection.TRN._queries, [])
 
             sql = "INSERT INTO qiita.test_table (int_column) VALUES (%s)"
             args = [[1], [2], [3]]
-            TRN.add(sql, args, many=True)
+            qdb.sql_connection.TRN.add(sql, args, many=True)
 
             exp = [(sql, [1]), (sql, [2]), (sql, [3])]
-            self.assertEqual(TRN._queries, exp)
+            self.assertEqual(qdb.sql_connection.TRN._queries, exp)
 
     def test_add_error(self):
-        with TRN:
+        with qdb.sql_connection.TRN:
             with self.assertRaises(TypeError):
-                TRN.add("SELECT 42", 1)
+                qdb.sql_connection.TRN.add("SELECT 42", 1)
 
             with self.assertRaises(TypeError):
-                TRN.add("SELECT 42", {'foo': 'bar'}, many=True)
+                qdb.sql_connection.TRN.add("SELECT 42", {'foo': 'bar'}, many=True)
 
             with self.assertRaises(TypeError):
-                TRN.add("SELECT 42", [1, 1], many=True)
+                qdb.sql_connection.TRN.add("SELECT 42", [1, 1], many=True)
 
     def test_execute(self):
-        with TRN:
+        with qdb.sql_connection.TRN:
             sql = """INSERT INTO qiita.test_table (str_column, int_column)
                      VALUES (%s, %s)"""
-            TRN.add(sql, ["test_insert", 2])
+            qdb.sql_connection.TRN.add(sql, ["test_insert", 2])
             sql = """UPDATE qiita.test_table
                      SET int_column = %s, bool_column = %s
                      WHERE str_column = %s"""
-            TRN.add(sql, [20, False, "test_insert"])
-            obs = TRN.execute()
+            qdb.sql_connection.TRN.add(sql, [20, False, "test_insert"])
+            obs = qdb.sql_connection.TRN.execute()
             self.assertEqual(obs, [None, None])
             self._assert_sql_equal([])
 
         self._assert_sql_equal([("test_insert", False, 20)])
 
     def test_execute_many(self):
-        with TRN:
+        with qdb.sql_connection.TRN:
             sql = """INSERT INTO qiita.test_table (str_column, int_column)
                      VALUES (%s, %s)"""
             args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
-            TRN.add(sql, args, many=True)
+            qdb.sql_connection.TRN.add(sql, args, many=True)
             sql = """UPDATE qiita.test_table
                      SET int_column = %s, bool_column = %s
                      WHERE str_column = %s"""
-            TRN.add(sql, [20, False, 'insert2'])
-            obs = TRN.execute()
+            qdb.sql_connection.TRN.add(sql, [20, False, 'insert2'])
+            obs = qdb.sql_connection.TRN.execute()
             self.assertEqual(obs, [None, None, None, None])
 
             self._assert_sql_equal([])
@@ -295,28 +295,28 @@ class TestTransaction(TestBase):
                                 ('insert2', False, 20)])
 
     def test_execute_return(self):
-        with TRN:
+        with qdb.sql_connection.TRN:
             sql = """INSERT INTO qiita.test_table (str_column, int_column)
                      VALUES (%s, %s) RETURNING str_column, int_column"""
-            TRN.add(sql, ['test_insert', 2])
+            qdb.sql_connection.TRN.add(sql, ['test_insert', 2])
             sql = """UPDATE qiita.test_table SET bool_column = %s
                      WHERE str_column = %s RETURNING int_column"""
-            TRN.add(sql, [False, 'test_insert'])
-            obs = TRN.execute()
+            qdb.sql_connection.TRN.add(sql, [False, 'test_insert'])
+            obs = qdb.sql_connection.TRN.execute()
             self.assertEqual(obs, [[['test_insert', 2]], [[2]]])
 
     def test_execute_return_many(self):
-        with TRN:
+        with qdb.sql_connection.TRN:
             sql = """INSERT INTO qiita.test_table (str_column, int_column)
                      VALUES (%s, %s) RETURNING str_column, int_column"""
             args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
-            TRN.add(sql, args, many=True)
+            qdb.sql_connection.TRN.add(sql, args, many=True)
             sql = """UPDATE qiita.test_table SET bool_column = %s
                      WHERE str_column = %s"""
-            TRN.add(sql, [False, 'insert2'])
+            qdb.sql_connection.TRN.add(sql, [False, 'insert2'])
             sql = "SELECT * FROM qiita.test_table"
-            TRN.add(sql)
-            obs = TRN.execute()
+            qdb.sql_connection.TRN.add(sql)
+            obs = qdb.sql_connection.TRN.execute()
             exp = [[['insert1', 1]],  # First query of the many query
                    [['insert2', 2]],  # Second query of the many query
                    [['insert3', 3]],  # Third query of the many query
@@ -327,70 +327,70 @@ class TestTransaction(TestBase):
             self.assertEqual(obs, exp)
 
     def test_execute_huge_transaction(self):
-        with TRN:
+        with qdb.sql_connection.TRN:
             # Add a lot of inserts to the transaction
             sql = "INSERT INTO qiita.test_table (int_column) VALUES (%s)"
             for i in range(1000):
-                TRN.add(sql, [i])
+                qdb.sql_connection.TRN.add(sql, [i])
             # Add some updates to the transaction
             sql = """UPDATE qiita.test_table SET bool_column = %s
                      WHERE int_column = %s"""
             for i in range(500):
-                TRN.add(sql, [False, i])
+                qdb.sql_connection.TRN.add(sql, [False, i])
             # Make the transaction fail with the last insert
             sql = """INSERT INTO qiita.table_to_make (the_trans_to_fail)
                      VALUES (1)"""
-            TRN.add(sql)
+            qdb.sql_connection.TRN.add(sql)
 
             with self.assertRaises(ValueError):
-                TRN.execute()
+                qdb.sql_connection.TRN.execute()
 
             # make sure rollback correctly
             self._assert_sql_equal([])
 
     def test_execute_commit_false(self):
-        with TRN:
+        with qdb.sql_connection.TRN:
             sql = """INSERT INTO qiita.test_table (str_column, int_column)
                      VALUES (%s, %s) RETURNING str_column, int_column"""
             args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
-            TRN.add(sql, args, many=True)
+            qdb.sql_connection.TRN.add(sql, args, many=True)
 
-            obs = TRN.execute()
+            obs = qdb.sql_connection.TRN.execute()
             exp = [[['insert1', 1]], [['insert2', 2]], [['insert3', 3]]]
             self.assertEqual(obs, exp)
 
             self._assert_sql_equal([])
 
-            TRN.commit()
+            qdb.sql_connection.TRN.commit()
 
             self._assert_sql_equal([('insert1', True, 1), ('insert2', True, 2),
                                     ('insert3', True, 3)])
 
     def test_execute_commit_false_rollback(self):
-        with TRN:
+        with qdb.sql_connection.TRN:
             sql = """INSERT INTO qiita.test_table (str_column, int_column)
                      VALUES (%s, %s) RETURNING str_column, int_column"""
             args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
-            TRN.add(sql, args, many=True)
+            qdb.sql_connection.TRN.add(sql, args, many=True)
 
-            obs = TRN.execute()
+            obs = qdb.sql_connection.TRN.execute()
             exp = [[['insert1', 1]], [['insert2', 2]], [['insert3', 3]]]
             self.assertEqual(obs, exp)
 
             self._assert_sql_equal([])
 
-            TRN.rollback()
+            qdb.sql_connection.TRN.rollback()
 
             self._assert_sql_equal([])
 
     def test_execute_commit_false_wipe_queries(self):
-        with TRN:
+        with qdb.sql_connection.TRN:
             sql = """INSERT INTO qiita.test_table (str_column, int_column)
                      VALUES (%s, %s) RETURNING str_column, int_column"""
             args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
-            TRN.add(sql, args, many=True)
+            qdb.sql_connection.TRN.add(sql, args, many=True)
 
-            obs = TRN.execute()
+            obs = qdb.sql_connection.TRN.execute()
             exp = [[['insert1', 1]], [['insert2', 2]], [['insert3', 3]]]
             self.assertEqual(obs, exp)
 
@@ -399,166 +399,166 @@ class TestTransaction(TestBase):
             sql = """UPDATE qiita.test_table SET bool_column = %s
                      WHERE str_column = %s"""
             args = [False, 'insert2']
-            TRN.add(sql, args)
-            self.assertEqual(TRN._queries, [(sql, args)])
+            qdb.sql_connection.TRN.add(sql, args)
+            self.assertEqual(qdb.sql_connection.TRN._queries, [(sql, args)])
 
-            TRN.execute()
+            qdb.sql_connection.TRN.execute()
             self._assert_sql_equal([])
 
         self._assert_sql_equal([('insert1', True, 1), ('insert3', True, 3),
                                 ('insert2', False, 2)])
 
     def test_execute_fetchlast(self):
-        with TRN:
+        with qdb.sql_connection.TRN:
             sql = """INSERT INTO qiita.test_table (str_column, int_column)
                      VALUES (%s, %s) RETURNING str_column, int_column"""
             args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
-            TRN.add(sql, args, many=True)
+            qdb.sql_connection.TRN.add(sql, args, many=True)
 
             sql = """SELECT EXISTS(
                         SELECT * FROM qiita.test_table WHERE int_column=%s)"""
-            TRN.add(sql, [2])
-            self.assertTrue(TRN.execute_fetchlast())
+            qdb.sql_connection.TRN.add(sql, [2])
+            self.assertTrue(qdb.sql_connection.TRN.execute_fetchlast())
 
     def test_execute_fetchindex(self):
-        with TRN:
+        with qdb.sql_connection.TRN:
             sql = """INSERT INTO qiita.test_table (str_column, int_column)
                      VALUES (%s, %s) RETURNING str_column, int_column"""
             args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
-            TRN.add(sql, args, many=True)
-            self.assertEqual(TRN.execute_fetchindex(), [['insert3', 3]])
+            qdb.sql_connection.TRN.add(sql, args, many=True)
+            self.assertEqual(qdb.sql_connection.TRN.execute_fetchindex(), [['insert3', 3]])
 
             sql = """INSERT INTO qiita.test_table (str_column, int_column)
                      VALUES (%s, %s) RETURNING str_column, int_column"""
             args = [['insert4', 4], ['insert5', 5], ['insert6', 6]]
-            TRN.add(sql, args, many=True)
-            self.assertEqual(TRN.execute_fetchindex(3), [['insert4', 4]])
+            qdb.sql_connection.TRN.add(sql, args, many=True)
+            self.assertEqual(qdb.sql_connection.TRN.execute_fetchindex(3), [['insert4', 4]])
 
     def test_execute_fetchflatten(self):
-        with TRN:
+        with qdb.sql_connection.TRN:
             sql = """INSERT INTO qiita.test_table (str_column, int_column)
                      VALUES (%s, %s)"""
             args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
-            TRN.add(sql, args, many=True)
+            qdb.sql_connection.TRN.add(sql, args, many=True)
 
             sql = "SELECT str_column, int_column FROM qiita.test_table"
-            TRN.add(sql)
+            qdb.sql_connection.TRN.add(sql)
 
             sql = "SELECT int_column FROM qiita.test_table"
-            TRN.add(sql)
-            obs = TRN.execute_fetchflatten()
+            qdb.sql_connection.TRN.add(sql)
+            obs = qdb.sql_connection.TRN.execute_fetchflatten()
             self.assertEqual(obs, [1, 2, 3])
 
             sql = "SELECT 42"
-            TRN.add(sql)
-            obs = TRN.execute_fetchflatten(idx=3)
+            qdb.sql_connection.TRN.add(sql)
+            obs = qdb.sql_connection.TRN.execute_fetchflatten(idx=3)
             self.assertEqual(obs, ['insert1', 1, 'insert2', 2, 'insert3', 3])
 
     def test_context_manager_rollback(self):
         try:
-            with TRN:
+            with qdb.sql_connection.TRN:
                 sql = """INSERT INTO qiita.test_table (str_column, int_column)
                      VALUES (%s, %s) RETURNING str_column, int_column"""
                 args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
-                TRN.add(sql, args, many=True)
+                qdb.sql_connection.TRN.add(sql, args, many=True)
 
-                TRN.execute()
+                qdb.sql_connection.TRN.execute()
                 raise ValueError("Force exiting the context manager")
         except ValueError:
             pass
         self._assert_sql_equal([])
         self.assertEqual(
-            TRN._connection.get_transaction_status(),
+            qdb.sql_connection.TRN._connection.get_transaction_status(),
             TRANSACTION_STATUS_IDLE)
 
     def test_context_manager_execute(self):
-        with TRN:
+        with qdb.sql_connection.TRN:
             sql = """INSERT INTO qiita.test_table (str_column, int_column)
                  VALUES (%s, %s) RETURNING str_column, int_column"""
             args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
-            TRN.add(sql, args, many=True)
+            qdb.sql_connection.TRN.add(sql, args, many=True)
             self._assert_sql_equal([])
 
         self._assert_sql_equal([('insert1', True, 1), ('insert2', True, 2),
                                 ('insert3', True, 3)])
         self.assertEqual(
-            TRN._connection.get_transaction_status(),
+            qdb.sql_connection.TRN._connection.get_transaction_status(),
             TRANSACTION_STATUS_IDLE)
 
     def test_context_manager_no_commit(self):
-        with TRN:
+        with qdb.sql_connection.TRN:
             sql = """INSERT INTO qiita.test_table (str_column, int_column)
                  VALUES (%s, %s) RETURNING str_column, int_column"""
             args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
-            TRN.add(sql, args, many=True)
+            qdb.sql_connection.TRN.add(sql, args, many=True)
 
-            TRN.execute()
+            qdb.sql_connection.TRN.execute()
             self._assert_sql_equal([])
 
         self._assert_sql_equal([('insert1', True, 1), ('insert2', True, 2),
                                 ('insert3', True, 3)])
         self.assertEqual(
-            TRN._connection.get_transaction_status(),
+            qdb.sql_connection.TRN._connection.get_transaction_status(),
             TRANSACTION_STATUS_IDLE)
 
     def test_context_manager_multiple(self):
-        self.assertEqual(TRN._contexts_entered, 0)
+        self.assertEqual(qdb.sql_connection.TRN._contexts_entered, 0)
 
-        with TRN:
-            self.assertEqual(TRN._contexts_entered, 1)
+        with qdb.sql_connection.TRN:
+            self.assertEqual(qdb.sql_connection.TRN._contexts_entered, 1)
 
-            TRN.add("SELECT 42")
-            with TRN:
-                self.assertEqual(TRN._contexts_entered, 2)
+            qdb.sql_connection.TRN.add("SELECT 42")
+            with qdb.sql_connection.TRN:
+                self.assertEqual(qdb.sql_connection.TRN._contexts_entered, 2)
                 sql = """INSERT INTO qiita.test_table (str_column, int_column)
                          VALUES (%s, %s) RETURNING str_column, int_column"""
                 args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
-                TRN.add(sql, args, many=True)
+                qdb.sql_connection.TRN.add(sql, args, many=True)
 
             # We exited the second context, nothing should have been executed
-            self.assertEqual(TRN._contexts_entered, 1)
+            self.assertEqual(qdb.sql_connection.TRN._contexts_entered, 1)
             self.assertEqual(
-                TRN._connection.get_transaction_status(),
+                qdb.sql_connection.TRN._connection.get_transaction_status(),
                 TRANSACTION_STATUS_IDLE)
             self._assert_sql_equal([])
 
         # We have exited the first context, everything should have been
         # executed and committed
-        self.assertEqual(TRN._contexts_entered, 0)
+        self.assertEqual(qdb.sql_connection.TRN._contexts_entered, 0)
         self._assert_sql_equal([('insert1', True, 1), ('insert2', True, 2),
                                 ('insert3', True, 3)])
         self.assertEqual(
-            TRN._connection.get_transaction_status(),
+            qdb.sql_connection.TRN._connection.get_transaction_status(),
             TRANSACTION_STATUS_IDLE)
 
     def test_context_manager_multiple_2(self):
-        self.assertEqual(TRN._contexts_entered, 0)
+        self.assertEqual(qdb.sql_connection.TRN._contexts_entered, 0)
 
         def tester():
-            self.assertEqual(TRN._contexts_entered, 1)
-            with TRN:
-                self.assertEqual(TRN._contexts_entered, 2)
+            self.assertEqual(qdb.sql_connection.TRN._contexts_entered, 1)
+            with qdb.sql_connection.TRN:
+                self.assertEqual(qdb.sql_connection.TRN._contexts_entered, 2)
                 sql = """SELECT EXISTS(
                         SELECT * FROM qiita.test_table WHERE int_column=%s)"""
-                TRN.add(sql, [2])
-                self.assertTrue(TRN.execute_fetchlast())
-            self.assertEqual(TRN._contexts_entered, 1)
+                qdb.sql_connection.TRN.add(sql, [2])
+                self.assertTrue(qdb.sql_connection.TRN.execute_fetchlast())
+            self.assertEqual(qdb.sql_connection.TRN._contexts_entered, 1)
 
-        with TRN:
-            self.assertEqual(TRN._contexts_entered, 1)
+        with qdb.sql_connection.TRN:
+            self.assertEqual(qdb.sql_connection.TRN._contexts_entered, 1)
             sql = """INSERT INTO qiita.test_table (str_column, int_column)
                          VALUES (%s, %s) RETURNING str_column, int_column"""
             args = [['insert1', 1], ['insert2', 2], ['insert3', 3]]
-            TRN.add(sql, args, many=True)
+            qdb.sql_connection.TRN.add(sql, args, many=True)
             tester()
-            self.assertEqual(TRN._contexts_entered, 1)
+            self.assertEqual(qdb.sql_connection.TRN._contexts_entered, 1)
             self._assert_sql_equal([])
 
-        self.assertEqual(TRN._contexts_entered, 0)
+        self.assertEqual(qdb.sql_connection.TRN._contexts_entered, 0)
         self._assert_sql_equal([('insert1', True, 1), ('insert2', True, 2),
                                 ('insert3', True, 3)])
         self.assertEqual(
-            TRN._connection.get_transaction_status(),
+            qdb.sql_connection.TRN._connection.get_transaction_status(),
             TRANSACTION_STATUS_IDLE)
 
     def test_post_commit_funcs(self):
@@ -570,9 +570,9 @@ class TestTransaction(TestBase):
             with open(fp, 'w') as f:
                 f.write('\n')
 
-        with TRN:
-            TRN.add("SELECT 42")
-            TRN.add_post_commit_func(func, fp)
+        with qdb.sql_connection.TRN:
+            qdb.sql_connection.TRN.add("SELECT 42")
+            qdb.sql_connection.TRN.add_post_commit_func(func, fp)
 
         self.assertTrue(exists(fp))
 
@@ -581,9 +581,9 @@ class TestTransaction(TestBase):
             raise ValueError()
 
         with self.assertRaises(RuntimeError):
-            with TRN:
-                TRN.add("SELECT 42")
-                TRN.add_post_commit_func(func)
+            with qdb.sql_connection.TRN:
+                qdb.sql_connection.TRN.add("SELECT 42")
+                qdb.sql_connection.TRN.add_post_commit_func(func)
 
     def test_post_rollback_funcs(self):
         fd, fp = mkstemp()
@@ -594,10 +594,10 @@ class TestTransaction(TestBase):
             with open(fp, 'w') as f:
                 f.write('\n')
 
-        with TRN:
-            TRN.add("SELECT 42")
-            TRN.add_post_rollback_func(func, fp)
-            TRN.rollback()
+        with qdb.sql_connection.TRN:
+            qdb.sql_connection.TRN.add("SELECT 42")
+            qdb.sql_connection.TRN.add_post_rollback_func(func, fp)
+            qdb.sql_connection.TRN.rollback()
 
         self.assertTrue(exists(fp))
 
@@ -606,49 +606,49 @@ class TestTransaction(TestBase):
             raise ValueError()
 
         with self.assertRaises(RuntimeError):
-            with TRN:
-                TRN.add("SELECT 42")
-                TRN.add_post_rollback_func(func)
-                TRN.rollback()
+            with qdb.sql_connection.TRN:
+                qdb.sql_connection.TRN.add("SELECT 42")
+                qdb.sql_connection.TRN.add_post_rollback_func(func)
+                qdb.sql_connection.TRN.rollback()
 
     def test_context_manager_checker(self):
         with self.assertRaises(RuntimeError):
-            TRN.add("SELECT 42")
+            qdb.sql_connection.TRN.add("SELECT 42")
 
         with self.assertRaises(RuntimeError):
-            TRN.execute()
+            qdb.sql_connection.TRN.execute()
 
         with self.assertRaises(RuntimeError):
-            TRN.commit()
+            qdb.sql_connection.TRN.commit()
 
         with self.assertRaises(RuntimeError):
-            TRN.rollback()
+            qdb.sql_connection.TRN.rollback()
 
-        with TRN:
-            TRN.add("SELECT 42")
+        with qdb.sql_connection.TRN:
+            qdb.sql_connection.TRN.add("SELECT 42")
 
         with self.assertRaises(RuntimeError):
-            TRN.execute()
+            qdb.sql_connection.TRN.execute()
 
     def test_index(self):
-        with TRN:
-            self.assertEqual(TRN.index, 0)
+        with qdb.sql_connection.TRN:
+            self.assertEqual(qdb.sql_connection.TRN.index, 0)
 
-            TRN.add("SELECT 42")
-            self.assertEqual(TRN.index, 1)
+            qdb.sql_connection.TRN.add("SELECT 42")
+            self.assertEqual(qdb.sql_connection.TRN.index, 1)
 
             sql = "INSERT INTO qiita.test_table (int_column) VALUES (%s)"
             args = [[1], [2], [3]]
-            TRN.add(sql, args, many=True)
-            self.assertEqual(TRN.index, 4)
+            qdb.sql_connection.TRN.add(sql, args, many=True)
+            self.assertEqual(qdb.sql_connection.TRN.index, 4)
 
-            TRN.execute()
-            self.assertEqual(TRN.index, 4)
+            qdb.sql_connection.TRN.execute()
+            self.assertEqual(qdb.sql_connection.TRN.index, 4)
 
-            TRN.add(sql, args, many=True)
-            self.assertEqual(TRN.index, 7)
+            qdb.sql_connection.TRN.add(sql, args, many=True)
+            self.assertEqual(qdb.sql_connection.TRN.index, 7)
 
-        self.assertEqual(TRN.index, 0)
+        self.assertEqual(qdb.sql_connection.TRN.index, 0)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR depends on #1530 so review/merge that one first.

Fixes the tests for the artifact, base, job, logger, ontology, parameters, reference, sql_connection objects. It also fixes test_setup.py. 

It should be fast to review as there where almost no changes required to the objects themselves. Most of the changes are related to the import changes in the test files.