### PR TITLE
Fixing more tests

### DIFF
--- a/qiita_db/__init__.py
+++ b/qiita_db/__init__.py
@@ -23,6 +23,7 @@ import logger
 import meta_util
 import ontology
 import parameters
+import portal
 import reference
 import search
 import software
@@ -32,5 +33,6 @@ import user
 
 __all__ = ["analysis", "artifact", "base", "commands", "environment_manager",
            "exceptions", "investigation", "job", "logger", "meta_util",
-           "ontology", "parameters", "reference", "search", "software",
-           "sql_connection", "study", "user", "util", "metadata_template"]
+           "ontology", "parameters", "portal", "reference", "search",
+           "software", "sql_connection", "study", "user", "util",
+           "metadata_template"]

--- a/qiita_db/portal.py
+++ b/qiita_db/portal.py
@@ -330,7 +330,7 @@ class Portal(qdb.base.QiitaObject):
         Returns
         -------
         set of qiita_db.analysis.Analysis
-            All analysis belonging to the portal
+            All analyses belonging to the portal
         """
         with qdb.sql_connection.TRN:
             sql = """SELECT analysis_id

--- a/qiita_db/portal.py
+++ b/qiita_db/portal.py
@@ -198,18 +198,21 @@ class Portal(qdb.base.QiitaObject):
             return True
 
     def get_studies(self):
-        """Returns study id for all Studies belonging to the portal
+        """Returns all studies belonging to the portal
 
         Returns
         -------
-        set of int
-            All study ids in the database that match the given portal
+        set of qiita_db.study.Study
+            All studies attached to the portal
         """
         with qdb.sql_connection.TRN:
-            sql = """SELECT study_id FROM qiita.study_portal
+            sql = """SELECT study_id
+                     FROM qiita.study_portal
                      WHERE portal_type_id = %s"""
             qdb.sql_connection.TRN.add(sql, [self._id])
-            return set(qdb.sql_connection.TRN.execute_fetchflatten())
+            return set(
+                qdb.study.Study(sid)
+                for sid in qdb.sql_connection.TRN.execute_fetchflatten())
 
     def _check_studies(self, studies):
         with qdb.sql_connection.TRN:
@@ -289,8 +292,8 @@ class Portal(qdb.base.QiitaObject):
 
             # Make sure study not used in analysis in portal
             sql = """SELECT DISTINCT study_id
-                     FROM qiita.study_processed_data
-                        JOIN qiita.analysis_sample USING (processed_data_id)
+                     FROM qiita.study_artifact
+                        JOIN qiita.analysis_sample USING (artifact_id)
                         JOIN qiita.analysis_portal USING (analysis_id)
                      WHERE portal_type_id = %s AND study_id IN %s"""
             qdb.sql_connection.TRN.add(sql, [self.id, tuple(studies)])
@@ -322,19 +325,21 @@ class Portal(qdb.base.QiitaObject):
             qdb.sql_connection.TRN.execute()
 
     def get_analyses(self):
-        """Returns analysis id for all Analyses belonging to a portal
+        """Returns all analyses belonging to a portal
 
         Returns
         -------
-        set of int
-            All analysis ids in the database that match the given portal
+        set of qiita_db.analysis.Analysis
+            All analysis belonging to the portal
         """
         with qdb.sql_connection.TRN:
             sql = """SELECT analysis_id
                      FROM qiita.analysis_portal
                      WHERE portal_type_id = %s"""
             qdb.sql_connection.TRN.add(sql, [self._id])
-            return set(qdb.sql_connection.TRN.execute_fetchflatten())
+            return set(
+                qdb.analysis.Analysis(aid)
+                for aid in qdb.sql_connection.TRN.execute_fetchflatten())
 
     def _check_analyses(self, analyses):
         with qdb.sql_connection.TRN:
@@ -385,8 +390,8 @@ class Portal(qdb.base.QiitaObject):
                 # Make sure new portal has access to all studies in analysis
                 sql = """SELECT DISTINCT analysis_id
                          FROM qiita.analysis_sample
-                            JOIN qiita.study_processed_data
-                                USING (processed_data_id)
+                            JOIN qiita.study_artifact
+                                USING (artifact_id)
                          WHERE study_id NOT IN (
                             SELECT study_id
                             FROM qiita.study_portal

--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -282,15 +282,16 @@ class Software(qdb.base.QiitaObject):
 
         Returns
         -------
-        list of int
-            The command identifiers
+        list of qiita_db.software.Command
+            The commands attached to this software package
         """
         with qdb.sql_connection.TRN:
             sql = """SELECT command_id
                      FROM qiita.software_command
                      WHERE software_id = %s"""
             qdb.sql_connection.TRN.add(sql, [self.id])
-            return qdb.sql_connection.TRN.execute_fetchflatten()
+            return [Command(cid)
+                    for cid in qdb.sql_connection.TRN.execute_fetchflatten()]
 
     @property
     def publications(self):

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -9,27 +9,28 @@
 from unittest import TestCase, main
 
 from qiita_core.util import qiita_test_checker
-from qiita_db.software import Command, Software, Parameters
-from qiita_db.exceptions import QiitaDBDuplicateError
+import qiita_db as qdb
 
 
 @qiita_test_checker()
 class CommandTests(TestCase):
     def setUp(self):
-        self.software = Software(1)
+        self.software = qdb.software.Software(1)
 
     def test_exists(self):
-        self.assertFalse(Command.exists(self.software, "donotexists"))
-        self.assertTrue(Command.exists(self.software, "split_libraries.py"))
+        self.assertFalse(qdb.software.Command.exists(
+            self.software, "donotexists"))
+        self.assertTrue(qdb.software.Command.exists(
+            self.software, "split_libraries.py"))
 
     def test_create_error_duplicate(self):
-        with self.assertRaises(QiitaDBDuplicateError):
-            Command.create(
+        with self.assertRaises(qdb.exceptions.QiitaDBDuplicateError):
+            qdb.software.Command.create(
                 self.software, "Test Command", "This is a command for testing",
                 "split_libraries.py", "preprocessed_spectra_params")
 
     def test_create(self):
-        obs = Command.create(
+        obs = qdb.software.Command.create(
             self.software, "Test Command", "This is a command for testing",
             "test_command.py", "preprocessed_spectra_params")
         self.assertEqual(obs.name, "Test Command")
@@ -38,33 +39,35 @@ class CommandTests(TestCase):
         self.assertEqual(obs.parameters_table, "preprocessed_spectra_params")
 
     def test_name(self):
-        self.assertEqual(Command(1).name, "Split libraries FASTQ")
-        self.assertEqual(Command(2).name, "Split libraries")
+        self.assertEqual(qdb.software.Command(1).name, "Split libraries FASTQ")
+        self.assertEqual(qdb.software.Command(2).name, "Split libraries")
 
     def test_description(self):
         self.assertEqual(
-            Command(1).description,
+            qdb.software.Command(1).description,
             "Demultiplexes and applies quality control to FASTQ data")
         self.assertEqual(
-            Command(2).description,
+            qdb.software.Command(2).description,
             "Demultiplexes and applies quality control to FASTA data")
 
     def test_cli(self):
-        self.assertEqual(Command(1).cli, "split_libraries_fastq.py")
-        self.assertEqual(Command(2).cli, "split_libraries.py")
+        self.assertEqual(qdb.software.Command(1).cli,
+                         "split_libraries_fastq.py")
+        self.assertEqual(qdb.software.Command(2).cli, "split_libraries.py")
 
     def test_parameters_table(self):
-        self.assertEqual(Command(1).parameters_table,
+        self.assertEqual(qdb.software.Command(1).parameters_table,
                          "preprocessed_sequence_illumina_params")
-        self.assertEqual(Command(2).parameters_table,
+        self.assertEqual(qdb.software.Command(2).parameters_table,
                          "preprocessed_sequence_454_params")
 
 
 @qiita_test_checker()
 class SoftwareTests(TestCase):
     def test_create(self):
-        obs = Software.create("New Software", "0.1.0",
-                              "This is adding a new software for testing")
+        obs = qdb.software.Software.create(
+            "New Software", "0.1.0",
+            "This is adding a new software for testing")
         self.assertEqual(obs.name, "New Software")
         self.assertEqual(obs.version, "0.1.0")
         self.assertEqual(obs.description,
@@ -74,9 +77,9 @@ class SoftwareTests(TestCase):
 
     def test_create_with_publications(self):
         exp_publications = [['10.1000/nmeth.f.101', '12345678']]
-        obs = Software.create("Published Software", "1.0.0",
-                              "Another testing software",
-                              publications=exp_publications)
+        obs = qdb.software.Software.create(
+            "Published Software", "1.0.0", "Another testing software",
+            publications=exp_publications)
         self.assertEqual(obs.name, "Published Software")
         self.assertEqual(obs.version, "1.0.0")
         self.assertEqual(obs.description, "Another testing software")
@@ -84,26 +87,28 @@ class SoftwareTests(TestCase):
         self.assertEqual(obs.publications, exp_publications)
 
     def test_name(self):
-        self.assertEqual(Software(1).name, "QIIME")
+        self.assertEqual(qdb.software.Software(1).name, "QIIME")
 
     def test_version(self):
-        self.assertEqual(Software(1).version, "1.9.1")
+        self.assertEqual(qdb.software.Software(1).version, "1.9.1")
 
     def test_description(self):
         exp = ("Quantitative Insights Into Microbial Ecology (QIIME) is an "
                "open-source bioinformatics pipeline for performing microbiome "
                "analysis from raw DNA sequencing data")
-        self.assertEqual(Software(1).description, exp)
+        self.assertEqual(qdb.software.Software(1).description, exp)
 
     def test_commands(self):
-        self.assertEqual(Software(1).commands, [1, 2, 3])
+        exp = [qdb.software.Command(1), qdb.software.Command(2),
+               qdb.software.Command(3)]
+        self.assertEqual(qdb.software.Software(1).commands, exp)
 
     def test_publications(self):
-        self.assertEqual(Software(1).publications,
+        self.assertEqual(qdb.software.Software(1).publications,
                          [['10.1038/nmeth.f.303', '20383131']])
 
     def test_add_publications(self):
-        tester = Software(1)
+        tester = qdb.software.Software(1)
         self.assertEqual(tester.publications,
                          [['10.1038/nmeth.f.303', '20383131']])
         tester.add_publications([['10.1000/nmeth.f.101', '12345678']])
@@ -115,14 +120,14 @@ class SoftwareTests(TestCase):
 @qiita_test_checker()
 class ParametersTests(TestCase):
     def test_init(self):
-        obs = Parameters(1, Command(1))
+        obs = qdb.software.Parameters(1, qdb.software.Command(1))
         self.assertEqual(obs.id, 1)
         self.assertEqual(obs._table, "preprocessed_sequence_illumina_params")
-        self.assertEqual(obs.command, Command(1))
+        self.assertEqual(obs.command, qdb.software.Command(1))
 
     def test_exists(self):
-        cmd = Command(1)
-        obs = Parameters.exists(
+        cmd = qdb.software.Command(1)
+        obs = qdb.software.Parameters.exists(
             cmd, max_bad_run_length=3, min_per_read_length_fraction=0.75,
             sequence_max_n=0, rev_comp_barcode=False,
             rev_comp_mapping_barcodes=False, rev_comp=False,
@@ -130,7 +135,7 @@ class ParametersTests(TestCase):
             max_barcode_errors=1.5)
         self.assertTrue(obs)
 
-        obs = Parameters.exists(
+        obs = qdb.software.Parameters.exists(
             cmd, max_bad_run_length=3, min_per_read_length_fraction=0.75,
             sequence_max_n=0, rev_comp_barcode=False,
             rev_comp_mapping_barcodes=False, rev_comp=False,
@@ -139,8 +144,8 @@ class ParametersTests(TestCase):
         self.assertFalse(obs)
 
     def test_create(self):
-        cmd = Command(1)
-        obs = Parameters.create(
+        cmd = qdb.software.Command(1)
+        obs = qdb.software.Parameters.create(
             "test_create", cmd, max_bad_run_length=3,
             min_per_read_length_fraction=0.75, sequence_max_n=0,
             rev_comp_barcode=False, rev_comp_mapping_barcodes=False,
@@ -158,13 +163,15 @@ class ParametersTests(TestCase):
         self.assertEqual(obs.command, cmd)
 
     def test_iter(self):
-        cmd = Command(1)
-        obs = list(Parameters.iter(cmd))
-        exp = [Parameters(i, cmd) for i in range(1, 8)]
+        cmd = qdb.software.Command(1)
+        obs = list(qdb.software.Parameters.iter(cmd))
+        exp = [qdb.software.Parameters(i, cmd) for i in range(1, 8)]
         self.assertEqual(obs, exp)
 
     def test_name(self):
-        self.assertEqual(Parameters(1, Command(1)).name, "Defaults")
+        self.assertEqual(
+            qdb.software.Parameters(1, qdb.software.Command(1)).name,
+            "Defaults")
 
     def test_values(self):
         exp = {'min_per_read_length_fraction': 0.75,
@@ -172,17 +179,21 @@ class ParametersTests(TestCase):
                'rev_comp': False, 'phred_quality_threshold': 3,
                'rev_comp_barcode': False, 'sequence_max_n': 0,
                'barcode_type': 'golay_12', 'rev_comp_mapping_barcodes': False}
-        self.assertEqual(Parameters(1, Command(1)).values, exp)
+        self.assertEqual(
+            qdb.software.Parameters(1, qdb.software.Command(1)).values, exp)
 
     def test_to_str(self):
         exp = ("--barcode_type 'golay_12' --max_bad_run_length '3' "
                "--max_barcode_errors '1.5' "
                "--min_per_read_length_fraction '0.75' "
                "--phred_quality_threshold '3' --sequence_max_n '0'")
-        self.assertEqual(Parameters(1, Command(1)).to_str(), exp)
+        self.assertEqual(
+            qdb.software.Parameters(1, qdb.software.Command(1)).to_str(), exp)
 
     def test_command(self):
-        self.assertEqual(Parameters(1, Command(1)).command, Command(1))
+        self.assertEqual(
+            qdb.software.Parameters(1, qdb.software.Command(1)).command,
+            qdb.software.Command(1))
 
 if __name__ == '__main__':
     main()

--- a/qiita_db/test/test_sql.py
+++ b/qiita_db/test/test_sql.py
@@ -66,10 +66,13 @@ class TestSQL(TestCase):
         with open(fp, 'w') as f:
             f.write("test")
         fp = [(fp, 7)]
-        new = qdb.artifact.Artifact.create(fp, "BIOM", parents=[qdb.artifact.Artifact(2), qdb.artifact.Artifact(3)],
-                              processing_parameters=qdb.software.Parameters(1, qdb.software.Command(1)),
-                              can_be_submitted_to_ebi=True,
-                              can_be_submitted_to_vamps=True)
+        params = qdb.software.Parameters(1, qdb.software.Command(1))
+        new = qdb.artifact.Artifact.create(
+            fp, "BIOM",
+            parents=[qdb.artifact.Artifact(2), qdb.artifact.Artifact(3)],
+            processing_parameters=params,
+            can_be_submitted_to_ebi=True,
+            can_be_submitted_to_vamps=True)
         self._files_to_remove.extend([afp for _, afp, _ in new.filepaths])
         obs = self.conn_handler.execute_fetchall(sql, [new.id])
         exp = [[1]]
@@ -87,7 +90,8 @@ class TestSQL(TestCase):
                              'library_construction_protocol': 'AAAA',
                              'experiment_design_description': 'BBBB'}},
             orient='index')
-        pt = qdb.metadata_template.prep_template.PrepTemplate.create(metadata, qdb.study.Study(1), "18S")
+        pt = qdb.metadata_template.prep_template.PrepTemplate.create(
+            metadata, qdb.study.Study(1), "18S")
         fd, fp = mkstemp(suffix='_seqs.fastq')
         close(fd)
         self._files_to_remove.append(fp)
@@ -124,9 +128,10 @@ class TestSQL(TestCase):
         with open(fp, 'w') as f:
             f.write("test")
         fp = [(fp, 4)]
-        new = qdb.artifact.Artifact.create(fp, "Demultiplexed",
-                              parents=[qdb.artifact.Artifact(1), new_root],
-                              processing_parameters=qdb.software.Parameters(1, qdb.software.Command(1)))
+        params = qdb.software.Parameters(1, qdb.software.Command(1))
+        new = qdb.artifact.Artifact.create(
+            fp, "Demultiplexed", parents=[qdb.artifact.Artifact(1), new_root],
+            processing_parameters=params)
         self._files_to_remove.extend([afp for _, afp, _ in new.filepaths])
         obs = self.conn_handler.execute_fetchall(sql, [new.id])
         exp = [[1], [new_root.id]]

--- a/qiita_db/test/test_sql.py
+++ b/qiita_db/test/test_sql.py
@@ -6,10 +6,7 @@ from os.path import exists
 import pandas as pd
 
 from qiita_core.util import qiita_test_checker
-from qiita_db.artifact import Artifact
-from qiita_db.software import Parameters, Command
-from qiita_db.study import Study
-from qiita_db.metadata_template import PrepTemplate
+import qiita_db as qdb
 
 
 @qiita_test_checker()
@@ -69,8 +66,8 @@ class TestSQL(TestCase):
         with open(fp, 'w') as f:
             f.write("test")
         fp = [(fp, 7)]
-        new = Artifact.create(fp, "BIOM", parents=[Artifact(2), Artifact(3)],
-                              processing_parameters=Parameters(1, Command(1)),
+        new = qdb.artifact.Artifact.create(fp, "BIOM", parents=[qdb.artifact.Artifact(2), qdb.artifact.Artifact(3)],
+                              processing_parameters=qdb.software.Parameters(1, qdb.software.Command(1)),
                               can_be_submitted_to_ebi=True,
                               can_be_submitted_to_vamps=True)
         self._files_to_remove.extend([afp for _, afp, _ in new.filepaths])
@@ -90,14 +87,14 @@ class TestSQL(TestCase):
                              'library_construction_protocol': 'AAAA',
                              'experiment_design_description': 'BBBB'}},
             orient='index')
-        pt = PrepTemplate.create(metadata, Study(1), "18S")
+        pt = qdb.metadata_template.prep_template.PrepTemplate.create(metadata, qdb.study.Study(1), "18S")
         fd, fp = mkstemp(suffix='_seqs.fastq')
         close(fd)
         self._files_to_remove.append(fp)
         with open(fp, 'w') as f:
             f.write("test")
         fp = [(fp, 1)]
-        new_root = Artifact.create(fp, "FASTQ", prep_template=pt)
+        new_root = qdb.artifact.Artifact.create(fp, "FASTQ", prep_template=pt)
         self._files_to_remove.extend(
             [afp for _, afp, _ in new_root.filepaths])
         return new_root
@@ -127,9 +124,9 @@ class TestSQL(TestCase):
         with open(fp, 'w') as f:
             f.write("test")
         fp = [(fp, 4)]
-        new = Artifact.create(fp, "Demultiplexed",
-                              parents=[Artifact(1), new_root],
-                              processing_parameters=Parameters(1, Command(1)))
+        new = qdb.artifact.Artifact.create(fp, "Demultiplexed",
+                              parents=[qdb.artifact.Artifact(1), new_root],
+                              processing_parameters=qdb.software.Parameters(1, qdb.software.Command(1)))
         self._files_to_remove.extend([afp for _, afp, _ in new.filepaths])
         obs = self.conn_handler.execute_fetchall(sql, [new.id])
         exp = [[1], [new_root.id]]

--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -17,32 +17,7 @@ from functools import partial
 import pandas as pd
 
 from qiita_core.util import qiita_test_checker
-from qiita_db.exceptions import (QiitaDBColumnError, QiitaDBError,
-                                 QiitaDBLookupError)
-from qiita_db.data import RawData
-from qiita_db.study import Study
-from qiita_db.reference import Reference
-from qiita_db.metadata_template import PrepTemplate
-from qiita_db.user import User
-from qiita_db.util import (exists_table, exists_dynamic_table, scrub_data,
-                           compute_checksum, check_table_cols,
-                           check_required_columns, convert_to_id,
-                           get_table_cols, get_table_cols_w_type,
-                           get_filetypes, get_filepath_types, get_count,
-                           check_count, get_processed_params_tables,
-                           params_dict_to_json, insert_filepaths,
-                           get_db_files_base_dir, get_data_types,
-                           purge_filepaths, get_filepath_id,
-                           get_mountpoint, get_mountpoint_path_by_id,
-                           get_files_from_uploads_folders,
-                           get_environmental_packages, get_timeseries_types,
-                           filepath_id_to_rel_path, filepath_ids_to_rel_paths,
-                           move_filepaths_to_upload_folder,
-                           move_upload_files_to_trash,
-                           check_access_to_analysis_result, infer_status,
-                           get_preprocessed_params_tables, add_message,
-                           add_system_message, clear_system_messages,
-                           retrieve_filepaths)
+import qiita_db as qdb
 
 
 @qiita_test_checker()
@@ -65,35 +40,35 @@ class DBUtilTests(TestCase):
     def test_params_dict_to_json(self):
         params_dict = {'opt1': '1', 'opt2': [2, '3'], 3: 9}
         exp = '{"3":9,"opt1":"1","opt2":[2,"3"]}'
-        self.assertEqual(params_dict_to_json(params_dict), exp)
+        self.assertEqual(qdb.util.params_dict_to_json(params_dict), exp)
 
     def test_check_required_columns(self):
         # Doesn't do anything if correct info passed, only errors if wrong info
-        check_required_columns(self.required, self.table)
+        qdb.util.check_required_columns(self.required, self.table)
 
     def test_check_required_columns_fail(self):
         self.required.remove('study_title')
-        with self.assertRaises(QiitaDBColumnError):
-            check_required_columns(self.required, self.table)
+        with self.assertRaises(qdb.exceptions.QiitaDBColumnError):
+            qdb.util.check_required_columns(self.required, self.table)
 
     def test_check_table_cols(self):
         # Doesn't do anything if correct info passed, only errors if wrong info
-        check_table_cols(self.required, self.table)
+        qdb.util.check_table_cols(self.required, self.table)
 
     def test_check_table_cols_fail(self):
         self.required.append('BADTHINGNOINHERE')
-        with self.assertRaises(QiitaDBColumnError):
-            check_table_cols(self.required, self.table)
+        with self.assertRaises(qdb.exceptions.QiitaDBColumnError):
+            qdb.util.check_table_cols(self.required, self.table)
 
     def test_get_table_cols(self):
-        obs = get_table_cols("qiita_user")
+        obs = qdb.util.get_table_cols("qiita_user")
         exp = {"email", "user_level_id", "password", "name", "affiliation",
                "address", "phone", "user_verify_code", "pass_reset_code",
                "pass_reset_timestamp"}
         self.assertEqual(set(obs), exp)
 
     def test_get_table_cols_w_type(self):
-        obs = get_table_cols_w_type("preprocessed_sequence_illumina_params")
+        obs = qdb.util.get_table_cols_w_type("preprocessed_sequence_illumina_params")
         exp = [['param_set_name', 'character varying'],
                ['parameters_id', 'bigint'],
                ['max_bad_run_length', 'integer'],
@@ -110,69 +85,62 @@ class DBUtilTests(TestCase):
     def test_exists_table(self):
         """Correctly checks if a table exists"""
         # True cases
-        self.assertTrue(exists_table("filepath"))
-        self.assertTrue(exists_table("qiita_user"))
-        self.assertTrue(exists_table("analysis"))
-        self.assertTrue(exists_table("prep_1"))
-        self.assertTrue(exists_table("sample_1"))
+        self.assertTrue(qdb.util.exists_table("filepath"))
+        self.assertTrue(qdb.util.exists_table("qiita_user"))
+        self.assertTrue(qdb.util.exists_table("analysis"))
+        self.assertTrue(qdb.util.exists_table("prep_1"))
+        self.assertTrue(qdb.util.exists_table("sample_1"))
         # False cases
-        self.assertFalse(exists_table("sample_2"))
-        self.assertFalse(exists_table("prep_2"))
-        self.assertFalse(exists_table("foo_table"))
-        self.assertFalse(exists_table("bar_table"))
+        self.assertFalse(qdb.util.exists_table("sample_2"))
+        self.assertFalse(qdb.util.exists_table("prep_2"))
+        self.assertFalse(qdb.util.exists_table("foo_table"))
+        self.assertFalse(qdb.util.exists_table("bar_table"))
 
     def test_exists_dynamic_table(self):
         """Correctly checks if a dynamic table exists"""
         # True cases
-        self.assertTrue(exists_dynamic_table(
+        self.assertTrue(qdb.util.exists_dynamic_table(
             "preprocessed_sequence_illumina_params", "preprocessed_",
             "_params"))
-        self.assertTrue(exists_dynamic_table("prep_1", "prep_", ""))
-        self.assertTrue(exists_dynamic_table("filepath", "", ""))
+        self.assertTrue(qdb.util.exists_dynamic_table("prep_1", "prep_", ""))
+        self.assertTrue(qdb.util.exists_dynamic_table("filepath", "", ""))
         # False cases
-        self.assertFalse(exists_dynamic_table(
+        self.assertFalse(qdb.util.exists_dynamic_table(
             "preprocessed_foo_params", "preprocessed_", "_params"))
-        self.assertFalse(exists_dynamic_table(
+        self.assertFalse(qdb.util.exists_dynamic_table(
             "preprocessed__params", "preprocessed_", "_params"))
-        self.assertFalse(exists_dynamic_table(
+        self.assertFalse(qdb.util.exists_dynamic_table(
             "foo_params", "preprocessed_", "_params"))
-        self.assertFalse(exists_dynamic_table(
+        self.assertFalse(qdb.util.exists_dynamic_table(
             "preprocessed_foo", "preprocessed_", "_params"))
-        self.assertFalse(exists_dynamic_table(
+        self.assertFalse(qdb.util.exists_dynamic_table(
             "foo", "preprocessed_", "_params"))
 
     def test_convert_to_id(self):
         """Tests that ids are returned correctly"""
-        self.assertEqual(convert_to_id("directory", "filepath_type"), 8)
-        self.assertEqual(convert_to_id("running", "analysis_status",
+        self.assertEqual(qdb.util.convert_to_id("directory", "filepath_type"), 8)
+        self.assertEqual(qdb.util.convert_to_id("running", "analysis_status",
                                        "status"), 3)
-        self.assertEqual(convert_to_id("EMP", "portal_type", "portal"), 2)
+        self.assertEqual(qdb.util.convert_to_id("EMP", "portal_type", "portal"), 2)
 
     def test_convert_to_id_bad_value(self):
         """Tests that ids are returned correctly"""
-        with self.assertRaises(QiitaDBLookupError):
-            convert_to_id("FAKE", "filepath_type")
+        with self.assertRaises(qdb.exceptions.QiitaDBLookupError):
+            qdb.util.convert_to_id("FAKE", "filepath_type")
 
-    def test_get_filetypes(self):
-        """Tests that get_filetypes works with valid arguments"""
-
-        obs = get_filetypes()
+    def test_get_artifact_types(self):
+        obs = qdb.util.get_artifact_types()
         exp = {'SFF': 1, 'FASTA_Sanger': 2, 'FASTQ': 3, 'FASTA': 4,
-               'per_sample_FASTQ': 5}
+               'per_sample_FASTQ': 5, 'Demultiplexed': 6, 'BIOM': 7}
         self.assertEqual(obs, exp)
 
-        obs = get_filetypes(key='filetype_id')
+        obs = qdb.util.get_artifact_types(key_by_id=True)
         exp = {v: k for k, v in exp.items()}
         self.assertEqual(obs, exp)
 
-    def test_get_filetypes_fail(self):
-        """Tests that get_Filetypes fails with invalid argument"""
-        with self.assertRaises(QiitaDBColumnError):
-            get_filetypes(key='invalid')
-
     def test_get_filepath_types(self):
         """Tests that get_filepath_types works with valid arguments"""
-        obs = get_filepath_types()
+        obs = qdb.util.get_filepath_types()
         exp = {'raw_forward_seqs': 1, 'raw_reverse_seqs': 2,
                'raw_barcodes': 3, 'preprocessed_fasta': 4,
                'preprocessed_fastq': 5, 'preprocessed_demux': 6, 'biom': 7,
@@ -184,44 +152,44 @@ class DBUtilTests(TestCase):
             "SELECT filepath_type,filepath_type_id FROM qiita.filepath_type"))
         self.assertEqual(obs, exp)
 
-        obs = get_filepath_types(key='filepath_type_id')
+        obs = qdb.util.get_filepath_types(key='filepath_type_id')
         exp = {v: k for k, v in exp.items()}
         self.assertEqual(obs, exp)
 
     def test_get_filepath_types_fail(self):
         """Tests that get_Filetypes fails with invalid argument"""
-        with self.assertRaises(QiitaDBColumnError):
-            get_filepath_types(key='invalid')
+        with self.assertRaises(qdb.exceptions.QiitaDBColumnError):
+            qdb.util.get_filepath_types(key='invalid')
 
     def test_get_data_types(self):
         """Tests that get_data_types works with valid arguments"""
-        obs = get_data_types()
+        obs = qdb.util.get_data_types()
         exp = {'16S': 1, '18S': 2, 'ITS': 3, 'Proteomic': 4, 'Metabolomic': 5,
                'Metagenomic': 6}
         self.assertEqual(obs, exp)
 
-        obs = get_data_types(key='data_type_id')
+        obs = qdb.util.get_data_types(key='data_type_id')
         exp = {v: k for k, v in exp.items()}
         self.assertEqual(obs, exp)
 
     def test_get_count(self):
         """Checks that get_count retrieves proper count"""
-        self.assertEqual(get_count('qiita.study_person'), 3)
+        self.assertEqual(qdb.util.get_count('qiita.study_person'), 3)
 
     def test_check_count(self):
         """Checks that check_count returns True and False appropriately"""
-        self.assertTrue(check_count('qiita.study_person', 3))
-        self.assertFalse(check_count('qiita.study_person', 2))
+        self.assertTrue(qdb.util.check_count('qiita.study_person', 3))
+        self.assertFalse(qdb.util.check_count('qiita.study_person', 2))
 
     def test_get_preprocessed_params_tables(self):
-        obs = get_preprocessed_params_tables()
+        obs = qdb.util.get_preprocessed_params_tables()
         exp = ['preprocessed_sequence_454_params',
                'preprocessed_sequence_illumina_params',
                'preprocessed_spectra_params']
         self.assertEqual(obs, exp)
 
     def test_get_processed_params_tables(self):
-        obs = get_processed_params_tables()
+        obs = qdb.util.get_processed_params_tables()
         self.assertEqual(obs, ['processed_params_sortmerna',
                                'processed_params_uclust'])
 
@@ -234,11 +202,11 @@ class DBUtilTests(TestCase):
 
         exp_new_id = 1 + self.conn_handler.execute_fetchone(
             "SELECT count(1) FROM qiita.filepath")[0]
-        obs = insert_filepaths([(fp, 1)], 1, "raw_data", "filepath")
+        obs = qdb.util.insert_filepaths([(fp, 1)], 1, "raw_data", "filepath")
         self.assertEqual(obs, [exp_new_id])
 
         # Check that the files have been copied correctly
-        exp_fp = join(get_db_files_base_dir(), "raw_data",
+        exp_fp = join(qdb.util.get_db_files_base_dir(), "raw_data",
                       "1_%s" % basename(fp))
         self.assertTrue(exists(exp_fp))
         self.files_to_remove.append(exp_fp)
@@ -259,12 +227,12 @@ class DBUtilTests(TestCase):
 
         exp_new_id = 1 + self.conn_handler.execute_fetchone(
             "SELECT count(1) FROM qiita.filepath")[0]
-        obs = insert_filepaths([(fp, "raw_forward_seqs")], 1, "raw_data",
+        obs = qdb.util.insert_filepaths([(fp, "raw_forward_seqs")], 1, "raw_data",
                                "filepath")
         self.assertEqual(obs, [exp_new_id])
 
         # Check that the files have been copied correctly
-        exp_fp = join(get_db_files_base_dir(), "raw_data",
+        exp_fp = join(qdb.util.get_db_files_base_dir(), "raw_data",
                       "1_%s" % basename(fp))
         self.assertTrue(exists(exp_fp))
         self.files_to_remove.append(exp_fp)
@@ -277,8 +245,8 @@ class DBUtilTests(TestCase):
         self.assertEqual(obs, exp)
 
     def test_retrieve_filepaths(self):
-        obs = retrieve_filepaths('artifact_filepath', 'artifact_id', 1)
-        path_builder = partial(join, get_db_files_base_dir(), "raw_data")
+        obs = qdb.util.retrieve_filepaths('artifact_filepath', 'artifact_id', 1)
+        path_builder = partial(join, qdb.util.get_db_files_base_dir(), "raw_data")
         exp = [(1, path_builder("1_s_G1_L001_sequences.fastq.gz"),
                 "raw_forward_seqs"),
                (2, path_builder("1_s_G1_L001_sequences_barcodes.fastq.gz"),
@@ -288,7 +256,7 @@ class DBUtilTests(TestCase):
     def _common_purge_filpeaths_test(self):
         # Get all the filepaths so we can test if they've been removed or not
         sql_fp = "SELECT filepath, data_directory_id FROM qiita.filepath"
-        fps = [join(get_mountpoint_path_by_id(dd_id), fp) for fp, dd_id in
+        fps = [join(qdb.util.get_mountpoint_path_by_id(dd_id), fp) for fp, dd_id in
                self.conn_handler.execute_fetchall(sql_fp)]
 
         # Make sure that the files exist - specially for travis
@@ -298,7 +266,7 @@ class DBUtilTests(TestCase):
                     f.write('\n')
                 self.files_to_remove.append(fp)
 
-        _, raw_data_mp = get_mountpoint('raw_data')[0]
+        _, raw_data_mp = qdb.util.get_mountpoint('raw_data')[0]
 
         removed_fps = [
             join(raw_data_mp, '2_sequences_barcodes.fastq.gz'),
@@ -324,11 +292,11 @@ class DBUtilTests(TestCase):
         for fp in removed_fps:
             self.assertTrue(exists(fp))
 
-        exp_count = get_count("qiita.filepath") - 2
+        exp_count = qdb.util.get_count("qiita.filepath") - 2
 
-        purge_filepaths()
+        qdb.util.purge_filepaths()
 
-        obs_count = get_count("qiita.filepath")
+        obs_count = qdb.util.get_count("qiita.filepath")
 
         # Check that only 2 rows have been removed
         self.assertEqual(obs_count, exp_count)
@@ -360,7 +328,7 @@ class DBUtilTests(TestCase):
         # reference without tree and taxonomy:
         fd, seqs_fp = mkstemp(suffix="_seqs.fna")
         close(fd)
-        ref = Reference.create("null_db", "13_2", seqs_fp)
+        ref = qdb.reference.Reference.create("null_db", "13_2", seqs_fp)
         self.files_to_remove.append(ref.sequence_fp)
 
         self._common_purge_filpeaths_test()
@@ -370,7 +338,7 @@ class DBUtilTests(TestCase):
         # files
         fd, seqs_fp = mkstemp(suffix='_seqs.fastq')
         close(fd)
-        st = Study(1)
+        st = qdb.study.Study(1)
         metadata_dict = {
             'SKB8.640193': {'center_name': 'ANL',
                             'primer': 'GTGCCAGCMGCCGCGGTAA',
@@ -381,21 +349,22 @@ class DBUtilTests(TestCase):
                             'library_construction_protocol': 'AAAA',
                             'experiment_design_description': 'BBBB'}}
         metadata = pd.DataFrame.from_dict(metadata_dict, orient='index')
-        pt = PrepTemplate.create(metadata, Study(1), "16S")
+        pt = qdb.metadata_template.prep_template.PrepTemplate.create(metadata, qdb.study.Study(1), "16S")
 
-        rd = RawData.create(2, [pt], [(seqs_fp, 1)])
-        filepaths = rd.get_filepaths()
+        artifact = qdb.artifact.Artifact.create(
+            [(seqs_fp, 1)], "FASTQ", prep_template=pt)
+        filepaths = artifact.filepaths
         # deleting reference so we can directly call
         # move_filepaths_to_upload_folder
         for fid, _, _ in filepaths:
             self.conn_handler.execute(
-                "DELETE FROM qiita.raw_filepath WHERE filepath_id=%s", (fid,))
+                "DELETE FROM qiita.artifact_filepath WHERE filepath_id=%s", (fid,))
 
         # moving filepaths
-        move_filepaths_to_upload_folder(st.id, filepaths)
+        qdb.util.move_filepaths_to_upload_folder(st.id, filepaths)
 
         # check that they do not exist in the old path but do in the new one
-        path_for_removal = join(get_mountpoint("uploads")[0][1], str(st.id))
+        path_for_removal = join(qdb.util.get_mountpoint("uploads")[0][1], str(st.id))
         for _, fp, _ in filepaths:
             self.assertFalse(exists(fp))
             new_fp = join(path_for_removal, basename(fp).split('_', 1)[1])
@@ -404,26 +373,26 @@ class DBUtilTests(TestCase):
             self.files_to_remove.append(new_fp)
 
     def test_get_filepath_id(self):
-        _, base = get_mountpoint("raw_data")[0]
+        _, base = qdb.util.get_mountpoint("raw_data")[0]
         fp = join(base, '1_s_G1_L001_sequences.fastq.gz')
-        obs = get_filepath_id("raw_data", fp)
+        obs = qdb.util.get_filepath_id("raw_data", fp)
         self.assertEqual(obs, 1)
 
     def test_get_filepath_id_error(self):
-        with self.assertRaises(QiitaDBError):
-            get_filepath_id("raw_data", "Not_a_path")
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.util.get_filepath_id("raw_data", "Not_a_path")
 
     def test_get_mountpoint(self):
-        exp = [(5, join(get_db_files_base_dir(), 'raw_data'))]
-        obs = get_mountpoint("raw_data")
+        exp = [(5, join(qdb.util.get_db_files_base_dir(), 'raw_data'))]
+        obs = qdb.util.get_mountpoint("raw_data")
         self.assertEqual(obs, exp)
 
-        exp = [(1, join(get_db_files_base_dir(), 'analysis'))]
-        obs = get_mountpoint("analysis")
+        exp = [(1, join(qdb.util.get_db_files_base_dir(), 'analysis'))]
+        obs = qdb.util.get_mountpoint("analysis")
         self.assertEqual(obs, exp)
 
-        exp = [(2, join(get_db_files_base_dir(), 'job'))]
-        obs = get_mountpoint("job")
+        exp = [(2, join(qdb.util.get_db_files_base_dir(), 'job'))]
+        obs = qdb.util.get_mountpoint("job")
         self.assertEqual(obs, exp)
 
         # inserting new ones so we can test that it retrieves these and
@@ -431,7 +400,7 @@ class DBUtilTests(TestCase):
         self.conn_handler.execute(
             "UPDATE qiita.data_directory SET active=false WHERE "
             "data_directory_id=1")
-        count = get_count('qiita.data_directory')
+        count = qdb.util.get_count('qiita.data_directory')
         sql = """INSERT INTO qiita.data_directory (data_type, mountpoint,
                                                    subdirectory, active)
                  VALUES ('analysis', 'analysis_tmp', true, true),
@@ -439,44 +408,44 @@ class DBUtilTests(TestCase):
         self.conn_handler.execute(sql)
 
         # this should have been updated
-        exp = [(count + 1, join(get_db_files_base_dir(), 'analysis_tmp'))]
-        obs = get_mountpoint("analysis")
+        exp = [(count + 1, join(qdb.util.get_db_files_base_dir(), 'analysis_tmp'))]
+        obs = qdb.util.get_mountpoint("analysis")
         self.assertEqual(obs, exp)
 
         # these 2 shouldn't
-        exp = [(5, join(get_db_files_base_dir(), 'raw_data'))]
-        obs = get_mountpoint("raw_data")
+        exp = [(5, join(qdb.util.get_db_files_base_dir(), 'raw_data'))]
+        obs = qdb.util.get_mountpoint("raw_data")
         self.assertEqual(obs, exp)
 
-        exp = [(2, join(get_db_files_base_dir(), 'job'))]
-        obs = get_mountpoint("job")
+        exp = [(2, join(qdb.util.get_db_files_base_dir(), 'job'))]
+        obs = qdb.util.get_mountpoint("job")
         self.assertEqual(obs, exp)
 
         # testing multi returns
-        exp = [(5, join(get_db_files_base_dir(), 'raw_data')),
-               (count + 2, join(get_db_files_base_dir(), 'raw_data_tmp'))]
-        obs = get_mountpoint("raw_data", retrieve_all=True)
+        exp = [(5, join(qdb.util.get_db_files_base_dir(), 'raw_data')),
+               (count + 2, join(qdb.util.get_db_files_base_dir(), 'raw_data_tmp'))]
+        obs = qdb.util.get_mountpoint("raw_data", retrieve_all=True)
         self.assertEqual(obs, exp)
 
         # testing retrieve subdirectory
         exp = [
-            (5, join(get_db_files_base_dir(), 'raw_data'), False),
-            (count + 2, join(get_db_files_base_dir(), 'raw_data_tmp'), True)]
-        obs = get_mountpoint("raw_data", retrieve_all=True,
+            (5, join(qdb.util.get_db_files_base_dir(), 'raw_data'), False),
+            (count + 2, join(qdb.util.get_db_files_base_dir(), 'raw_data_tmp'), True)]
+        obs = qdb.util.get_mountpoint("raw_data", retrieve_all=True,
                              retrieve_subdir=True)
         self.assertEqual(obs, exp)
 
     def test_get_mountpoint_path_by_id(self):
-        exp = join(get_db_files_base_dir(), 'raw_data')
-        obs = get_mountpoint_path_by_id(5)
+        exp = join(qdb.util.get_db_files_base_dir(), 'raw_data')
+        obs = qdb.util.get_mountpoint_path_by_id(5)
         self.assertEqual(obs, exp)
 
-        exp = join(get_db_files_base_dir(), 'analysis')
-        obs = get_mountpoint_path_by_id(1)
+        exp = join(qdb.util.get_db_files_base_dir(), 'analysis')
+        obs = qdb.util.get_mountpoint_path_by_id(1)
         self.assertEqual(obs, exp)
 
-        exp = join(get_db_files_base_dir(), 'job')
-        obs = get_mountpoint_path_by_id(2)
+        exp = join(qdb.util.get_db_files_base_dir(), 'job')
+        obs = qdb.util.get_mountpoint_path_by_id(2)
         self.assertEqual(obs, exp)
 
         # inserting new ones so we can test that it retrieves these and
@@ -484,7 +453,7 @@ class DBUtilTests(TestCase):
         self.conn_handler.execute(
             "UPDATE qiita.data_directory SET active=false WHERE "
             "data_directory_id=1")
-        count = get_count('qiita.data_directory')
+        count = qdb.util.get_count('qiita.data_directory')
         sql = """INSERT INTO qiita.data_directory (data_type, mountpoint,
                                                    subdirectory, active)
                  VALUES ('analysis', 'analysis_tmp', true, true),
@@ -492,36 +461,36 @@ class DBUtilTests(TestCase):
         self.conn_handler.execute(sql)
 
         # this should have been updated
-        exp = join(get_db_files_base_dir(), 'analysis_tmp')
-        obs = get_mountpoint_path_by_id(count + 1)
+        exp = join(qdb.util.get_db_files_base_dir(), 'analysis_tmp')
+        obs = qdb.util.get_mountpoint_path_by_id(count + 1)
         self.assertEqual(obs, exp)
 
         # these 2 shouldn't
-        exp = join(get_db_files_base_dir(), 'raw_data')
-        obs = get_mountpoint_path_by_id(5)
+        exp = join(qdb.util.get_db_files_base_dir(), 'raw_data')
+        obs = qdb.util.get_mountpoint_path_by_id(5)
         self.assertEqual(obs, exp)
 
-        exp = join(get_db_files_base_dir(), 'job')
-        obs = get_mountpoint_path_by_id(2)
+        exp = join(qdb.util.get_db_files_base_dir(), 'job')
+        obs = qdb.util.get_mountpoint_path_by_id(2)
         self.assertEqual(obs, exp)
 
     def test_get_files_from_uploads_folders(self):
         # something has been uploaded and ignoring hidden files/folders
         # and folders
         exp = [(7, 'uploaded_file.txt')]
-        obs = get_files_from_uploads_folders("1")
+        obs = qdb.util.get_files_from_uploads_folders("1")
         self.assertEqual(obs, exp)
 
         # nothing has been uploaded
         exp = []
-        obs = get_files_from_uploads_folders("2")
+        obs = qdb.util.get_files_from_uploads_folders("2")
         self.assertEqual(obs, exp)
 
     def test_move_upload_files_to_trash(self):
         test_filename = 'this_is_a_test_file.txt'
 
         # create file to move to trash
-        fid, folder = get_mountpoint("uploads")[0]
+        fid, folder = qdb.util.get_mountpoint("uploads")[0]
         test_fp = join(folder, '1', test_filename)
         with open(test_fp, 'w') as f:
             f.write('test')
@@ -529,28 +498,28 @@ class DBUtilTests(TestCase):
         self.files_to_remove.append(test_fp)
 
         exp = [(fid, 'this_is_a_test_file.txt'), (fid, 'uploaded_file.txt')]
-        obs = get_files_from_uploads_folders("1")
+        obs = qdb.util.get_files_from_uploads_folders("1")
         self.assertItemsEqual(obs, exp)
 
         # move file
-        move_upload_files_to_trash(1, [(fid, test_filename)])
+        qdb.util.move_upload_files_to_trash(1, [(fid, test_filename)])
         exp = [(fid, 'uploaded_file.txt')]
-        obs = get_files_from_uploads_folders("1")
+        obs = qdb.util.get_files_from_uploads_folders("1")
         self.assertItemsEqual(obs, exp)
 
         # testing errors
-        with self.assertRaises(QiitaDBError):
-            move_upload_files_to_trash(2, [(fid, test_filename)])
-        with self.assertRaises(QiitaDBError):
-            move_upload_files_to_trash(1, [(10, test_filename)])
-        with self.assertRaises(QiitaDBError):
-            move_upload_files_to_trash(1, [(fid, test_filename)])
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.util.move_upload_files_to_trash(2, [(fid, test_filename)])
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.util.move_upload_files_to_trash(1, [(10, test_filename)])
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.util.move_upload_files_to_trash(1, [(fid, test_filename)])
 
         # removing trash folder
         rmtree(join(folder, '1', 'trash'))
 
     def test_get_environmental_packages(self):
-        obs = get_environmental_packages()
+        obs = qdb.util.get_environmental_packages()
         exp = [['air', 'ep_air'],
                ['built environment', 'ep_built_environment'],
                ['host-associated', 'ep_host_associated'],
@@ -573,7 +542,7 @@ class DBUtilTests(TestCase):
         self.assertEqual(sorted(obs), sorted(exp))
 
     def test_get_timeseries_types(self):
-        obs = get_timeseries_types()
+        obs = qdb.util.get_timeseries_types()
         exp = [[1, 'None', 'None'],
                [2, 'real', 'single intervention'],
                [3, 'real', 'multiple intervention'],
@@ -587,48 +556,48 @@ class DBUtilTests(TestCase):
         self.assertEqual(obs, exp)
 
     def test_filepath_id_to_rel_path(self):
-        obs = filepath_id_to_rel_path(1)
+        obs = qdb.util.filepath_id_to_rel_path(1)
         exp = 'raw_data/1_s_G1_L001_sequences.fastq.gz'
         self.assertEqual(obs, exp)
 
-        obs = filepath_id_to_rel_path(3)
+        obs = qdb.util.filepath_id_to_rel_path(3)
         exp = 'preprocessed_data/1_seqs.fna'
         self.assertEqual(obs, exp)
 
     def test_filepath_ids_to_rel_paths(self):
-        obs = filepath_ids_to_rel_paths([1, 3])
+        obs = qdb.util.filepath_ids_to_rel_paths([1, 3])
         exp = {1: 'raw_data/1_s_G1_L001_sequences.fastq.gz',
                3: 'preprocessed_data/1_seqs.fna'}
 
         self.assertEqual(obs, exp)
 
     def test_check_access_to_analysis_result(self):
-        obs = check_access_to_analysis_result('test@foo.bar',
+        obs = qdb.util.check_access_to_analysis_result('test@foo.bar',
                                               '1_job_result.txt')
         exp = [10]
 
         self.assertEqual(obs, exp)
 
     def test_add_message(self):
-        count = get_count('qiita.message') + 1
-        users = [User('shared@foo.bar'), User('admin@foo.bar')]
-        add_message("TEST MESSAGE", users)
+        count = qdb.util.get_count('qiita.message') + 1
+        users = [qdb.user.User('shared@foo.bar'), qdb.user.User('admin@foo.bar')]
+        qdb.util.add_message("TEST MESSAGE", users)
 
-        obs = [[x[0], x[1]] for x in User('shared@foo.bar').messages()]
+        obs = [[x[0], x[1]] for x in qdb.user.User('shared@foo.bar').messages()]
         exp = [[count, 'TEST MESSAGE'], [1, 'message 1']]
         self.assertEqual(obs, exp)
-        obs = [[x[0], x[1]] for x in User('admin@foo.bar').messages()]
+        obs = [[x[0], x[1]] for x in qdb.user.User('admin@foo.bar').messages()]
         exp = [[count, 'TEST MESSAGE']]
         self.assertEqual(obs, exp)
 
     def test_add_system_message(self):
-        count = get_count('qiita.message') + 1
-        add_system_message("SYS MESSAGE", datetime(2015, 8, 5, 19, 41))
+        count = qdb.util.get_count('qiita.message') + 1
+        qdb.util.add_system_message("SYS MESSAGE", datetime(2015, 8, 5, 19, 41))
 
-        obs = [[x[0], x[1]] for x in User('shared@foo.bar').messages()]
+        obs = [[x[0], x[1]] for x in qdb.user.User('shared@foo.bar').messages()]
         exp = [[count, 'SYS MESSAGE'], [1, 'message 1']]
         self.assertEqual(obs, exp)
-        obs = [[x[0], x[1]] for x in User('admin@foo.bar').messages()]
+        obs = [[x[0], x[1]] for x in qdb.user.User('admin@foo.bar').messages()]
         exp = [[count, 'SYS MESSAGE']]
         self.assertEqual(obs, exp)
 
@@ -638,23 +607,23 @@ class DBUtilTests(TestCase):
         self.assertEqual(obs, exp)
 
     def test_clear_system_messages(self):
-        message_id = get_count('qiita.message') + 1
-        obs = [[x[0], x[1]] for x in User('shared@foo.bar').messages()]
+        message_id = qdb.util.get_count('qiita.message') + 1
+        obs = [[x[0], x[1]] for x in qdb.user.User('shared@foo.bar').messages()]
         exp = [[1, 'message 1']]
         self.assertEqual(obs, exp)
 
-        add_system_message("SYS MESSAGE", datetime(2015, 8, 5, 19, 41))
-        obs = [[x[0], x[1]] for x in User('shared@foo.bar').messages()]
+        qdb.util.add_system_message("SYS MESSAGE", datetime(2015, 8, 5, 19, 41))
+        obs = [[x[0], x[1]] for x in qdb.user.User('shared@foo.bar').messages()]
         exp = [[1, 'message 1'], [message_id, 'SYS MESSAGE']]
         self.assertItemsEqual(obs, exp)
 
-        clear_system_messages()
-        obs = [[x[0], x[1]] for x in User('shared@foo.bar').messages()]
+        qdb.util.clear_system_messages()
+        obs = [[x[0], x[1]] for x in qdb.user.User('shared@foo.bar').messages()]
         exp = [[1, 'message 1']]
         self.assertEqual(obs, exp)
 
         # Run again with no system messages to make sure no errors
-        clear_system_messages()
+        qdb.util.clear_system_messages()
 
 
 class UtilTests(TestCase):
@@ -668,36 +637,36 @@ class UtilTests(TestCase):
 
     def test_compute_checksum(self):
         """Correctly returns the file checksum"""
-        obs = compute_checksum(self.filepath)
+        obs = qdb.util.compute_checksum(self.filepath)
         exp = 1719580229
         self.assertEqual(obs, exp)
 
     def test_scrub_data_nothing(self):
         """Returns the same string without changes"""
-        self.assertEqual(scrub_data("nothing_changes"), "nothing_changes")
+        self.assertEqual(qdb.util.scrub_data("nothing_changes"), "nothing_changes")
 
     def test_scrub_data_semicolon(self):
         """Correctly removes the semicolon from the string"""
-        self.assertEqual(scrub_data("remove_;_char"), "remove__char")
+        self.assertEqual(qdb.util.scrub_data("remove_;_char"), "remove__char")
 
     def test_scrub_data_single_quote(self):
         """Correctly removes single quotes from the string"""
-        self.assertEqual(scrub_data("'quotes'"), "quotes")
+        self.assertEqual(qdb.util.scrub_data("'quotes'"), "quotes")
 
     def test_infer_status(self):
-        obs = infer_status([])
+        obs = qdb.util.infer_status([])
         self.assertEqual(obs, 'sandbox')
 
-        obs = infer_status([['private']])
+        obs = qdb.util.infer_status([['private']])
         self.assertEqual(obs, 'private')
 
-        obs = infer_status([['private'], ['public']])
+        obs = qdb.util.infer_status([['private'], ['public']])
         self.assertEqual(obs, 'public')
 
-        obs = infer_status([['sandbox'], ['awaiting_approval']])
+        obs = qdb.util.infer_status([['sandbox'], ['awaiting_approval']])
         self.assertEqual(obs, 'awaiting_approval')
 
-        obs = infer_status([['sandbox'], ['sandbox']])
+        obs = qdb.util.infer_status([['sandbox'], ['sandbox']])
         self.assertEqual(obs, 'sandbox')
 
 if __name__ == '__main__':

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -129,29 +129,26 @@ def convert_type(obj):
     return item
 
 
-def get_filetypes(key='type'):
-    """Gets the list of possible filetypes from the filetype table
+def get_artifact_types(key_by_id=False):
+    """Gets the list of possible artifact types
 
     Parameters
     ----------
-    key : {'type', 'filetype_id'}, optional
-        Defaults to "type". Determines the format of the returned dict.
+    key : bool, optional
+        Determines the format of the returned dict. Defaults to false.
 
     Returns
     -------
     dict
-        If `key` is "type", dict is of the form {type: filetype_id}
-        If `key` is "filetype_id", dict is of the form {filetype_id: type}
+        If key_by_id is True, dict is of the form
+        {artifact_type_id: artifact_type}
+        If key_by_id is False, dict is of the form
+        {artifact_type: artifact_type_id}
     """
     with qdb.sql_connection.TRN:
-        if key == 'type':
-            cols = 'type, filetype_id'
-        elif key == 'filetype_id':
-            cols = 'filetype_id, type'
-        else:
-            raise qdb.exceptions.QiitaDBColumnError(
-                "Unknown key. Pass either 'type' or 'filetype_id'.")
-        sql = 'SELECT {} FROM qiita.filetype'.format(cols)
+        cols = ('artifact_type_id, artifact_type'
+                if key_by_id else 'artifact_type, artifact_type_id')
+        sql = "SELECT {} FROM qiita.artifact_type".format(cols)
         qdb.sql_connection.TRN.add(sql)
         return dict(qdb.sql_connection.TRN.execute_fetchindex())
 


### PR DESCRIPTION
This PR depends on #1531, so review/merge that one first.

This PR fixes the tests for software, portal, test_sql.py and util.

The software and portal objects have been modified to return instances of other objects rather than the ids.