### PR TITLE
Plugin: revamping processing parameters

### DIFF
--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -104,8 +104,8 @@ class Command(qdb.base.QiitaObject):
             The description of the command
         parameters : dict
             The description of the parameters that this command received. The
-            format is: {parameter_name: (paramter_type, default)},
-            where parameter_name, paramter_type and default are strings. If
+            format is: {parameter_name: (parameter_type, default)},
+            where parameter_name, parameter_type and default are strings. If
             default is None.
 
         Returns
@@ -141,7 +141,7 @@ class Command(qdb.base.QiitaObject):
             if len(vals) != 2:
                 raise qdb.exceptions.QiitaDBError(
                     "Malformed parameters dictionary, the format should be "
-                    "{param_name: [paramter_type, default]}. Found: "
+                    "{param_name: [parameter_type, default]}. Found: "
                     "%s for parameter name %s" % (vals, pname))
 
             ptype, dflt = vals
@@ -629,7 +629,7 @@ class Parameters(object):
     """
 
     def __eq__(self, other):
-        """Equality based on the paramter values and the command"""
+        """Equality based on the parameter values and the command"""
         if type(self) != type(other):
             return False
         if self.command != other.command:
@@ -642,8 +642,8 @@ class Parameters(object):
     def load(cls, command, json_str=None, values_dict=None):
         """Load the parameters set form a json str or from a dict of values
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         command : qiita_db.software.Command
             The command to which the parameter set belongs to
         json_str : str, optional
@@ -745,7 +745,7 @@ class Parameters(object):
                 raise qdb.exceptions.QiitaDBError(
                     "Provided required parameters not expected.\n"
                     "Missing required parameters: %s\n"
-                    "Extra required paramters: %s\n"
+                    "Extra required parameters: %s\n"
                     % (', '.join(missing_reqd), ', '.join(extra_reqd)))
 
             if opt_params:

--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -265,6 +265,24 @@ class Command(qdb.base.QiitaObject):
             res = qdb.sql_connection.TRN.execute_fetchindex()
             return {pname: [ptype, dflt] for pname, ptype, dflt in res}
 
+    @property
+    def default_parameter_sets(self):
+        """Returns the list of default parameter sets
+
+        Returns
+        -------
+        generator of qiita_db.software.DefaultParameters
+        """
+        with qdb.sql_connection.TRN:
+            sql = """SELECT default_parameter_set_id
+                     FROM qiita.default_parameter_set
+                     WHERE command_id = %s
+                     ORDER BY default_parameter_set_id"""
+            qdb.sql_connection.TRN.add(sql, [self.id])
+            res = qdb.sql_connection.TRN.execute_fetchflatten()
+            for pid in res:
+                yield DefaultParameters(pid)
+
 
 class Software(qdb.base.QiitaObject):
     r"""A software package available in the system

--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -612,6 +612,16 @@ class Parameters(object):
     'from_default_params'.
     """
 
+    def __eq__(self, other):
+        """Equality based on the paramter values and the command"""
+        if type(self) != type(other):
+            return False
+        if self.command != other.command:
+            return False
+        if self.values != other.values:
+            return False
+        return True
+
     @classmethod
     def load(cls, json_str, command):
         """Load the parameters set form a json str

--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -485,7 +485,7 @@ class DefaultParameters(qdb.base.QiitaObject):
                     % (', '.join(missing_in_user), ', '.join(extra_in_user)))
 
             sql = """SELECT parameter_set
-                     FROM qiita.deafult_parameter_set
+                     FROM qiita.default_parameter_set
                      WHERE command_id = %s"""
             qdb.sql_connection.TRN.add(sql, [command.id])
             for p_set in qdb.sql_connection.TRN.execute_fetchflatten():
@@ -547,9 +547,9 @@ class DefaultParameters(qdb.base.QiitaObject):
             The name of the parameter set
         """
         with qdb.sql_connection.TRN:
-            sql = """SELECT param_set_name
+            sql = """SELECT parameter_set_name
                      FROM qiita.default_parameter_set
-                     WHERE parameters_id = %s"""
+                     WHERE default_parameter_set_id = %s"""
             qdb.sql_connection.TRN.add(sql, [self.id])
             return qdb.sql_connection.TRN.execute_fetchlast()
 
@@ -565,7 +565,7 @@ class DefaultParameters(qdb.base.QiitaObject):
         with qdb.sql_connection.TRN:
             sql = """SELECT parameter_set
                      FROM qiita.default_parameter_set
-                     WHERE parameters_id = %s"""
+                     WHERE default_parameter_set_id = %s"""
             qdb.sql_connection.TRN.add(sql, [self.id])
             return qdb.sql_connection.TRN.execute_fetchlast()
 
@@ -582,5 +582,5 @@ class DefaultParameters(qdb.base.QiitaObject):
             sql = """SELECT command_id
                      FROM qiita.default_parameter_set
                      WHERE default_parameter_set_id = %s"""
-        qdb.sql_connection.TRN.add(sql, [self.id])
-        return Command(qdb.sql_connection.TRN.execute_fetchlast())
+            qdb.sql_connection.TRN.add(sql, [self.id])
+            return Command(qdb.sql_connection.TRN.execute_fetchlast())

--- a/qiita_db/support_files/patches/33.sql
+++ b/qiita_db/support_files/patches/33.sql
@@ -234,7 +234,7 @@ INSERT INTO qiita.publication (doi, pubmed_id) VALUES ('10.1038/nmeth.f.303', '2
 INSERT INTO qiita.software_publication (software_id, publication_doi) VALUES (1, '10.1038/nmeth.f.303');
 -- Magic number 1: we just created the software table and inserted the QIIME
 -- software, which will receive the ID 1
-INSERT INTO qiita.software_command (software_id, name, description, cli_cmd, parameters_table) VALUES
+INSERT INTO qiita.software_command (software_id, name, description) VALUES
     (1, 'Split libraries FASTQ', 'Demultiplexes and applies quality control to FASTQ data'),
     (1, 'Split libraries', 'Demultiplexes and applies quality control to FASTA data'),
     (1, 'Pick closed-reference OTUs', 'OTU picking using a closed reference approach');
@@ -370,46 +370,46 @@ CREATE FUNCTION generate_params(command_id bigint, params_id bigint, parent_id b
             SELECT * INTO c1_rec
             FROM qiita.preprocessed_sequence_illumina_params
             WHERE parameters_id = params_id;
-            val := ('{"max_bad_run_length":' || rec.max_bad_run_length || ','
-                    '"min_per_read_length_fraction":' || rec.min_per_read_length_fraction || ','
-                    '"sequence_max_n":' || rec.sequence_max_n || ','
-                    '"rev_comp_barcode":' || rec.rev_comp_barcode || ','
-                    '"rev_comp_mapping_barcodes":' || rec.rev_comp_mapping_barcodes || ','
-                    '"rev_comp":' || rec.rev_comp || ','
-                    '"phred_quality_threshold":' || rec.phred_quality_threshold || ','
-                    '"barcode_type":"' || rec.barcode_type || '",'
-                    '"max_barcode_errors":' || rec.max_barcode_errors || ','
+            val := ('{"max_bad_run_length":' || c1_rec.max_bad_run_length || ','
+                    '"min_per_read_length_fraction":' || c1_rec.min_per_read_length_fraction || ','
+                    '"sequence_max_n":' || c1_rec.sequence_max_n || ','
+                    '"rev_comp_barcode":' || c1_rec.rev_comp_barcode || ','
+                    '"rev_comp_mapping_barcodes":' || c1_rec.rev_comp_mapping_barcodes || ','
+                    '"rev_comp":' || c1_rec.rev_comp || ','
+                    '"phred_quality_threshold":' || c1_rec.phred_quality_threshold || ','
+                    '"barcode_type":"' || c1_rec.barcode_type || '",'
+                    '"max_barcode_errors":' || c1_rec.max_barcode_errors || ','
                     '"input_data":' || parent_id || '}')::json;
         ELSIF command_id = 2 THEN
             SELECT * INTO c2_rec
             FROM qiita.preprocessed_sequence_454_params
             WHERE parameters_id = params_id;
-            val := ('{"min_seq_len":' || rec.min_seq_len || ','
-                    '"max_seq_len":' || rec.max_seq_len || ','
-                    '"trim_seq_length":' || rec.trim_seq_length || ','
-                    '"min_qual_score":' || rec.min_qual_score || ','
-                    '"max_ambig":' || rec.max_ambig || ','
-                    '"max_homopolymer":' || rec.max_homopolymer || ','
-                    '"max_primer_mismatch":' || rec.max_primer_mismatch || ','
-                    '"barcode_type":"' || rec.barcode_type || '",'
-                    '"max_barcode_errors":' || rec.max_barcode_errors || ','
-                    '"disable_bc_correction":' || rec.disable_bc_correction || ','
-                    '"qual_score_window":' || rec.qual_score_window || ','
-                    '"disable_primers":' || rec.disable_primers || ','
-                    '"reverse_primers":"' || rec.reverse_primers || '",'
-                    '"reverse_primer_mismatches":' || rec.reverse_primer_mismatches || ','
-                    '"truncate_ambi_bases":' || rec.truncate_ambig_bases || ','
+            val := ('{"min_seq_len":' || c2_rec.min_seq_len || ','
+                    '"max_seq_len":' || c2_rec.max_seq_len || ','
+                    '"trim_seq_length":' || c2_rec.trim_seq_length || ','
+                    '"min_qual_score":' || c2_rec.min_qual_score || ','
+                    '"max_ambig":' || c2_rec.max_ambig || ','
+                    '"max_homopolymer":' || c2_rec.max_homopolymer || ','
+                    '"max_primer_mismatch":' || c2_rec.max_primer_mismatch || ','
+                    '"barcode_type":"' || c2_rec.barcode_type || '",'
+                    '"max_barcode_errors":' || c2_rec.max_barcode_errors || ','
+                    '"disable_bc_correction":' || c2_rec.disable_bc_correction || ','
+                    '"qual_score_window":' || c2_rec.qual_score_window || ','
+                    '"disable_primers":' || c2_rec.disable_primers || ','
+                    '"reverse_primers":"' || c2_rec.reverse_primers || '",'
+                    '"reverse_primer_mismatches":' || c2_rec.reverse_primer_mismatches || ','
+                    '"truncate_ambi_bases":' || c2_rec.truncate_ambig_bases || ','
                     '"input_data":' || parent_id || '}')::json;
         ELSE
             SELECT * INTO c3_rec
             FROM qiita.processed_params_sortmerna
             WHERE parameters_id = params_id;
-            val := ('{"reference":' || rec.reference_id || ','
-                    '"sortmerna_e_value":' || rec.sortmerna_e_value || ','
-                    '"sortmerna_max_pos":' || rec.sortmerna_max_pos || ','
-                    '"similarity":' || rec.similarity || ','
-                    '"sortmerna_coverage":' || rec.sortmerna_coverage || ','
-                    '"threads":' || rec.threads || ','
+            val := ('{"reference":' || c3_rec.reference_id || ','
+                    '"sortmerna_e_value":' || c3_rec.sortmerna_e_value || ','
+                    '"sortmerna_max_pos":' || c3_rec.sortmerna_max_pos || ','
+                    '"similarity":' || c3_rec.similarity || ','
+                    '"sortmerna_coverage":' || c3_rec.sortmerna_coverage || ','
+                    '"threads":' || c3_rec.threads || ','
                     '"input_data":' || parent_id || '}')::json;
         END IF;
         RETURN val;
@@ -529,7 +529,7 @@ BEGIN
             -- Insert the preprocessed data in the artifact table
             INSERT INTO qiita.artifact (generated_timestamp, visibility_id,
                                         artifact_type_id, data_type_id, command_id,
-                                        command_parameters_id, can_be_submitted_to_ebi,
+                                        command_parameters, can_be_submitted_to_ebi,
                                         can_be_submitted_to_vamps)
                 VALUES (now(), ppd_vis_id, demux_type_id, ppd_vals.data_type_id, ppd_cmd_id,
                         params, TRUE, TRUE)
@@ -584,7 +584,7 @@ BEGIN
                 -- OTU pickking command is the number 3
                 INSERT INTO qiita.artifact (generated_timestamp, visibility_id,
                                             artifact_type_id, data_type_id, command_id,
-                                            command_parameters_id)
+                                            command_parameters)
                     VALUES (pd_vals.processed_date, pd_vals.processed_data_status_id,
                             biom_type_id, ppd_vals.data_type_id, 3, params)
                     RETURNING artifact_id into pd_a_id;
@@ -662,6 +662,7 @@ ALTER TABLE qiita.analysis_sample ADD CONSTRAINT pk_analysis_sample PRIMARY KEY 
 DROP FUNCTION infer_rd_status(bigint, bigint);
 DROP FUNCTION infer_ppd_status(bigint);
 DROP FUNCTION choose_command_id(varchar);
+DROP FUNCTION generate_params(bigint, bigint, bigint);
 
 -- Drop the old SQL structure from the schema
 ALTER TABLE qiita.prep_template DROP COLUMN raw_data_id;
@@ -678,6 +679,11 @@ DROP TABLE qiita.preprocessed_data;
 DROP TABLE qiita.raw_filepath;
 DROP TABLE qiita.raw_data;
 DROP TABLE qiita.study_pmid;
+DROP TABLE qiita.processed_params_uclust;
+DROP TABLE qiita.processed_params_sortmerna;
+DROP TABLE qiita.preprocessed_sequence_454_params;
+DROP TABLE qiita.preprocessed_sequence_illumina_params;
+DROP TABLE qiita.preprocessed_spectra_params;
 
 -- Create a function to return the roots of an artifact, i.e. the source artifacts
 CREATE FUNCTION qiita.find_artifact_roots(a_id bigint) RETURNS SETOF bigint AS $$
@@ -721,7 +727,7 @@ CREATE TABLE qiita.processing_job (
 	processing_job_id          UUID     NOT NULL,
 	email                      varchar  NOT NULL,
 	command_id                 bigint   NOT NULL,
-	command_parameters_id      bigint   NOT NULL,
+	command_parameters         json     NOT NULL,
 	processing_job_status_id   bigint   NOT NULL,
 	logging_id                 bigint  ,
 	heartbeat                  timestamp  ,
@@ -734,7 +740,7 @@ CREATE INDEX idx_processing_job_status_id ON qiita.processing_job ( processing_j
 CREATE INDEX idx_processing_job_logging ON qiita.processing_job ( logging_id ) ;
 COMMENT ON COLUMN qiita.processing_job.email IS 'The user that launched the job';
 COMMENT ON COLUMN qiita.processing_job.command_id IS 'The command launched';
-COMMENT ON COLUMN qiita.processing_job.command_parameters_id IS 'The parameters used in the command';
+COMMENT ON COLUMN qiita.processing_job.command_parameters IS 'The parameters used in the command';
 COMMENT ON COLUMN qiita.processing_job.logging_id IS 'In case of failure, point to the log entry that holds more information about the error';
 COMMENT ON COLUMN qiita.processing_job.heartbeat IS 'The last heartbeat received by this job';
 ALTER TABLE qiita.processing_job ADD CONSTRAINT fk_processing_job_qiita_user FOREIGN KEY ( email ) REFERENCES qiita.qiita_user( email )    ;

--- a/qiita_db/support_files/patches/33.sql
+++ b/qiita_db/support_files/patches/33.sql
@@ -63,7 +63,7 @@ CREATE INDEX idx_command_parameter ON qiita.command_parameter ( command_id ) ;
 ALTER TABLE qiita.command_parameter ADD CONSTRAINT fk_command_parameter FOREIGN KEY ( command_id ) REFERENCES qiita.software_command( command_id )    ;
 
 -- default_parameter_set tables - holds the default parameter sets defined by
--- the system. If no arbitrary parameters is allowed in the system only the
+-- the system. If no arbitrary parameters are allowed in the system only the
 -- ones listed here will be shown. Note that the only parameters that are listed
 -- here are the ones that are not required, since the ones required do not
 -- have a default

--- a/qiita_db/support_files/populate_test_db.sql
+++ b/qiita_db/support_files/populate_test_db.sql
@@ -315,13 +315,16 @@ INSERT INTO qiita.study_prep_template (study_id, prep_template_id) VALUES (1, 1)
 -- Insert some artifacts
 --   1 (Raw fastq) ---> 2 (demultiplexed) ---> 4 (otu table)
 --                  \-> 3 (demultiplexed)
-INSERT INTO qiita.artifact (generated_timestamp, command_id, command_parameters_id,
+INSERT INTO qiita.artifact (generated_timestamp, command_id, command_parameters,
                             visibility_id, artifact_type_id, data_type_id,
                             can_be_submitted_to_ebi, can_be_submitted_to_vamps)
     VALUES ('Mon Oct 1 09:30:27 2012', NULL, NULL, 3, 3, 2, FALSE, FALSE),
-           ('Mon Oct 1 10:30:27 2012', 1, 1, 3, 6, 2, TRUE, TRUE),
-           ('Mon Oct 1 11:30:27 2012', 1, 2, 3, 6, 2, TRUE, TRUE),
-           ('Tue Oct 2 17:30:00 2012', 3, 1, 3, 7, 2, FALSE, FALSE);
+           ('Mon Oct 1 10:30:27 2012', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":false,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1}'::json,
+            3, 6, 2, TRUE, TRUE),
+           ('Mon Oct 1 11:30:27 2012', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":true,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1}'::json,
+            3, 6, 2, TRUE, TRUE),
+           ('Tue Oct 2 17:30:00 2012', 3, '{"reference":1,"sortmerna_e_value":1,"sortmerna_max_pos":10000,"similarity":0.97,"sortmerna_coverage":0.97,"threads":1,"input_data":2}'::json,
+            3, 7, 2, FALSE, FALSE);
 
 -- Link the child artifacts with their parents artifacts
 INSERT INTO qiita.parent_artifact (parent_id, artifact_id)
@@ -386,9 +389,6 @@ INSERT INTO qiita.ebi_run_accession (sample_id, artifact_id, ebi_run_accession)
 -- Populate the reference table
 INSERT INTO qiita.reference (reference_name, reference_version, sequence_filepath, taxonomy_filepath, tree_filepath) VALUES ('Greengenes', '13_8', 6, 7, 8);
 
--- Insert the processed params uclust used for preprocessed data 1
-INSERT INTO qiita.processed_params_uclust (similarity, enable_rev_strand_match, suppress_new_clusters, reference_id) VALUES (0.97, TRUE, TRUE, 1);
-
 -- Insert filepath for job results files
 INSERT INTO qiita.filepath (filepath, filepath_type_id, checksum, checksum_algorithm_id, data_directory_id) VALUES
 ('1_job_result.txt', 9, '852952723', 1, 2),
@@ -447,9 +447,6 @@ INSERT INTO qiita.term (term_id, ontology_id, term, identifier, definition, name
 INSERT INTO qiita.filepath (filepath, filepath_type_id, checksum, checksum_algorithm_id, data_directory_id) VALUES ('1_19700101-000000.txt', 14, '852952723', 1, 9);
 INSERT INTO qiita.sample_template_filepath VALUES (1, 14);
 
--- Add processing parameters for sortmerna
-INSERT INTO qiita.processed_params_sortmerna (reference_id, sortmerna_e_value, sortmerna_max_pos, similarity, sortmerna_coverage, threads) VALUES (1, 1, 10000, 0.97, 0.97, 1);
-
 --add collection to the database
 INSERT INTO qiita.collection (email, name, description) VALUES ('test@foo.bar', 'TEST_COLLECTION', 'collection for testing purposes');
 
@@ -483,9 +480,9 @@ INSERT INTO qiita.logging (time, severity_id, msg, information)
 
 -- Create some processing jobs
 INSERT INTO qiita.processing_job
-        (processing_job_id, email, command_id, command_parameters_id,
+        (processing_job_id, email, command_id, command_parameters,
          processing_job_status_id, logging_id, heartbeat, step)
-    VALUES ('063e553b-327c-4818-ab4a-adfe58e49860', 'test@foo.bar', 1, 1, 1, NULL, NULL, NULL),
-           ('bcc7ebcd-39c1-43e4-af2d-822e3589f14d', 'test@foo.bar', 2, 1, 2, NULL, 'Sun Nov 22 21:00:00 2015', 'demultiplexing'),
-           ('b72369f9-a886-4193-8d3d-f7b504168e75', 'shared@foo.bar', 1, 2, 3, NULL, 'Sun Nov 22 21:15:00 2015', NULL),
-           ('d19f76ee-274e-4c1b-b3a2-a12d73507c55', 'shared@foo.bar', 2, 1, 4, 1, 'Sun Nov 22 21:30:00 2015', 'generating demux file');
+    VALUES ('063e553b-327c-4818-ab4a-adfe58e49860', 'test@foo.bar', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":false,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1}'::json, 1, NULL, NULL, NULL),
+           ('bcc7ebcd-39c1-43e4-af2d-822e3589f14d', 'test@foo.bar', 2, '{"min_seq_len":100,"max_seq_len":1000,"trim_seq_length":false,"min_qual_score":25,"max_ambig":6,"max_homopolymer":6,"max_primer_mismatch":0,"barcode_type":"golay_12","max_barcode_errors":1.5,"disable_bc_correction":false,"qual_score_window":0,"disable_primers":false,"reverse_primers":"disable","reverse_primer_mismatches":0,"truncate_ambi_bases":false,"input_data":1}'::json, 2, NULL, 'Sun Nov 22 21:00:00 2015', 'demultiplexing'),
+           ('b72369f9-a886-4193-8d3d-f7b504168e75', 'shared@foo.bar', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":true,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1}'::json, 3, NULL, 'Sun Nov 22 21:15:00 2015', NULL),
+           ('d19f76ee-274e-4c1b-b3a2-a12d73507c55', 'shared@foo.bar', 3, '{"reference":1,"sortmerna_e_value":1,"sortmerna_max_pos":10000,"similarity":0.97,"sortmerna_coverage":0.97,"threads":1,"input_data":2}'::json, 4, 1, 'Sun Nov 22 21:30:00 2015', 'generating demux file');

--- a/qiita_db/support_files/populate_test_db.sql
+++ b/qiita_db/support_files/populate_test_db.sql
@@ -486,3 +486,7 @@ INSERT INTO qiita.processing_job
            ('bcc7ebcd-39c1-43e4-af2d-822e3589f14d', 'test@foo.bar', 2, '{"min_seq_len":100,"max_seq_len":1000,"trim_seq_length":false,"min_qual_score":25,"max_ambig":6,"max_homopolymer":6,"max_primer_mismatch":0,"barcode_type":"golay_12","max_barcode_errors":1.5,"disable_bc_correction":false,"qual_score_window":0,"disable_primers":false,"reverse_primers":"disable","reverse_primer_mismatches":0,"truncate_ambi_bases":false,"input_data":1}'::json, 2, NULL, 'Sun Nov 22 21:00:00 2015', 'demultiplexing'),
            ('b72369f9-a886-4193-8d3d-f7b504168e75', 'shared@foo.bar', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":true,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1}'::json, 3, NULL, 'Sun Nov 22 21:15:00 2015', NULL),
            ('d19f76ee-274e-4c1b-b3a2-a12d73507c55', 'shared@foo.bar', 3, '{"reference":1,"sortmerna_e_value":1,"sortmerna_max_pos":10000,"similarity":0.97,"sortmerna_coverage":0.97,"threads":1,"input_data":2}'::json, 4, 1, 'Sun Nov 22 21:30:00 2015', 'generating demux file');
+
+-- Add a default parameter set for sortemrna
+INSERT INTO qiita.default_parameter_set (command_id, parameter_set_name, parameter_set)
+    VALUES (3, 'Defaults', '{"reference":1,"sortmerna_e_value":1,"sortmerna_max_pos":10000,"similarity":0.97,"sortmerna_coverage":0.97,"threads":1}'::json);

--- a/qiita_db/support_files/qiita-db.dbs
+++ b/qiita_db/support_files/qiita-db.dbs
@@ -213,7 +213,9 @@
 			<column name="artifact_id" type="bigserial" jt="-5" mandatory="y" />
 			<column name="generated_timestamp" type="timestamp" jt="93" mandatory="y" />
 			<column name="command_id" type="bigint" jt="-5" />
-			<column name="command_parameters_id" type="bigint" jt="-5" />
+			<column name="command_parameters" type="varchar" jt="12" >
+				<comment><![CDATA[Varchar in dbschema but is JSON in the postgresDB]]></comment>
+			</column>
 			<column name="visibility_id" type="bigint" jt="-5" mandatory="y" >
 				<comment><![CDATA[If the artifact is sandbox, awaiting_for_approval, private or public]]></comment>
 			</column>
@@ -1296,8 +1298,6 @@
 			<column name="name" type="varchar" jt="12" mandatory="y" />
 			<column name="software_id" type="bigint" jt="-5" mandatory="y" />
 			<column name="description" type="varchar" jt="12" mandatory="y" />
-			<column name="cli_cmd" type="varchar" jt="12" />
-			<column name="parameters_table" type="varchar" jt="12" mandatory="y" />
 			<index name="pk_soft_command" unique="PRIMARY_KEY" >
 				<column name="command_id" />
 			</index>
@@ -1719,28 +1719,28 @@ Controlled Vocabulary]]></comment>
 		<entity schema="qiita" name="study_portal" color="a8c4ef" x="1995" y="45" />
 		<entity schema="qiita" name="data_type" color="d0def5" x="690" y="1170" />
 		<entity schema="qiita" name="study_artifact" color="b2cdf7" x="1605" y="705" />
-		<entity schema="qiita" name="software" color="b2cdf7" x="1920" y="780" />
 		<entity schema="qiita" name="software_publication" color="b2cdf7" x="2340" y="795" />
 		<entity schema="qiita" name="visibility" color="b2cdf7" x="1050" y="945" />
 		<entity schema="qiita" name="study_sample" color="d0def5" x="1455" y="150" />
 		<entity schema="qiita" name="ebi_run_accession" color="b2cdf7" x="1350" y="945" />
 		<entity schema="qiita" name="artifact_type" color="d0def5" x="1410" y="735" />
-		<entity schema="qiita" name="software_command" color="b2cdf7" x="1740" y="780" />
 		<entity schema="qiita" name="publication" color="b2cdf7" x="2535" y="795" />
 		<entity schema="qiita" name="timeseries_type" color="c0d4f3" x="2235" y="555" />
 		<entity schema="qiita" name="study_publication" color="b2cdf7" x="2340" y="705" />
 		<entity schema="qiita" name="data_directory" color="b2cdf7" x="840" y="735" />
-		<entity schema="qiita" name="artifact" color="b2cdf7" x="1200" y="750" />
 		<entity schema="qiita" name="preprocessed_spectra_params" color="d0def5" x="1995" y="1830" />
 		<entity schema="qiita" name="processed_params_uclust" color="d0def5" x="1725" y="1470" />
 		<entity schema="qiita" name="reference" color="c0d4f3" x="1725" y="1290" />
 		<entity schema="qiita" name="processing_job_status" color="b2cdf7" x="1740" y="1170" />
-		<entity schema="qiita" name="default_parameter_set" color="b2cdf7" x="2025" y="1065" />
 		<entity schema="qiita" name="processing_job" color="b2cdf7" x="1740" y="975" />
 		<entity schema="qiita" name="preprocessed_sequence_454_params" color="c0d4f3" x="1725" y="1605" />
 		<entity schema="qiita" name="processed_params_sortmerna" color="a8c4ef" x="1980" y="1425" />
-		<entity schema="qiita" name="command_parameter" color="b2cdf7" x="2055" y="900" />
 		<entity schema="qiita" name="preprocessed_sequence_illumina_params" color="d0def5" x="1980" y="1605" />
+		<entity schema="qiita" name="command_parameter" color="b2cdf7" x="2055" y="870" />
+		<entity schema="qiita" name="default_parameter_set" color="b2cdf7" x="2025" y="1005" />
+		<entity schema="qiita" name="software" color="b2cdf7" x="2040" y="750" />
+		<entity schema="qiita" name="software_command" color="b2cdf7" x="1845" y="750" />
+		<entity schema="qiita" name="artifact" color="b2cdf7" x="1200" y="750" />
 		<group name="Group_analyses" color="c4e0f9" >
 			<comment>analysis tables</comment>
 			<entity schema="qiita" name="analysis" />

--- a/qiita_db/support_files/qiita-db.dbs
+++ b/qiita_db/support_files/qiita-db.dbs
@@ -954,171 +954,6 @@
 				<column name="sample_id" />
 			</index>
 		</table>
-		<table name="preprocessed_sequence_454_params" >
-			<comment>Parameters used for processing sequence data.</comment>
-			<column name="parameters_id" type="bigserial" jt="-5" mandatory="y" />
-			<column name="param_set_name" type="varchar" length="100" jt="12" mandatory="y" >
-				<comment><![CDATA[The name of the parameter set]]></comment>
-			</column>
-			<column name="min_seq_len" type="integer" jt="4" mandatory="y" >
-				<defo>200</defo>
-				<comment><![CDATA[The minimum sequence length]]></comment>
-			</column>
-			<column name="max_seq_len" type="integer" jt="4" mandatory="y" >
-				<defo>1000</defo>
-				<comment><![CDATA[The maximum sequence length]]></comment>
-			</column>
-			<column name="trim_seq_length" type="bool" jt="-7" mandatory="y" >
-				<defo>f</defo>
-				<comment><![CDATA[Whether to trim the sequence length or not]]></comment>
-			</column>
-			<column name="min_qual_score" type="integer" jt="4" mandatory="y" >
-				<defo>25</defo>
-				<comment><![CDATA[The minimum phred quality score]]></comment>
-			</column>
-			<column name="max_ambig" type="integer" jt="4" mandatory="y" >
-				<defo>6</defo>
-				<comment><![CDATA[The maximum number of ambiguous characters]]></comment>
-			</column>
-			<column name="max_homopolymer" type="integer" jt="4" mandatory="y" >
-				<defo>6</defo>
-				<comment><![CDATA[The maximum homopolymer run]]></comment>
-			</column>
-			<column name="max_primer_mismatch" type="integer" jt="4" mandatory="y" >
-				<defo>0</defo>
-				<comment><![CDATA[Maximum number of mismatches to the primer allowed]]></comment>
-			</column>
-			<column name="barcode_type" type="varchar" jt="12" mandatory="y" >
-				<defo>&#039;golay_12&#039;</defo>
-				<comment><![CDATA[The barcode type used]]></comment>
-			</column>
-			<column name="max_barcode_errors" type="real" jt="7" mandatory="y" >
-				<defo>1.5</defo>
-				<comment><![CDATA[The maximum number of allowed barcode errors]]></comment>
-			</column>
-			<column name="disable_bc_correction" type="bool" jt="-7" mandatory="y" >
-				<defo>f</defo>
-				<comment><![CDATA[Disable barcode correction]]></comment>
-			</column>
-			<column name="qual_score_window" type="integer" jt="4" mandatory="y" >
-				<defo>0</defo>
-				<comment><![CDATA[Enable a sliding window quality score threshold, this is the size of the window]]></comment>
-			</column>
-			<column name="disable_primers" type="bool" jt="-7" mandatory="y" >
-				<defo>f</defo>
-				<comment><![CDATA[Disable primer checking]]></comment>
-			</column>
-			<column name="reverse_primers" type="varchar" jt="12" mandatory="y" >
-				<defo>&#039;disable&#039;</defo>
-				<comment><![CDATA[Check for reverse primers]]></comment>
-			</column>
-			<column name="reverse_primer_mismatches" type="integer" jt="4" mandatory="y" >
-				<defo>0</defo>
-				<comment><![CDATA[The number of allowed mismatches in the reverse primer]]></comment>
-			</column>
-			<column name="truncate_ambig_bases_bool" type="bool" jt="-7" mandatory="y" >
-				<defo>f</defo>
-				<comment><![CDATA[Truncate at the first ambiguous base]]></comment>
-			</column>
-			<index name="pk_preprocessed_sequence_454_params" unique="PRIMARY_KEY" >
-				<column name="parameters_id" />
-			</index>
-		</table>
-		<table name="preprocessed_sequence_illumina_params" >
-			<comment>Parameters used for processing illumina sequence data.</comment>
-			<column name="parameters_id" type="bigserial" jt="-5" mandatory="y" />
-			<column name="max_bad_run_length" type="integer" jt="4" mandatory="y" >
-				<defo>3</defo>
-			</column>
-			<column name="min_per_read_length_fraction" type="real" jt="7" mandatory="y" >
-				<defo>0.75</defo>
-			</column>
-			<column name="sequence_max_n" type="integer" jt="4" mandatory="y" >
-				<defo>0</defo>
-			</column>
-			<column name="rev_comp_barcode" type="bool" jt="-7" mandatory="y" >
-				<defo>FALSE</defo>
-			</column>
-			<column name="rev_comp_mapping_barcodes" type="bool" jt="-7" mandatory="y" >
-				<defo>FALSE</defo>
-			</column>
-			<column name="rev_comp" type="bool" jt="-7" mandatory="y" >
-				<defo>FALSE</defo>
-			</column>
-			<column name="phred_quality_threshold" type="integer" jt="4" mandatory="y" >
-				<defo>3</defo>
-			</column>
-			<column name="barcode_type" type="varchar" jt="12" mandatory="y" >
-				<defo>&#039;golay_12&#039;</defo>
-			</column>
-			<column name="max_barcode_errors" type="real" jt="7" mandatory="y" >
-				<defo>1.5</defo>
-			</column>
-			<column name="param_set_name" type="varchar" length="100" jt="12" mandatory="y" >
-				<comment><![CDATA[The name of the parameter set]]></comment>
-			</column>
-			<index name="pk_preprocessed_sequence_illumina_params" unique="PRIMARY_KEY" >
-				<column name="parameters_id" />
-			</index>
-		</table>
-		<table name="preprocessed_spectra_params" >
-			<comment>Parameters used for processing spectra data.</comment>
-			<column name="parameters_id" type="bigserial" jt="-5" mandatory="y" />
-			<column name="col" type="varchar" jt="12" />
-			<index name="pk_preprocessed_spectra_params" unique="PRIMARY_KEY" >
-				<column name="parameters_id" />
-			</index>
-		</table>
-		<table name="processed_params_sortmerna" >
-			<comment>Parameters used for processing data using method sortmerna</comment>
-			<column name="parameters_id" type="bigserial" jt="-5" mandatory="y" />
-			<column name="reference_id" type="bigint" jt="-5" mandatory="y" >
-				<comment><![CDATA[What version of reference or type of reference used]]></comment>
-			</column>
-			<column name="sortmerna_e_value" type="float8" jt="6" mandatory="y" />
-			<column name="sortmerna_max_pos" type="integer" jt="4" mandatory="y" />
-			<column name="similarity" type="float8" jt="6" mandatory="y" />
-			<column name="sortmerna_coverage" type="float8" jt="6" mandatory="y" />
-			<column name="threads" type="integer" jt="4" mandatory="y" />
-			<column name="param_set_name" type="varchar" length="100" jt="12" mandatory="y" >
-				<defo>&#039;Default&#039;</defo>
-				<comment><![CDATA[The name of the parameter set]]></comment>
-			</column>
-			<index name="pk_processed_params_sortmerna" unique="PRIMARY_KEY" >
-				<column name="parameters_id" />
-			</index>
-			<index name="idx_processed_params_sortmerna" unique="NORMAL" >
-				<column name="reference_id" />
-			</index>
-			<fk name="fk_processed_params_sortmerna" to_schema="qiita" to_table="reference" >
-				<fk_column name="reference_id" pk="reference_id" />
-			</fk>
-		</table>
-		<table name="processed_params_uclust" >
-			<comment>Parameters used for processing data using method uclust</comment>
-			<column name="parameters_id" type="bigserial" jt="-5" mandatory="y" />
-			<column name="reference_id" type="bigint" jt="-5" mandatory="y" >
-				<comment><![CDATA[What version of reference or type of reference used]]></comment>
-			</column>
-			<column name="similarity" type="float8" jt="6" mandatory="y" >
-				<defo>0.97</defo>
-			</column>
-			<column name="enable_rev_strand_match" type="bool" jt="-7" mandatory="y" >
-				<defo>TRUE</defo>
-			</column>
-			<column name="suppress_new_clusters" type="bool" jt="-7" mandatory="y" >
-				<defo>TRUE</defo>
-			</column>
-			<index name="pk_processed_params_uclust" unique="PRIMARY_KEY" >
-				<column name="parameters_id" />
-			</index>
-			<index name="idx_processed_params_uclust" unique="NORMAL" >
-				<column name="reference_id" />
-			</index>
-			<fk name="fk_processed_params_uclust" to_schema="qiita" to_table="reference" >
-				<fk_column name="reference_id" pk="reference_id" />
-			</fk>
-		</table>
 		<table name="processing_job" >
 			<column name="processing_job_id" type="bigserial" jt="-5" mandatory="y" >
 				<comment><![CDATA[Using bigserial in DBSchema - however in the postgres DB this column is of type UUID.]]></comment>
@@ -1129,8 +964,8 @@
 			<column name="command_id" type="bigint" jt="-5" mandatory="y" >
 				<comment><![CDATA[The command launched]]></comment>
 			</column>
-			<column name="command_parameters_id" type="bigint" jt="-5" mandatory="y" >
-				<comment><![CDATA[The parameters used in the command]]></comment>
+			<column name="command_parameters" type="varchar" jt="12" mandatory="y" >
+				<comment><![CDATA[The parameters used in the command in JSON format]]></comment>
 			</column>
 			<column name="processing_job_status_id" type="bigint" length="1" jt="-5" mandatory="y" />
 			<column name="logging_id" type="bigint" jt="-5" >
@@ -1728,19 +1563,14 @@ Controlled Vocabulary]]></comment>
 		<entity schema="qiita" name="timeseries_type" color="c0d4f3" x="2235" y="555" />
 		<entity schema="qiita" name="study_publication" color="b2cdf7" x="2340" y="705" />
 		<entity schema="qiita" name="data_directory" color="b2cdf7" x="840" y="735" />
-		<entity schema="qiita" name="preprocessed_spectra_params" color="d0def5" x="1995" y="1830" />
-		<entity schema="qiita" name="processed_params_uclust" color="d0def5" x="1725" y="1470" />
-		<entity schema="qiita" name="reference" color="c0d4f3" x="1725" y="1290" />
-		<entity schema="qiita" name="processing_job_status" color="b2cdf7" x="1740" y="1170" />
-		<entity schema="qiita" name="processing_job" color="b2cdf7" x="1740" y="975" />
-		<entity schema="qiita" name="preprocessed_sequence_454_params" color="c0d4f3" x="1725" y="1605" />
-		<entity schema="qiita" name="processed_params_sortmerna" color="a8c4ef" x="1980" y="1425" />
-		<entity schema="qiita" name="preprocessed_sequence_illumina_params" color="d0def5" x="1980" y="1605" />
-		<entity schema="qiita" name="command_parameter" color="b2cdf7" x="2055" y="870" />
-		<entity schema="qiita" name="default_parameter_set" color="b2cdf7" x="2025" y="1005" />
-		<entity schema="qiita" name="software" color="b2cdf7" x="2040" y="750" />
-		<entity schema="qiita" name="software_command" color="b2cdf7" x="1845" y="750" />
+		<entity schema="qiita" name="reference" color="c0d4f3" x="1785" y="1290" />
+		<entity schema="qiita" name="software" color="b2cdf7" x="2100" y="750" />
+		<entity schema="qiita" name="software_command" color="b2cdf7" x="1905" y="750" />
 		<entity schema="qiita" name="artifact" color="b2cdf7" x="1200" y="750" />
+		<entity schema="qiita" name="processing_job_status" color="b2cdf7" x="2025" y="1140" />
+		<entity schema="qiita" name="processing_job" color="b2cdf7" x="1800" y="1095" />
+		<entity schema="qiita" name="default_parameter_set" color="b2cdf7" x="2100" y="930" />
+		<entity schema="qiita" name="command_parameter" color="b2cdf7" x="1920" y="945" />
 		<group name="Group_analyses" color="c4e0f9" >
 			<comment>analysis tables</comment>
 			<entity schema="qiita" name="analysis" />
@@ -1828,12 +1658,7 @@ Controlled Vocabulary]]></comment>
 			<entity schema="qiita" name="prep_template" />
 		</group>
 		<group name="Group_processing" color="c4e0f9" >
-			<entity schema="qiita" name="preprocessed_sequence_454_params" />
-			<entity schema="qiita" name="preprocessed_sequence_illumina_params" />
 			<entity schema="qiita" name="reference" />
-			<entity schema="qiita" name="processed_params_uclust" />
-			<entity schema="qiita" name="processed_params_sortmerna" />
-			<entity schema="qiita" name="preprocessed_spectra_params" />
 			<entity schema="qiita" name="software" />
 			<entity schema="qiita" name="software_command" />
 			<entity schema="qiita" name="processing_job" />

--- a/qiita_db/support_files/qiita-db.dbs
+++ b/qiita_db/support_files/qiita-db.dbs
@@ -476,6 +476,23 @@
 				<fk_column name="data_type_id" pk="data_type_id" />
 			</fk>
 		</table>
+		<table name="command_parameter" >
+			<column name="command_id" type="bigint" jt="-5" mandatory="y" />
+			<column name="parameter_name" type="varchar" jt="12" mandatory="y" />
+			<column name="parameter_type" type="varchar" jt="12" mandatory="y" />
+			<column name="required" type="bool" jt="-7" mandatory="y" />
+			<column name="default_value" type="varchar" jt="12" />
+			<index name="idx_command_parameter" unique="NORMAL" >
+				<column name="command_id" />
+			</index>
+			<index name="idx_command_parameter_0" unique="PRIMARY_KEY" >
+				<column name="command_id" />
+				<column name="parameter_name" />
+			</index>
+			<fk name="fk_command_parameter" to_schema="qiita" to_table="software_command" >
+				<fk_column name="command_id" pk="command_id" />
+			</fk>
+		</table>
 		<table name="controlled_vocab" >
 			<column name="controlled_vocab_id" type="bigserial" jt="-5" mandatory="y" />
 			<column name="controlled_vocab" type="varchar" jt="12" mandatory="y" />
@@ -522,6 +539,27 @@
 			<index name="idx_data_type" unique="UNIQUE" >
 				<column name="data_type" />
 			</index>
+		</table>
+		<table name="default_parameter_set" >
+			<column name="default_parameter_set_id" type="bigserial" jt="-5" mandatory="y" />
+			<column name="command_id" type="bigint" jt="-5" mandatory="y" />
+			<column name="parameter_set_name" type="varchar" jt="12" mandatory="y" />
+			<column name="parameter_set" type="varchar" jt="12" mandatory="y" >
+				<comment><![CDATA[This is a varchar here - but is of type JSON in postgresql.]]></comment>
+			</column>
+			<index name="pk_default_parameter_set" unique="PRIMARY_KEY" >
+				<column name="default_parameter_set_id" />
+			</index>
+			<index name="idx_default_parameter_set" unique="NORMAL" >
+				<column name="command_id" />
+			</index>
+			<index name="idx_default_parameter_set_0" unique="UNIQUE" >
+				<column name="command_id" />
+				<column name="parameter_set_name" />
+			</index>
+			<fk name="fk_default_parameter_set" to_schema="qiita" to_table="software_command" >
+				<fk_column name="command_id" pk="command_id" />
+			</fk>
 		</table>
 		<table name="ebi_run_accession" >
 			<column name="sample_id" type="varchar" jt="12" mandatory="y" />
@@ -1693,14 +1731,16 @@ Controlled Vocabulary]]></comment>
 		<entity schema="qiita" name="study_publication" color="b2cdf7" x="2340" y="705" />
 		<entity schema="qiita" name="data_directory" color="b2cdf7" x="840" y="735" />
 		<entity schema="qiita" name="artifact" color="b2cdf7" x="1200" y="750" />
-		<entity schema="qiita" name="reference" color="c0d4f3" x="1725" y="1125" />
-		<entity schema="qiita" name="processed_params_uclust" color="d0def5" x="1725" y="1290" />
-		<entity schema="qiita" name="preprocessed_sequence_454_params" color="c0d4f3" x="1725" y="1425" />
-		<entity schema="qiita" name="preprocessed_spectra_params" color="d0def5" x="2010" y="1590" />
-		<entity schema="qiita" name="preprocessed_sequence_illumina_params" color="d0def5" x="1980" y="1365" />
-		<entity schema="qiita" name="processed_params_sortmerna" color="a8c4ef" x="1935" y="1185" />
-		<entity schema="qiita" name="processing_job" color="b2cdf7" x="1935" y="915" />
-		<entity schema="qiita" name="processing_job_status" color="b2cdf7" x="1995" y="1095" />
+		<entity schema="qiita" name="preprocessed_spectra_params" color="d0def5" x="1995" y="1830" />
+		<entity schema="qiita" name="processed_params_uclust" color="d0def5" x="1725" y="1470" />
+		<entity schema="qiita" name="reference" color="c0d4f3" x="1725" y="1290" />
+		<entity schema="qiita" name="processing_job_status" color="b2cdf7" x="1740" y="1170" />
+		<entity schema="qiita" name="default_parameter_set" color="b2cdf7" x="2025" y="1065" />
+		<entity schema="qiita" name="processing_job" color="b2cdf7" x="1740" y="975" />
+		<entity schema="qiita" name="preprocessed_sequence_454_params" color="c0d4f3" x="1725" y="1605" />
+		<entity schema="qiita" name="processed_params_sortmerna" color="a8c4ef" x="1980" y="1425" />
+		<entity schema="qiita" name="command_parameter" color="b2cdf7" x="2055" y="900" />
+		<entity schema="qiita" name="preprocessed_sequence_illumina_params" color="d0def5" x="1980" y="1605" />
 		<group name="Group_analyses" color="c4e0f9" >
 			<comment>analysis tables</comment>
 			<entity schema="qiita" name="analysis" />
@@ -1798,11 +1838,44 @@ Controlled Vocabulary]]></comment>
 			<entity schema="qiita" name="software_command" />
 			<entity schema="qiita" name="processing_job" />
 			<entity schema="qiita" name="processing_job_status" />
+			<entity schema="qiita" name="command_parameter" />
+			<entity schema="qiita" name="default_parameter_set" />
 		</group>
 		<group name="Group_publication" color="ffccff" >
 			<entity schema="qiita" name="publication" />
 			<entity schema="qiita" name="software_publication" />
 			<entity schema="qiita" name="study_publication" />
 		</group>
+		<script name="Sql" id="SQL7779022" >
+			<string><![CDATA[CREATE TABLE qiita.command_parameter ( 
+	command_id           bigint  NOT NULL,
+	parameter_name       varchar  NOT NULL,
+	parameter_type       varchar  NOT NULL,
+	required             bool  NOT NULL,
+	deafult_value        varchar  ,
+	CONSTRAINT idx_command_parameter_0 PRIMARY KEY ( command_id, parameter_name )
+ ) ;
+
+CREATE INDEX idx_command_parameter ON qiita.command_parameter ( command_id ) ;
+
+CREATE TABLE qiita.default_parameter_set ( 
+	default_parameter_set_id bigserial  NOT NULL,
+	command_id           bigint  NOT NULL,
+	parameter_set_name   varchar  NOT NULL,
+	parameter_set        varchar  NOT NULL,
+	CONSTRAINT pk_default_parameter_set PRIMARY KEY ( default_parameter_set_id ),
+	CONSTRAINT idx_default_parameter_set_0 UNIQUE ( command_id, parameter_set_name ) 
+ ) ;
+
+CREATE INDEX idx_default_parameter_set ON qiita.default_parameter_set ( command_id ) ;
+
+COMMENT ON COLUMN qiita.default_parameter_set.parameter_set IS 'This is a varchar here - but is of type JSON in postgresql.';
+
+ALTER TABLE qiita.command_parameter ADD CONSTRAINT fk_command_parameter FOREIGN KEY ( command_id ) REFERENCES qiita.software_command( command_id )    ;
+
+ALTER TABLE qiita.default_parameter_set ADD CONSTRAINT fk_default_parameter_set FOREIGN KEY ( command_id ) REFERENCES qiita.software_command( command_id )    ;
+
+]]></string>
+		</script>
 	</layout>
 </project>

--- a/qiita_db/support_files/qiita-db.html
+++ b/qiita_db/support_files/qiita-db.html
@@ -313,9 +313,9 @@ table {
 <rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='1045' y='133' width='760' height='2' />
 
 <!-- ============= Group 'Group_processing' ============= -->
-<rect class='grp' style='fill:#c4e0f9;stroke:#c5d4e0' x='1709' y='745' width='527' height='1175' />
-<text x='1720' y='760'>Group_processing</text>
-<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='1720' y='763' width='505' height='2' />
+<rect class='grp' style='fill:#c4e0f9;stroke:#c5d4e0' x='1709' y='715' width='527' height='1205' />
+<text x='1720' y='730'>Group_processing</text>
+<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='1720' y='733' width='505' height='2' />
 
 <!-- ============= Group 'Group_publication' ============= -->
 <rect class='grp' style='fill:#ffccff;stroke:#e0c5e0' x='2324' y='670' width='317' height='215' />
@@ -707,7 +707,7 @@ table {
 	study_artifact references artifact ( artifact_id )</title>
 </path>
 <text x='1538' y='700' transform='rotate(0 1538,700)' title='Foreign Key fk_study_artifact_artifact
-	study_artifact references artifact ( artifact_id )' style='fill:#a1a0a0;'>artifact_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2325 795 L 2025,795' >
+	study_artifact references artifact ( artifact_id )' style='fill:#a1a0a0;'>artifact_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2325 795 L 2145,795' >
 	<title>Foreign Key fk_software_publication
 	software_publication references software ( software_id )</title>
 </path>
@@ -727,12 +727,7 @@ table {
 	ebi_run_accession references artifact ( artifact_id )</title>
 </path>
 <text x='1283' y='955' transform='rotate(0 1283,955)' title='Foreign Key fk_ebi_run_accession_artifact
-	ebi_run_accession references artifact ( artifact_id )' style='fill:#a1a0a0;'>artifact_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1875 795 L 1905,795' >
-	<title>Foreign Key fk_soft_command_software
-	software_command references software ( software_id )</title>
-</path>
-<text x='1882' y='790' transform='rotate(0 1882,790)' title='Foreign Key fk_soft_command_software
-	software_command references software ( software_id )' style='fill:#a1a0a0;'>software_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2325 705 L 2107,705 Q 2100,705 2100,697 L 2100,630' >
+	ebi_run_accession references artifact ( artifact_id )' style='fill:#a1a0a0;'>artifact_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2325 705 L 2107,705 Q 2100,705 2100,697 L 2100,630' >
 	<title>Foreign Key fk_study_publication_study
 	study_publication references study ( study_id )</title>
 </path>
@@ -742,27 +737,7 @@ table {
 	study_publication references publication ( publication_doi -> doi )</title>
 </path>
 <text x='2467' y='760' transform='rotate(0 2467,760)' title='Foreign Key fk_study_publication
-	study_publication references publication ( publication_doi -> doi )' style='fill:#a1a0a0;'>publication_doi</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1185 915 L 1177,915 Q 1170,915 1170,922 L 1170,930' >
-	<title>Foreign Key fk_artifact_visibility
-	artifact references visibility ( visibility_id )</title>
-</path>
-<text x='1127' y='910' transform='rotate(0 1127,910)' title='Foreign Key fk_artifact_visibility
-	artifact references visibility ( visibility_id )' style='fill:#a1a0a0;'>visibility_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1395 840 L 1417,840 Q 1425,840 1425,832 L 1425,825' >
-	<title>Foreign Key fk_artifact_filetype
-	artifact references artifact_type ( artifact_type_id )</title>
-</path>
-<text x='1402' y='835' transform='rotate(0 1402,835)' title='Foreign Key fk_artifact_filetype
-	artifact references artifact_type ( artifact_type_id )' style='fill:#a1a0a0;'>artifact_type_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1395 855 L 1725,855' >
-	<title>Foreign Key fk_artifact_soft_command
-	artifact references software_command ( command_id )</title>
-</path>
-<text x='1402' y='850' transform='rotate(0 1402,850)' title='Foreign Key fk_artifact_soft_command
-	artifact references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1215 945 L 1215,1132 Q 1215,1140 1207,1140 L 787,1140 Q 780,1140 780,1147 L 780,1155' >
-	<title>Foreign Key fk_artifact_data_type
-	artifact references data_type ( data_type_id )</title>
-</path>
-<text x='1228' y='945' transform='rotate(90 1228,945)' title='Foreign Key fk_artifact_data_type
-	artifact references data_type ( data_type_id )' style='fill:#a1a0a0;'>data_type_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1740 1455 L 1740,1425' >
+	study_publication references publication ( publication_doi -> doi )' style='fill:#a1a0a0;'>publication_doi</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1740 1455 L 1740,1425' >
 	<title>Foreign Key fk_processed_params_uclust
 	processed_params_uclust references reference ( reference_id )</title>
 </path>
@@ -782,21 +757,16 @@ table {
 	reference references filepath ( tree_filepath -> filepath_id )</title>
 </path>
 <text x='1645' y='1315' transform='rotate(0 1645,1315)' title='Foreign Key fk_reference_tree_filepath
-	reference references filepath ( tree_filepath -> filepath_id )' style='fill:#a1a0a0;'>tree_filepath</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2010 1065 L 1942,1065 Q 1935,1065 1935,1057 L 1935,937 Q 1935,930 1927,930 L 1867,930 Q 1860,930 1860,922 L 1860,915' >
-	<title>Foreign Key fk_default_parameter_set
-	default_parameter_set references software_command ( command_id )</title>
-</path>
-<text x='1943' y='1060' transform='rotate(0 1943,1060)' title='Foreign Key fk_default_parameter_set
-	default_parameter_set references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1725 1050 L 1012,1050 Q 1005,1050 1005,1042 L 1005,412 Q 1005,405 997,405 L 480,405' >
+	reference references filepath ( tree_filepath -> filepath_id )' style='fill:#a1a0a0;'>tree_filepath</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1725 1050 L 1012,1050 Q 1005,1050 1005,1042 L 1005,412 Q 1005,405 997,405 L 480,405' >
 	<title>Foreign Key fk_processing_job_qiita_user
 	processing_job references qiita_user ( email )</title>
 </path>
 <text x='1699' y='1045' transform='rotate(0 1699,1045)' title='Foreign Key fk_processing_job_qiita_user
-	processing_job references qiita_user ( email )' style='fill:#a1a0a0;'>email</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1755 960 L 1755,915' >
+	processing_job references qiita_user ( email )' style='fill:#a1a0a0;'>email</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1860 960 L 1860,855' >
 	<title>Foreign Key fk_processing_job
 	processing_job references software_command ( command_id )</title>
 </path>
-<text x='1757' y='955' transform='rotate(270 1757,955)' title='Foreign Key fk_processing_job
+<text x='1862' y='955' transform='rotate(270 1862,955)' title='Foreign Key fk_processing_job
 	processing_job references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1755 1140 L 1755,1155' >
 	<title>Foreign Key fk_processing_job_status
 	processing_job references processing_job_status ( processing_job_status_id )</title>
@@ -812,12 +782,42 @@ table {
 	processed_params_sortmerna references reference ( reference_id )</title>
 </path>
 <text x='1900' y='1435' transform='rotate(0 1900,1435)' title='Foreign Key fk_processed_params_sortmerna
-	processed_params_sortmerna references reference ( reference_id )' style='fill:#a1a0a0;'>reference_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2040 900 L 1875,900' >
+	processed_params_sortmerna references reference ( reference_id )' style='fill:#a1a0a0;'>reference_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2040 870 L 1957,870 Q 1950,870 1950,862 L 1950,855' >
 	<title>Foreign Key fk_command_parameter
 	command_parameter references software_command ( command_id )</title>
 </path>
-<text x='1973' y='895' transform='rotate(0 1973,895)' title='Foreign Key fk_command_parameter
-	command_parameter references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><!-- ============= Table 'controlled_vocab_values' ============= -->
+<text x='1973' y='865' transform='rotate(0 1973,865)' title='Foreign Key fk_command_parameter
+	command_parameter references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2010 1005 L 1942,1005 Q 1935,1005 1935,997 L 1935,855' >
+	<title>Foreign Key fk_default_parameter_set
+	default_parameter_set references software_command ( command_id )</title>
+</path>
+<text x='1943' y='1000' transform='rotate(0 1943,1000)' title='Foreign Key fk_default_parameter_set
+	default_parameter_set references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1965 765 L 2025,765' >
+	<title>Foreign Key fk_soft_command_software
+	software_command references software ( software_id )</title>
+</path>
+<text x='1972' y='760' transform='rotate(0 1972,760)' title='Foreign Key fk_soft_command_software
+	software_command references software ( software_id )' style='fill:#a1a0a0;'>software_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1185 915 L 1177,915 Q 1170,915 1170,922 L 1170,930' >
+	<title>Foreign Key fk_artifact_visibility
+	artifact references visibility ( visibility_id )</title>
+</path>
+<text x='1127' y='910' transform='rotate(0 1127,910)' title='Foreign Key fk_artifact_visibility
+	artifact references visibility ( visibility_id )' style='fill:#a1a0a0;'>visibility_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1395 840 L 1417,840 Q 1425,840 1425,832 L 1425,825' >
+	<title>Foreign Key fk_artifact_filetype
+	artifact references artifact_type ( artifact_type_id )</title>
+</path>
+<text x='1402' y='835' transform='rotate(0 1402,835)' title='Foreign Key fk_artifact_filetype
+	artifact references artifact_type ( artifact_type_id )' style='fill:#a1a0a0;'>artifact_type_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1395 870 L 1867,870 Q 1875,870 1875,862 L 1875,855' >
+	<title>Foreign Key fk_artifact_soft_command
+	artifact references software_command ( command_id )</title>
+</path>
+<text x='1402' y='865' transform='rotate(0 1402,865)' title='Foreign Key fk_artifact_soft_command
+	artifact references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1215 945 L 1215,1132 Q 1215,1140 1207,1140 L 787,1140 Q 780,1140 780,1147 L 780,1155' >
+	<title>Foreign Key fk_artifact_data_type
+	artifact references data_type ( data_type_id )</title>
+</path>
+<text x='1228' y='945' transform='rotate(90 1228,945)' title='Foreign Key fk_artifact_data_type
+	artifact references data_type ( data_type_id )' style='fill:#a1a0a0;'>data_type_id</text><!-- ============= Table 'controlled_vocab_values' ============= -->
 <rect class='table' x='45' y='1688' width='150' height='120' rx='7' ry='7' />
 <path d='M 45.50 1714.50 L 45.50 1695.50 Q 45.50 1688.50 52.50 1688.50 L 187.50 1688.50 Q 194.50 1688.50 194.50 1695.50 L 194.50 1714.50 L45.50 1714.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
 <a xlink:href='#controlled_vocab_values'><text x='53' y='1702' class='tableTitle'>controlled_vocab_values</text><title>Table qiita.controlled_vocab_values</title></a>
@@ -1670,18 +1670,6 @@ Data type &#040;16S&#044; metabolome&#044; etc&#041; the job will use</title></a
 <a xlink:href='#study_artifact.artifact_id'><text x='1623' y='757'>artifact_id</text><title>artifact_id bigint not null</title></a>
 <a xlink:href='#study_artifact.artifact_id'><use id='fk' x='1683' y='746' xlink:href='#fk'/><title>References artifact ( artifact_id ) </title></a>
 
-<!-- ============= Table 'software' ============= -->
-<rect class='table' x='1920' y='773' width='105' height='105' rx='7' ry='7' />
-<path d='M 1920.50 799.50 L 1920.50 780.50 Q 1920.50 773.50 1927.50 773.50 L 2017.50 773.50 Q 2024.50 773.50 2024.50 780.50 L 2024.50 799.50 L1920.50 799.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#software'><text x='1949' y='787' class='tableTitle'>software</text><title>Table qiita.software</title></a>
-  <use id='nn' x='1922' y='807' xlink:href='#nn'/><a xlink:href='#software.software_id'><use id='pk' x='1922' y='806' xlink:href='#pk'/><title>Primary Key  ( software_id ) </title></a>
-<a xlink:href='#software.software_id'><text x='1938' y='817'>software_id</text><title>software_id bigserial not null</title></a>
-<a xlink:href='#software.software_id'><use id='ref' x='2013' y='806' xlink:href='#ref'/><title>Referred by software_command ( software_id ) 
-Referred by software_publication ( software_id ) </title></a>
-  <use id='nn' x='1922' y='822' xlink:href='#nn'/><a xlink:href='#software.name'><text x='1938' y='832'>name</text><title>name varchar not null</title></a>
-  <use id='nn' x='1922' y='837' xlink:href='#nn'/><a xlink:href='#software.version'><text x='1938' y='847'>version</text><title>version varchar not null</title></a>
-  <use id='nn' x='1922' y='852' xlink:href='#nn'/><a xlink:href='#software.description'><text x='1938' y='862'>description</text><title>description varchar not null</title></a>
-
 <!-- ============= Table 'software_publication' ============= -->
 <rect class='table' x='2340' y='788' width='135' height='75' rx='7' ry='7' />
 <path d='M 2340.50 814.50 L 2340.50 795.50 Q 2340.50 788.50 2347.50 788.50 L 2467.50 788.50 Q 2474.50 788.50 2474.50 795.50 L 2474.50 814.50 L2340.50 814.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
@@ -1744,26 +1732,6 @@ Type of artifact</title></a>
 <a xlink:href='#artifact_type.artifact_type'><text x='1428' y='787'>artifact_type</text><title>artifact_type varchar not null</title></a>
   <use id='nn' x='1412' y='792' xlink:href='#nn'/><a xlink:href='#artifact_type.description'><text x='1428' y='802'>description</text><title>description varchar not null</title></a>
 
-<!-- ============= Table 'software_command' ============= -->
-<rect class='table' x='1740' y='773' width='135' height='135' rx='7' ry='7' />
-<path d='M 1740.50 799.50 L 1740.50 780.50 Q 1740.50 773.50 1747.50 773.50 L 1867.50 773.50 Q 1874.50 773.50 1874.50 780.50 L 1874.50 799.50 L1740.50 799.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#software_command'><text x='1755' y='787' class='tableTitle'>software_command</text><title>Table qiita.software_command</title></a>
-  <use id='nn' x='1742' y='807' xlink:href='#nn'/><a xlink:href='#software_command.command_id'><use id='pk' x='1742' y='806' xlink:href='#pk'/><title>Primary Key  ( command_id ) </title></a>
-<a xlink:href='#software_command.command_id'><text x='1758' y='817'>command_id</text><title>command_id bigserial not null</title></a>
-<a xlink:href='#software_command.command_id'><use id='ref' x='1863' y='806' xlink:href='#ref'/><title>Referred by artifact ( command_id ) 
-Referred by processing_job ( command_id ) 
-Referred by command_parameter ( command_id ) 
-Referred by command_parameter ( command_id ) 
-Referred by default_parameter_set ( command_id ) 
-Referred by default_parameter_set ( command_id ) </title></a>
-  <use id='nn' x='1742' y='822' xlink:href='#nn'/><a xlink:href='#software_command.name'><text x='1758' y='832'>name</text><title>name varchar not null</title></a>
-  <use id='nn' x='1742' y='837' xlink:href='#nn'/><a xlink:href='#software_command.software_id'><use id='idx' x='1742' y='836' xlink:href='#idx'/><title>Index  ( software_id ) </title></a>
-<a xlink:href='#software_command.software_id'><text x='1758' y='847'>software_id</text><title>software_id bigint not null</title></a>
-<a xlink:href='#software_command.software_id'><use id='fk' x='1863' y='836' xlink:href='#fk'/><title>References software ( software_id ) </title></a>
-  <use id='nn' x='1742' y='852' xlink:href='#nn'/><a xlink:href='#software_command.description'><text x='1758' y='862'>description</text><title>description varchar not null</title></a>
-  <a xlink:href='#software_command.cli_cmd'><text x='1758' y='877'>cli_cmd</text><title>cli_cmd varchar</title></a>
-  <use id='nn' x='1742' y='882' xlink:href='#nn'/><a xlink:href='#software_command.parameters_table'><text x='1758' y='892'>parameters_table</text><title>parameters_table varchar not null</title></a>
-
 <!-- ============= Table 'publication' ============= -->
 <rect class='table' x='2535' y='788' width='90' height='75' rx='7' ry='7' />
 <path d='M 2535.50 814.50 L 2535.50 795.50 Q 2535.50 788.50 2542.50 788.50 L 2617.50 788.50 Q 2624.50 788.50 2624.50 795.50 L 2624.50 814.50 L2535.50 814.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
@@ -1808,39 +1776,6 @@ Referred by study_publication ( publication_doi -> doi ) </title></a>
   <use id='nn' x='842' y='792' xlink:href='#nn'/><a xlink:href='#data_directory.mountpoint'><text x='858' y='802'>mountpoint</text><title>mountpoint varchar not null</title></a>
   <use id='nn' x='842' y='807' xlink:href='#nn'/><a xlink:href='#data_directory.subdirectory'><text x='858' y='817'>subdirectory</text><title>subdirectory bool not null default FALSE</title></a>
   <use id='nn' x='842' y='822' xlink:href='#nn'/><a xlink:href='#data_directory.active'><text x='858' y='832'>active</text><title>active bool not null</title></a>
-
-<!-- ============= Table 'artifact' ============= -->
-<rect class='table' x='1200' y='743' width='195' height='195' rx='7' ry='7' />
-<path d='M 1200.50 769.50 L 1200.50 750.50 Q 1200.50 743.50 1207.50 743.50 L 1387.50 743.50 Q 1394.50 743.50 1394.50 750.50 L 1394.50 769.50 L1200.50 769.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#artifact'><text x='1278' y='757' class='tableTitle'>artifact</text><title>Table qiita.artifact
-Represents data in the system</title></a>
-  <use id='nn' x='1202' y='777' xlink:href='#nn'/><a xlink:href='#artifact.artifact_id'><use id='pk' x='1202' y='776' xlink:href='#pk'/><title>Primary Key  ( artifact_id ) </title></a>
-<a xlink:href='#artifact.artifact_id'><text x='1218' y='787'>artifact_id</text><title>artifact_id bigserial not null</title></a>
-<a xlink:href='#artifact.artifact_id'><use id='ref' x='1383' y='776' xlink:href='#ref'/><title>Referred by analysis_sample ( artifact_id ) 
-Referred by artifact_filepath ( artifact_id ) 
-Referred by ebi_run_accession ( artifact_id ) 
-Referred by parent_artifact ( artifact_id ) 
-Referred by parent_artifact ( parent_id -> artifact_id ) 
-Referred by prep_template ( artifact_id ) 
-Referred by study_artifact ( artifact_id ) </title></a>
-  <use id='nn' x='1202' y='792' xlink:href='#nn'/><a xlink:href='#artifact.generated_timestamp'><text x='1218' y='802'>generated_timestamp</text><title>generated_timestamp timestamp not null</title></a>
-  <a xlink:href='#artifact.command_id'><use id='idx' x='1202' y='806' xlink:href='#idx'/><title>Index  ( command_id ) </title></a>
-<a xlink:href='#artifact.command_id'><text x='1218' y='817'>command_id</text><title>command_id bigint</title></a>
-<a xlink:href='#artifact.command_id'><use id='fk' x='1383' y='806' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
-  <a xlink:href='#artifact.command_parameters_id'><text x='1218' y='832'>command_parameters_id</text><title>command_parameters_id bigint</title></a>
-  <use id='nn' x='1202' y='837' xlink:href='#nn'/><a xlink:href='#artifact.visibility_id'><use id='idx' x='1202' y='836' xlink:href='#idx'/><title>Index  ( visibility_id ) </title></a>
-<a xlink:href='#artifact.visibility_id'><text x='1218' y='847'>visibility_id</text><title>visibility_id bigint not null
-If the artifact is sandbox&#044; awaiting&#095;for&#095;approval&#044; private or public</title></a>
-<a xlink:href='#artifact.visibility_id'><use id='fk' x='1383' y='836' xlink:href='#fk'/><title>References visibility ( visibility_id ) </title></a>
-  <a xlink:href='#artifact.artifact_type_id'><use id='idx' x='1202' y='851' xlink:href='#idx'/><title>Index  ( artifact_type_id ) </title></a>
-<a xlink:href='#artifact.artifact_type_id'><text x='1218' y='862'>artifact_type_id</text><title>artifact_type_id integer</title></a>
-<a xlink:href='#artifact.artifact_type_id'><use id='fk' x='1383' y='851' xlink:href='#fk'/><title>References artifact_type ( artifact_type_id ) </title></a>
-  <use id='nn' x='1202' y='867' xlink:href='#nn'/><a xlink:href='#artifact.data_type_id'><use id='idx' x='1202' y='866' xlink:href='#idx'/><title>Index  ( data_type_id ) </title></a>
-<a xlink:href='#artifact.data_type_id'><text x='1218' y='877'>data_type_id</text><title>data_type_id bigint not null</title></a>
-<a xlink:href='#artifact.data_type_id'><use id='fk' x='1383' y='866' xlink:href='#fk'/><title>References data_type ( data_type_id ) </title></a>
-  <use id='nn' x='1202' y='882' xlink:href='#nn'/><a xlink:href='#artifact.can_be_submitted_to_ebi'><text x='1218' y='892'>can_be_submitted_to_ebi</text><title>can_be_submitted_to_ebi bool not null default &#039;FALSE&#039;</title></a>
-  <use id='nn' x='1202' y='897' xlink:href='#nn'/><a xlink:href='#artifact.can_be_submitted_to_vamps'><text x='1218' y='907'>can_be_submitted_to_vamps</text><title>can_be_submitted_to_vamps bool not null default &#039;FALSE&#039;</title></a>
-  <use id='nn' x='1202' y='912' xlink:href='#nn'/><a xlink:href='#artifact.submitted_to_vamps'><text x='1218' y='922'>submitted_to_vamps</text><title>submitted_to_vamps bool not null default &#039;FALSE&#039;</title></a>
 
 <!-- ============= Table 'preprocessed_spectra_params' ============= -->
 <rect class='table' x='1995' y='1823' width='180' height='75' rx='7' ry='7' />
@@ -1895,20 +1830,6 @@ Referred by processed_params_uclust ( reference_id ) </title></a>
 <a xlink:href='#processing_job_status.processing_job_status_id'><use id='ref' x='1953' y='1196' xlink:href='#ref'/><title>Referred by processing_job ( processing_job_status_id ) </title></a>
   <use id='nn' x='1742' y='1212' xlink:href='#nn'/><a xlink:href='#processing_job_status.processing_job_status'><text x='1758' y='1222'>processing_job_status</text><title>processing_job_status varchar not null</title></a>
   <use id='nn' x='1742' y='1227' xlink:href='#nn'/><a xlink:href='#processing_job_status.processing_job_status_description'><text x='1758' y='1237'>processing_job_status_description</text><title>processing_job_status_description varchar not null</title></a>
-
-<!-- ============= Table 'default_parameter_set' ============= -->
-<rect class='table' x='2025' y='1058' width='165' height='105' rx='7' ry='7' />
-<path d='M 2025.50 1084.50 L 2025.50 1065.50 Q 2025.50 1058.50 2032.50 1058.50 L 2182.50 1058.50 Q 2189.50 1058.50 2189.50 1065.50 L 2189.50 1084.50 L2025.50 1084.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#default_parameter_set'><text x='2047' y='1072' class='tableTitle'>default_parameter_set</text><title>Table qiita.default_parameter_set</title></a>
-  <use id='nn' x='2027' y='1092' xlink:href='#nn'/><a xlink:href='#default_parameter_set.default_parameter_set_id'><use id='pk' x='2027' y='1091' xlink:href='#pk'/><title>Primary Key  ( default_parameter_set_id ) </title></a>
-<a xlink:href='#default_parameter_set.default_parameter_set_id'><text x='2043' y='1102'>default_parameter_set_id</text><title>default_parameter_set_id bigserial not null</title></a>
-  <use id='nn' x='2027' y='1107' xlink:href='#nn'/><a xlink:href='#default_parameter_set.command_id'><use id='unq' x='2027' y='1106' xlink:href='#unq'/><title>Index  ( command_id ) Unique Index  ( command_id, parameter_set_name ) </title></a>
-<a xlink:href='#default_parameter_set.command_id'><text x='2043' y='1117'>command_id</text><title>command_id bigint not null</title></a>
-<a xlink:href='#default_parameter_set.command_id'><use id='fk' x='2178' y='1106' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
-  <use id='nn' x='2027' y='1122' xlink:href='#nn'/><a xlink:href='#default_parameter_set.parameter_set_name'><use id='unq' x='2027' y='1121' xlink:href='#unq'/><title>Unique Index  ( command_id, parameter_set_name ) </title></a>
-<a xlink:href='#default_parameter_set.parameter_set_name'><text x='2043' y='1132'>parameter_set_name</text><title>parameter_set_name varchar not null</title></a>
-  <use id='nn' x='2027' y='1137' xlink:href='#nn'/><a xlink:href='#default_parameter_set.parameter_set'><text x='2043' y='1147'>parameter_set</text><title>parameter_set varchar not null
-This is a varchar here &#045; but is of type JSON in postgresql&#046;</title></a>
 
 <!-- ============= Table 'processing_job' ============= -->
 <rect class='table' x='1740' y='968' width='180' height='165' rx='7' ry='7' />
@@ -1997,19 +1918,6 @@ What version of reference or type of reference used</title></a>
   <use id='nn' x='1982' y='1557' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.param_set_name'><text x='1998' y='1567'>param_set_name</text><title>param_set_name varchar&#040;100&#041; not null default &#039;Default&#039;
 The name of the parameter set</title></a>
 
-<!-- ============= Table 'command_parameter' ============= -->
-<rect class='table' x='2055' y='893' width='135' height='120' rx='7' ry='7' />
-<path d='M 2055.50 919.50 L 2055.50 900.50 Q 2055.50 893.50 2062.50 893.50 L 2182.50 893.50 Q 2189.50 893.50 2189.50 900.50 L 2189.50 919.50 L2055.50 919.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#command_parameter'><text x='2065' y='907' class='tableTitle'>command_parameter</text><title>Table qiita.command_parameter</title></a>
-  <use id='nn' x='2057' y='927' xlink:href='#nn'/><a xlink:href='#command_parameter.command_id'><use id='pk' x='2057' y='926' xlink:href='#pk'/><title>Index  ( command_id ) Primary Key  ( command_id, parameter_name ) </title></a>
-<a xlink:href='#command_parameter.command_id'><text x='2073' y='937'>command_id</text><title>command_id bigint not null</title></a>
-<a xlink:href='#command_parameter.command_id'><use id='fk' x='2178' y='926' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
-  <use id='nn' x='2057' y='942' xlink:href='#nn'/><a xlink:href='#command_parameter.parameter_name'><use id='pk' x='2057' y='941' xlink:href='#pk'/><title>Primary Key  ( command_id, parameter_name ) </title></a>
-<a xlink:href='#command_parameter.parameter_name'><text x='2073' y='952'>parameter_name</text><title>parameter_name varchar not null</title></a>
-  <use id='nn' x='2057' y='957' xlink:href='#nn'/><a xlink:href='#command_parameter.parameter_type'><text x='2073' y='967'>parameter_type</text><title>parameter_type varchar not null</title></a>
-  <use id='nn' x='2057' y='972' xlink:href='#nn'/><a xlink:href='#command_parameter.required'><text x='2073' y='982'>required</text><title>required bool not null</title></a>
-  <a xlink:href='#command_parameter.default_value'><text x='2073' y='997'>default_value</text><title>default_value varchar</title></a>
-
 <!-- ============= Table 'preprocessed_sequence_illumina_params' ============= -->
 <rect class='table' x='1980' y='1598' width='240' height='210' rx='7' ry='7' />
 <path d='M 1980.50 1624.50 L 1980.50 1605.50 Q 1980.50 1598.50 1987.50 1598.50 L 2212.50 1598.50 Q 2219.50 1598.50 2219.50 1605.50 L 2219.50 1624.50 L1980.50 1624.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
@@ -2028,6 +1936,97 @@ Parameters used for processing illumina sequence data&#046;</title></a>
   <use id='nn' x='1982' y='1767' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.max_barcode_errors'><text x='1998' y='1777'>max_barcode_errors</text><title>max_barcode_errors real not null default 1&#046;5</title></a>
   <use id='nn' x='1982' y='1782' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.param_set_name'><text x='1998' y='1792'>param_set_name</text><title>param_set_name varchar&#040;100&#041; not null
 The name of the parameter set</title></a>
+
+<!-- ============= Table 'command_parameter' ============= -->
+<rect class='table' x='2055' y='863' width='135' height='120' rx='7' ry='7' />
+<path d='M 2055.50 889.50 L 2055.50 870.50 Q 2055.50 863.50 2062.50 863.50 L 2182.50 863.50 Q 2189.50 863.50 2189.50 870.50 L 2189.50 889.50 L2055.50 889.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#command_parameter'><text x='2065' y='877' class='tableTitle'>command_parameter</text><title>Table qiita.command_parameter</title></a>
+  <use id='nn' x='2057' y='897' xlink:href='#nn'/><a xlink:href='#command_parameter.command_id'><use id='pk' x='2057' y='896' xlink:href='#pk'/><title>Index  ( command_id ) Primary Key  ( command_id, parameter_name ) </title></a>
+<a xlink:href='#command_parameter.command_id'><text x='2073' y='907'>command_id</text><title>command_id bigint not null</title></a>
+<a xlink:href='#command_parameter.command_id'><use id='fk' x='2178' y='896' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
+  <use id='nn' x='2057' y='912' xlink:href='#nn'/><a xlink:href='#command_parameter.parameter_name'><use id='pk' x='2057' y='911' xlink:href='#pk'/><title>Primary Key  ( command_id, parameter_name ) </title></a>
+<a xlink:href='#command_parameter.parameter_name'><text x='2073' y='922'>parameter_name</text><title>parameter_name varchar not null</title></a>
+  <use id='nn' x='2057' y='927' xlink:href='#nn'/><a xlink:href='#command_parameter.parameter_type'><text x='2073' y='937'>parameter_type</text><title>parameter_type varchar not null</title></a>
+  <use id='nn' x='2057' y='942' xlink:href='#nn'/><a xlink:href='#command_parameter.required'><text x='2073' y='952'>required</text><title>required bool not null</title></a>
+  <a xlink:href='#command_parameter.default_value'><text x='2073' y='967'>default_value</text><title>default_value varchar</title></a>
+
+<!-- ============= Table 'default_parameter_set' ============= -->
+<rect class='table' x='2025' y='998' width='165' height='105' rx='7' ry='7' />
+<path d='M 2025.50 1024.50 L 2025.50 1005.50 Q 2025.50 998.50 2032.50 998.50 L 2182.50 998.50 Q 2189.50 998.50 2189.50 1005.50 L 2189.50 1024.50 L2025.50 1024.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#default_parameter_set'><text x='2047' y='1012' class='tableTitle'>default_parameter_set</text><title>Table qiita.default_parameter_set</title></a>
+  <use id='nn' x='2027' y='1032' xlink:href='#nn'/><a xlink:href='#default_parameter_set.default_parameter_set_id'><use id='pk' x='2027' y='1031' xlink:href='#pk'/><title>Primary Key  ( default_parameter_set_id ) </title></a>
+<a xlink:href='#default_parameter_set.default_parameter_set_id'><text x='2043' y='1042'>default_parameter_set_id</text><title>default_parameter_set_id bigserial not null</title></a>
+  <use id='nn' x='2027' y='1047' xlink:href='#nn'/><a xlink:href='#default_parameter_set.command_id'><use id='unq' x='2027' y='1046' xlink:href='#unq'/><title>Index  ( command_id ) Unique Index  ( command_id, parameter_set_name ) </title></a>
+<a xlink:href='#default_parameter_set.command_id'><text x='2043' y='1057'>command_id</text><title>command_id bigint not null</title></a>
+<a xlink:href='#default_parameter_set.command_id'><use id='fk' x='2178' y='1046' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
+  <use id='nn' x='2027' y='1062' xlink:href='#nn'/><a xlink:href='#default_parameter_set.parameter_set_name'><use id='unq' x='2027' y='1061' xlink:href='#unq'/><title>Unique Index  ( command_id, parameter_set_name ) </title></a>
+<a xlink:href='#default_parameter_set.parameter_set_name'><text x='2043' y='1072'>parameter_set_name</text><title>parameter_set_name varchar not null</title></a>
+  <use id='nn' x='2027' y='1077' xlink:href='#nn'/><a xlink:href='#default_parameter_set.parameter_set'><text x='2043' y='1087'>parameter_set</text><title>parameter_set varchar not null
+This is a varchar here &#045; but is of type JSON in postgresql&#046;</title></a>
+
+<!-- ============= Table 'software' ============= -->
+<rect class='table' x='2040' y='743' width='105' height='105' rx='7' ry='7' />
+<path d='M 2040.50 769.50 L 2040.50 750.50 Q 2040.50 743.50 2047.50 743.50 L 2137.50 743.50 Q 2144.50 743.50 2144.50 750.50 L 2144.50 769.50 L2040.50 769.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#software'><text x='2069' y='757' class='tableTitle'>software</text><title>Table qiita.software</title></a>
+  <use id='nn' x='2042' y='777' xlink:href='#nn'/><a xlink:href='#software.software_id'><use id='pk' x='2042' y='776' xlink:href='#pk'/><title>Primary Key  ( software_id ) </title></a>
+<a xlink:href='#software.software_id'><text x='2058' y='787'>software_id</text><title>software_id bigserial not null</title></a>
+<a xlink:href='#software.software_id'><use id='ref' x='2133' y='776' xlink:href='#ref'/><title>Referred by software_command ( software_id ) 
+Referred by software_publication ( software_id ) </title></a>
+  <use id='nn' x='2042' y='792' xlink:href='#nn'/><a xlink:href='#software.name'><text x='2058' y='802'>name</text><title>name varchar not null</title></a>
+  <use id='nn' x='2042' y='807' xlink:href='#nn'/><a xlink:href='#software.version'><text x='2058' y='817'>version</text><title>version varchar not null</title></a>
+  <use id='nn' x='2042' y='822' xlink:href='#nn'/><a xlink:href='#software.description'><text x='2058' y='832'>description</text><title>description varchar not null</title></a>
+
+<!-- ============= Table 'software_command' ============= -->
+<rect class='table' x='1845' y='743' width='120' height='105' rx='7' ry='7' />
+<path d='M 1845.50 769.50 L 1845.50 750.50 Q 1845.50 743.50 1852.50 743.50 L 1957.50 743.50 Q 1964.50 743.50 1964.50 750.50 L 1964.50 769.50 L1845.50 769.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#software_command'><text x='1852' y='757' class='tableTitle'>software_command</text><title>Table qiita.software_command</title></a>
+  <use id='nn' x='1847' y='777' xlink:href='#nn'/><a xlink:href='#software_command.command_id'><use id='pk' x='1847' y='776' xlink:href='#pk'/><title>Primary Key  ( command_id ) </title></a>
+<a xlink:href='#software_command.command_id'><text x='1863' y='787'>command_id</text><title>command_id bigserial not null</title></a>
+<a xlink:href='#software_command.command_id'><use id='ref' x='1953' y='776' xlink:href='#ref'/><title>Referred by artifact ( command_id ) 
+Referred by processing_job ( command_id ) 
+Referred by command_parameter ( command_id ) 
+Referred by command_parameter ( command_id ) 
+Referred by default_parameter_set ( command_id ) 
+Referred by default_parameter_set ( command_id ) </title></a>
+  <use id='nn' x='1847' y='792' xlink:href='#nn'/><a xlink:href='#software_command.name'><text x='1863' y='802'>name</text><title>name varchar not null</title></a>
+  <use id='nn' x='1847' y='807' xlink:href='#nn'/><a xlink:href='#software_command.software_id'><use id='idx' x='1847' y='806' xlink:href='#idx'/><title>Index  ( software_id ) </title></a>
+<a xlink:href='#software_command.software_id'><text x='1863' y='817'>software_id</text><title>software_id bigint not null</title></a>
+<a xlink:href='#software_command.software_id'><use id='fk' x='1953' y='806' xlink:href='#fk'/><title>References software ( software_id ) </title></a>
+  <use id='nn' x='1847' y='822' xlink:href='#nn'/><a xlink:href='#software_command.description'><text x='1863' y='832'>description</text><title>description varchar not null</title></a>
+
+<!-- ============= Table 'artifact' ============= -->
+<rect class='table' x='1200' y='743' width='195' height='195' rx='7' ry='7' />
+<path d='M 1200.50 769.50 L 1200.50 750.50 Q 1200.50 743.50 1207.50 743.50 L 1387.50 743.50 Q 1394.50 743.50 1394.50 750.50 L 1394.50 769.50 L1200.50 769.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#artifact'><text x='1278' y='757' class='tableTitle'>artifact</text><title>Table qiita.artifact
+Represents data in the system</title></a>
+  <use id='nn' x='1202' y='777' xlink:href='#nn'/><a xlink:href='#artifact.artifact_id'><use id='pk' x='1202' y='776' xlink:href='#pk'/><title>Primary Key  ( artifact_id ) </title></a>
+<a xlink:href='#artifact.artifact_id'><text x='1218' y='787'>artifact_id</text><title>artifact_id bigserial not null</title></a>
+<a xlink:href='#artifact.artifact_id'><use id='ref' x='1383' y='776' xlink:href='#ref'/><title>Referred by analysis_sample ( artifact_id ) 
+Referred by artifact_filepath ( artifact_id ) 
+Referred by ebi_run_accession ( artifact_id ) 
+Referred by parent_artifact ( artifact_id ) 
+Referred by parent_artifact ( parent_id -> artifact_id ) 
+Referred by prep_template ( artifact_id ) 
+Referred by study_artifact ( artifact_id ) </title></a>
+  <use id='nn' x='1202' y='792' xlink:href='#nn'/><a xlink:href='#artifact.generated_timestamp'><text x='1218' y='802'>generated_timestamp</text><title>generated_timestamp timestamp not null</title></a>
+  <a xlink:href='#artifact.command_id'><use id='idx' x='1202' y='806' xlink:href='#idx'/><title>Index  ( command_id ) </title></a>
+<a xlink:href='#artifact.command_id'><text x='1218' y='817'>command_id</text><title>command_id bigint</title></a>
+<a xlink:href='#artifact.command_id'><use id='fk' x='1383' y='806' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
+  <a xlink:href='#artifact.command_parameters'><text x='1218' y='832'>command_parameters</text><title>command_parameters varchar
+Varchar in dbschema but is JSON in the postgresDB</title></a>
+  <use id='nn' x='1202' y='837' xlink:href='#nn'/><a xlink:href='#artifact.visibility_id'><use id='idx' x='1202' y='836' xlink:href='#idx'/><title>Index  ( visibility_id ) </title></a>
+<a xlink:href='#artifact.visibility_id'><text x='1218' y='847'>visibility_id</text><title>visibility_id bigint not null
+If the artifact is sandbox&#044; awaiting&#095;for&#095;approval&#044; private or public</title></a>
+<a xlink:href='#artifact.visibility_id'><use id='fk' x='1383' y='836' xlink:href='#fk'/><title>References visibility ( visibility_id ) </title></a>
+  <a xlink:href='#artifact.artifact_type_id'><use id='idx' x='1202' y='851' xlink:href='#idx'/><title>Index  ( artifact_type_id ) </title></a>
+<a xlink:href='#artifact.artifact_type_id'><text x='1218' y='862'>artifact_type_id</text><title>artifact_type_id integer</title></a>
+<a xlink:href='#artifact.artifact_type_id'><use id='fk' x='1383' y='851' xlink:href='#fk'/><title>References artifact_type ( artifact_type_id ) </title></a>
+  <use id='nn' x='1202' y='867' xlink:href='#nn'/><a xlink:href='#artifact.data_type_id'><use id='idx' x='1202' y='866' xlink:href='#idx'/><title>Index  ( data_type_id ) </title></a>
+<a xlink:href='#artifact.data_type_id'><text x='1218' y='877'>data_type_id</text><title>data_type_id bigint not null</title></a>
+<a xlink:href='#artifact.data_type_id'><use id='fk' x='1383' y='866' xlink:href='#fk'/><title>References data_type ( data_type_id ) </title></a>
+  <use id='nn' x='1202' y='882' xlink:href='#nn'/><a xlink:href='#artifact.can_be_submitted_to_ebi'><text x='1218' y='892'>can_be_submitted_to_ebi</text><title>can_be_submitted_to_ebi bool not null default &#039;FALSE&#039;</title></a>
+  <use id='nn' x='1202' y='897' xlink:href='#nn'/><a xlink:href='#artifact.can_be_submitted_to_vamps'><text x='1218' y='907'>can_be_submitted_to_vamps</text><title>can_be_submitted_to_vamps bool not null default &#039;FALSE&#039;</title></a>
+  <use id='nn' x='1202' y='912' xlink:href='#nn'/><a xlink:href='#artifact.submitted_to_vamps'><text x='1218' y='922'>submitted_to_vamps</text><title>submitted_to_vamps bool not null default &#039;FALSE&#039;</title></a>
 
 </g></svg>
 
@@ -4723,40 +4722,6 @@ Controlled Vocabulary </td>
 <br/><br/>
 <table class='bordered'>
 <thead>
-<tr><th colspan='3'><a name='software'>Table software</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='software.software_id'>software&#095;id</a></td>
-		<td> bigserial  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='software.name'>name</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='software.version'>version</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='software.description'>description</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>pk&#095;software primary key</td>
-		<td> ON software&#095;id</td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table class='bordered'>
-<thead>
 <tr><th colspan='3'><a name='software_publication'>Table software_publication</a></th></tr>
 </thead>
 <tbody>
@@ -4960,60 +4925,6 @@ Controlled Vocabulary </td>
 <br/><br/>
 <table class='bordered'>
 <thead>
-<tr><th colspan='3'><a name='software_command'>Table software_command</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='software_command.command_id'>command&#095;id</a></td>
-		<td> bigserial  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='software_command.name'>name</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='software_command.software_id'>software&#095;id</a></td>
-		<td> bigint  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='software_command.description'>description</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='software_command.cli_cmd'>cli&#095;cmd</a></td>
-		<td> varchar   </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='software_command.parameters_table'>parameters&#095;table</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>pk&#095;soft&#095;command primary key</td>
-		<td> ON command&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;soft&#095;command </td>
-		<td> ON software&#095;id</td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
-	<tr>
-		<td>fk_soft_command_software</td>
-		<td > ( software&#095;id ) ref <a href='#software'>software</a> (software&#095;id) </td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table class='bordered'>
-<thead>
 <tr><th colspan='3'><a name='publication'>Table publication</a></th></tr>
 </thead>
 <tbody>
@@ -5145,108 +5056,6 @@ Controlled Vocabulary </td>
 <tr><th colspan='3'><b>Indexes</b></th></tr>
 	<tr>		<td>pk&#095;data&#095;directory primary key</td>
 		<td> ON data&#095;directory&#095;id</td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table class='bordered'>
-<thead>
-<tr><th colspan='3'><a name='artifact'>Table artifact</a></th></tr>
-<tr><td colspan='3'>Represents data in the system </td></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='artifact.artifact_id'>artifact&#095;id</a></td>
-		<td> bigserial  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='artifact.generated_timestamp'>generated&#095;timestamp</a></td>
-		<td> timestamp  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='artifact.command_id'>command&#095;id</a></td>
-		<td> bigint   </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='artifact.command_parameters_id'>command&#095;parameters&#095;id</a></td>
-		<td> bigint   </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='artifact.visibility_id'>visibility&#095;id</a></td>
-		<td> bigint  NOT NULL  </td>
-		<td> If the artifact is sandbox&#044; awaiting&#095;for&#095;approval&#044; private or public </td>
-	</tr>
-	<tr>
-		<td><a name='artifact.artifact_type_id'>artifact&#095;type&#095;id</a></td>
-		<td> integer   </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='artifact.data_type_id'>data&#095;type&#095;id</a></td>
-		<td> bigint  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='artifact.can_be_submitted_to_ebi'>can&#095;be&#095;submitted&#095;to&#095;ebi</a></td>
-		<td> bool  NOT NULL  DEFO 'FALSE' </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='artifact.can_be_submitted_to_vamps'>can&#095;be&#095;submitted&#095;to&#095;vamps</a></td>
-		<td> bool  NOT NULL  DEFO 'FALSE' </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='artifact.submitted_to_vamps'>submitted&#095;to&#095;vamps</a></td>
-		<td> bool  NOT NULL  DEFO 'FALSE' </td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>pk&#095;artifact primary key</td>
-		<td> ON artifact&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;artifact&#095;0 </td>
-		<td> ON visibility&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;artifact&#095;1 </td>
-		<td> ON artifact&#095;type&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;artifact </td>
-		<td> ON command&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;artifact&#095;2 </td>
-		<td> ON data&#095;type&#095;id</td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
-	<tr>
-		<td>fk_artifact_visibility</td>
-		<td > ( visibility&#095;id ) ref <a href='#visibility'>visibility</a> (visibility&#095;id) </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td>fk_artifact_filetype</td>
-		<td > ( artifact&#095;type&#095;id ) ref <a href='#artifact&#095;type'>artifact&#095;type</a> (artifact&#095;type&#095;id) </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td>fk_artifact_soft_command</td>
-		<td > ( command&#095;id ) ref <a href='#software&#095;command'>software&#095;command</a> (command&#095;id) </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td>fk_artifact_data_type</td>
-		<td > ( data&#095;type&#095;id ) ref <a href='#data&#095;type'>data&#095;type</a> (data&#095;type&#095;id) </td>
 		<td>  </td>
 	</tr>
 </tbody>
@@ -5423,54 +5232,6 @@ Controlled Vocabulary </td>
 <tr><th colspan='3'><b>Indexes</b></th></tr>
 	<tr>		<td>pk&#095;processing&#095;job&#095;status primary key</td>
 		<td> ON processing&#095;job&#095;status&#095;id</td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table class='bordered'>
-<thead>
-<tr><th colspan='3'><a name='default_parameter_set'>Table default_parameter_set</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='default_parameter_set.default_parameter_set_id'>default&#095;parameter&#095;set&#095;id</a></td>
-		<td> bigserial  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='default_parameter_set.command_id'>command&#095;id</a></td>
-		<td> bigint  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='default_parameter_set.parameter_set_name'>parameter&#095;set&#095;name</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='default_parameter_set.parameter_set'>parameter&#095;set</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td> This is a varchar here &#045; but is of type JSON in postgresql&#046; </td>
-	</tr>
-<tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>pk&#095;default&#095;parameter&#095;set primary key</td>
-		<td> ON default&#095;parameter&#095;set&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;default&#095;parameter&#095;set </td>
-		<td> ON command&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;default&#095;parameter&#095;set&#095;0 unique</td>
-		<td> ON command&#095;id&#044; parameter&#095;set&#095;name</td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
-	<tr>
-		<td>fk_default_parameter_set</td>
-		<td > ( command&#095;id ) ref <a href='#software&#095;command'>software&#095;command</a> (command&#095;id) </td>
 		<td>  </td>
 	</tr>
 </tbody>
@@ -5735,55 +5496,6 @@ Controlled Vocabulary </td>
 <br/><br/>
 <table class='bordered'>
 <thead>
-<tr><th colspan='3'><a name='command_parameter'>Table command_parameter</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='command_parameter.command_id'>command&#095;id</a></td>
-		<td> bigint  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='command_parameter.parameter_name'>parameter&#095;name</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='command_parameter.parameter_type'>parameter&#095;type</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='command_parameter.required'>required</a></td>
-		<td> bool  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='command_parameter.default_value'>default&#095;value</a></td>
-		<td> varchar   </td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>idx&#095;command&#095;parameter </td>
-		<td> ON command&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;command&#095;parameter&#095;0 primary key</td>
-		<td> ON command&#095;id&#044; parameter&#095;name</td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
-	<tr>
-		<td>fk_command_parameter</td>
-		<td > ( command&#095;id ) ref <a href='#software&#095;command'>software&#095;command</a> (command&#095;id) </td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table class='bordered'>
-<thead>
 <tr><th colspan='3'><a name='preprocessed_sequence_illumina_params'>Table preprocessed_sequence_illumina_params</a></th></tr>
 <tr><td colspan='3'>Parameters used for processing illumina sequence data&#046; </td></tr>
 </thead>
@@ -5846,6 +5558,283 @@ Controlled Vocabulary </td>
 <tr><th colspan='3'><b>Indexes</b></th></tr>
 	<tr>		<td>pk&#095;preprocessed&#095;sequence&#095;illumina&#095;params primary key</td>
 		<td> ON parameters&#095;id</td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table class='bordered'>
+<thead>
+<tr><th colspan='3'><a name='command_parameter'>Table command_parameter</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='command_parameter.command_id'>command&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='command_parameter.parameter_name'>parameter&#095;name</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='command_parameter.parameter_type'>parameter&#095;type</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='command_parameter.required'>required</a></td>
+		<td> bool  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='command_parameter.default_value'>default&#095;value</a></td>
+		<td> varchar   </td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Indexes</b></th></tr>
+	<tr>		<td>idx&#095;command&#095;parameter </td>
+		<td> ON command&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;command&#095;parameter&#095;0 primary key</td>
+		<td> ON command&#095;id&#044; parameter&#095;name</td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
+	<tr>
+		<td>fk_command_parameter</td>
+		<td > ( command&#095;id ) ref <a href='#software&#095;command'>software&#095;command</a> (command&#095;id) </td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table class='bordered'>
+<thead>
+<tr><th colspan='3'><a name='default_parameter_set'>Table default_parameter_set</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='default_parameter_set.default_parameter_set_id'>default&#095;parameter&#095;set&#095;id</a></td>
+		<td> bigserial  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='default_parameter_set.command_id'>command&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='default_parameter_set.parameter_set_name'>parameter&#095;set&#095;name</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='default_parameter_set.parameter_set'>parameter&#095;set</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td> This is a varchar here &#045; but is of type JSON in postgresql&#046; </td>
+	</tr>
+<tr><th colspan='3'><b>Indexes</b></th></tr>
+	<tr>		<td>pk&#095;default&#095;parameter&#095;set primary key</td>
+		<td> ON default&#095;parameter&#095;set&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;default&#095;parameter&#095;set </td>
+		<td> ON command&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;default&#095;parameter&#095;set&#095;0 unique</td>
+		<td> ON command&#095;id&#044; parameter&#095;set&#095;name</td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
+	<tr>
+		<td>fk_default_parameter_set</td>
+		<td > ( command&#095;id ) ref <a href='#software&#095;command'>software&#095;command</a> (command&#095;id) </td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table class='bordered'>
+<thead>
+<tr><th colspan='3'><a name='software'>Table software</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='software.software_id'>software&#095;id</a></td>
+		<td> bigserial  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='software.name'>name</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='software.version'>version</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='software.description'>description</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Indexes</b></th></tr>
+	<tr>		<td>pk&#095;software primary key</td>
+		<td> ON software&#095;id</td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table class='bordered'>
+<thead>
+<tr><th colspan='3'><a name='software_command'>Table software_command</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='software_command.command_id'>command&#095;id</a></td>
+		<td> bigserial  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='software_command.name'>name</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='software_command.software_id'>software&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='software_command.description'>description</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Indexes</b></th></tr>
+	<tr>		<td>pk&#095;soft&#095;command primary key</td>
+		<td> ON command&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;soft&#095;command </td>
+		<td> ON software&#095;id</td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
+	<tr>
+		<td>fk_soft_command_software</td>
+		<td > ( software&#095;id ) ref <a href='#software'>software</a> (software&#095;id) </td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table class='bordered'>
+<thead>
+<tr><th colspan='3'><a name='artifact'>Table artifact</a></th></tr>
+<tr><td colspan='3'>Represents data in the system </td></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='artifact.artifact_id'>artifact&#095;id</a></td>
+		<td> bigserial  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='artifact.generated_timestamp'>generated&#095;timestamp</a></td>
+		<td> timestamp  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='artifact.command_id'>command&#095;id</a></td>
+		<td> bigint   </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='artifact.command_parameters'>command&#095;parameters</a></td>
+		<td> varchar   </td>
+		<td> Varchar in dbschema but is JSON in the postgresDB </td>
+	</tr>
+	<tr>
+		<td><a name='artifact.visibility_id'>visibility&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td> If the artifact is sandbox&#044; awaiting&#095;for&#095;approval&#044; private or public </td>
+	</tr>
+	<tr>
+		<td><a name='artifact.artifact_type_id'>artifact&#095;type&#095;id</a></td>
+		<td> integer   </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='artifact.data_type_id'>data&#095;type&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='artifact.can_be_submitted_to_ebi'>can&#095;be&#095;submitted&#095;to&#095;ebi</a></td>
+		<td> bool  NOT NULL  DEFO 'FALSE' </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='artifact.can_be_submitted_to_vamps'>can&#095;be&#095;submitted&#095;to&#095;vamps</a></td>
+		<td> bool  NOT NULL  DEFO 'FALSE' </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='artifact.submitted_to_vamps'>submitted&#095;to&#095;vamps</a></td>
+		<td> bool  NOT NULL  DEFO 'FALSE' </td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Indexes</b></th></tr>
+	<tr>		<td>pk&#095;artifact primary key</td>
+		<td> ON artifact&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;artifact&#095;0 </td>
+		<td> ON visibility&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;artifact&#095;1 </td>
+		<td> ON artifact&#095;type&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;artifact </td>
+		<td> ON command&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;artifact&#095;2 </td>
+		<td> ON data&#095;type&#095;id</td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
+	<tr>
+		<td>fk_artifact_visibility</td>
+		<td > ( visibility&#095;id ) ref <a href='#visibility'>visibility</a> (visibility&#095;id) </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td>fk_artifact_filetype</td>
+		<td > ( artifact&#095;type&#095;id ) ref <a href='#artifact&#095;type'>artifact&#095;type</a> (artifact&#095;type&#095;id) </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td>fk_artifact_soft_command</td>
+		<td > ( command&#095;id ) ref <a href='#software&#095;command'>software&#095;command</a> (command&#095;id) </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td>fk_artifact_data_type</td>
+		<td > ( data&#095;type&#095;id ) ref <a href='#data&#095;type'>data&#095;type</a> (data&#095;type&#095;id) </td>
 		<td>  </td>
 	</tr>
 </tbody>

--- a/qiita_db/support_files/qiita-db.html
+++ b/qiita_db/support_files/qiita-db.html
@@ -313,7 +313,7 @@ table {
 <rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='1045' y='133' width='760' height='2' />
 
 <!-- ============= Group 'Group_processing' ============= -->
-<rect class='grp' style='fill:#c4e0f9;stroke:#c5d4e0' x='1709' y='745' width='527' height='995' />
+<rect class='grp' style='fill:#c4e0f9;stroke:#c5d4e0' x='1709' y='745' width='527' height='1175' />
 <text x='1720' y='760'>Group_processing</text>
 <rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='1720' y='763' width='505' height='2' />
 
@@ -757,57 +757,67 @@ table {
 	artifact references software_command ( command_id )</title>
 </path>
 <text x='1402' y='850' transform='rotate(0 1402,850)' title='Foreign Key fk_artifact_soft_command
-	artifact references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1215 945 L 1215,1192 Q 1215,1200 1207,1200 L 795,1200' >
+	artifact references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1215 945 L 1215,1132 Q 1215,1140 1207,1140 L 787,1140 Q 780,1140 780,1147 L 780,1155' >
 	<title>Foreign Key fk_artifact_data_type
 	artifact references data_type ( data_type_id )</title>
 </path>
 <text x='1228' y='945' transform='rotate(90 1228,945)' title='Foreign Key fk_artifact_data_type
-	artifact references data_type ( data_type_id )' style='fill:#a1a0a0;'>data_type_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1710 1125 L 937,1125 Q 930,1125 930,1117 L 930,937 Q 930,930 922,930 L 810,930' >
-	<title>Foreign Key fk_reference_sequence_filepath
-	reference references filepath ( sequence_filepath -> filepath_id )</title>
-</path>
-<text x='1615' y='1120' transform='rotate(0 1615,1120)' title='Foreign Key fk_reference_sequence_filepath
-	reference references filepath ( sequence_filepath -> filepath_id )' style='fill:#a1a0a0;'>sequence_filepath</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1710 1140 L 952,1140 Q 945,1140 945,1132 L 945,922 Q 945,915 937,915 L 810,915' >
-	<title>Foreign Key fk_reference_taxonomy_filepath
-	reference references filepath ( taxonomy_filepath -> filepath_id )</title>
-</path>
-<text x='1612' y='1135' transform='rotate(0 1612,1135)' title='Foreign Key fk_reference_taxonomy_filepath
-	reference references filepath ( taxonomy_filepath -> filepath_id )' style='fill:#a1a0a0;'>taxonomy_filepath</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1710 1155 L 967,1155 Q 960,1155 960,1147 L 960,982 Q 960,975 952,975 L 802,975 Q 795,975 795,967 L 795,960' >
-	<title>Foreign Key fk_reference_tree_filepath
-	reference references filepath ( tree_filepath -> filepath_id )</title>
-</path>
-<text x='1645' y='1150' transform='rotate(0 1645,1150)' title='Foreign Key fk_reference_tree_filepath
-	reference references filepath ( tree_filepath -> filepath_id )' style='fill:#a1a0a0;'>tree_filepath</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1740 1275 L 1740,1260' >
+	artifact references data_type ( data_type_id )' style='fill:#a1a0a0;'>data_type_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1740 1455 L 1740,1425' >
 	<title>Foreign Key fk_processed_params_uclust
 	processed_params_uclust references reference ( reference_id )</title>
 </path>
-<text x='1742' y='1270' transform='rotate(270 1742,1270)' title='Foreign Key fk_processed_params_uclust
-	processed_params_uclust references reference ( reference_id )' style='fill:#a1a0a0;'>reference_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1920 1185 L 1860,1185' >
-	<title>Foreign Key fk_processed_params_sortmerna
-	processed_params_sortmerna references reference ( reference_id )</title>
+<text x='1742' y='1450' transform='rotate(270 1742,1450)' title='Foreign Key fk_processed_params_uclust
+	processed_params_uclust references reference ( reference_id )' style='fill:#a1a0a0;'>reference_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1710 1290 L 952,1290 Q 945,1290 945,1282 L 945,937 Q 945,930 937,930 L 810,930' >
+	<title>Foreign Key fk_reference_sequence_filepath
+	reference references filepath ( sequence_filepath -> filepath_id )</title>
 </path>
-<text x='1855' y='1180' transform='rotate(0 1855,1180)' title='Foreign Key fk_processed_params_sortmerna
-	processed_params_sortmerna references reference ( reference_id )' style='fill:#a1a0a0;'>reference_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1920 1050 L 1012,1050 Q 1005,1050 1005,1042 L 1005,412 Q 1005,405 997,405 L 480,405' >
+<text x='1615' y='1285' transform='rotate(0 1615,1285)' title='Foreign Key fk_reference_sequence_filepath
+	reference references filepath ( sequence_filepath -> filepath_id )' style='fill:#a1a0a0;'>sequence_filepath</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1710 1305 L 1357,1305 Q 1350,1305 1350,1297 L 1350,1072 Q 1350,1065 1342,1065 L 937,1065 Q 930,1065 930,1057 L 930,922 Q 930,915 922,915 L 810,915' >
+	<title>Foreign Key fk_reference_taxonomy_filepath
+	reference references filepath ( taxonomy_filepath -> filepath_id )</title>
+</path>
+<text x='1612' y='1300' transform='rotate(0 1612,1300)' title='Foreign Key fk_reference_taxonomy_filepath
+	reference references filepath ( taxonomy_filepath -> filepath_id )' style='fill:#a1a0a0;'>taxonomy_filepath</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1710 1320 L 1552,1320 Q 1545,1320 1545,1312 L 1545,1087 Q 1545,1080 1537,1080 L 967,1080 Q 960,1080 960,1072 L 960,982 Q 960,975 952,975 L 802,975 Q 795,975 795,967 L 795,960' >
+	<title>Foreign Key fk_reference_tree_filepath
+	reference references filepath ( tree_filepath -> filepath_id )</title>
+</path>
+<text x='1645' y='1315' transform='rotate(0 1645,1315)' title='Foreign Key fk_reference_tree_filepath
+	reference references filepath ( tree_filepath -> filepath_id )' style='fill:#a1a0a0;'>tree_filepath</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2010 1065 L 1942,1065 Q 1935,1065 1935,1057 L 1935,937 Q 1935,930 1927,930 L 1867,930 Q 1860,930 1860,922 L 1860,915' >
+	<title>Foreign Key fk_default_parameter_set
+	default_parameter_set references software_command ( command_id )</title>
+</path>
+<text x='1943' y='1060' transform='rotate(0 1943,1060)' title='Foreign Key fk_default_parameter_set
+	default_parameter_set references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1725 1050 L 1012,1050 Q 1005,1050 1005,1042 L 1005,412 Q 1005,405 997,405 L 480,405' >
 	<title>Foreign Key fk_processing_job_qiita_user
 	processing_job references qiita_user ( email )</title>
 </path>
-<text x='1894' y='1045' transform='rotate(0 1894,1045)' title='Foreign Key fk_processing_job_qiita_user
-	processing_job references qiita_user ( email )' style='fill:#a1a0a0;'>email</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1920 930 L 1867,930 Q 1860,930 1860,922 L 1860,915' >
+<text x='1699' y='1045' transform='rotate(0 1699,1045)' title='Foreign Key fk_processing_job_qiita_user
+	processing_job references qiita_user ( email )' style='fill:#a1a0a0;'>email</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1755 960 L 1755,915' >
 	<title>Foreign Key fk_processing_job
 	processing_job references software_command ( command_id )</title>
 </path>
-<text x='1853' y='925' transform='rotate(0 1853,925)' title='Foreign Key fk_processing_job
-	processing_job references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1980 1080 L 1980,1095' >
+<text x='1757' y='955' transform='rotate(270 1757,955)' title='Foreign Key fk_processing_job
+	processing_job references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1755 1140 L 1755,1155' >
 	<title>Foreign Key fk_processing_job_status
 	processing_job references processing_job_status ( processing_job_status_id )</title>
 </path>
-<text x='1993' y='1080' transform='rotate(90 1993,1080)' title='Foreign Key fk_processing_job_status
-	processing_job references processing_job_status ( processing_job_status_id )' style='fill:#a1a0a0;'>processing_job_status_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1920 1035 L 1552,1035 Q 1545,1035 1545,1042 L 1545,1477 Q 1545,1485 1537,1485 L 832,1485 Q 825,1485 825,1492 L 825,1500' >
+<text x='1768' y='1140' transform='rotate(90 1768,1140)' title='Foreign Key fk_processing_job_status
+	processing_job references processing_job_status ( processing_job_status_id )' style='fill:#a1a0a0;'>processing_job_status_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1725 1110 L 937,1110 Q 930,1110 930,1117 L 930,1477 Q 930,1485 922,1485 L 832,1485 Q 825,1485 825,1492 L 825,1500' >
 	<title>Foreign Key fk_processing_job_logging
 	processing_job references logging ( logging_id )</title>
 </path>
-<text x='1865' y='1030' transform='rotate(0 1865,1030)' title='Foreign Key fk_processing_job_logging
-	processing_job references logging ( logging_id )' style='fill:#a1a0a0;'>logging_id</text><!-- ============= Table 'controlled_vocab_values' ============= -->
+<text x='1670' y='1105' transform='rotate(0 1670,1105)' title='Foreign Key fk_processing_job_logging
+	processing_job references logging ( logging_id )' style='fill:#a1a0a0;'>logging_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1965 1440 L 1852,1440 Q 1845,1440 1845,1432 L 1845,1425' >
+	<title>Foreign Key fk_processed_params_sortmerna
+	processed_params_sortmerna references reference ( reference_id )</title>
+</path>
+<text x='1900' y='1435' transform='rotate(0 1900,1435)' title='Foreign Key fk_processed_params_sortmerna
+	processed_params_sortmerna references reference ( reference_id )' style='fill:#a1a0a0;'>reference_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2040 900 L 1875,900' >
+	<title>Foreign Key fk_command_parameter
+	command_parameter references software_command ( command_id )</title>
+</path>
+<text x='1973' y='895' transform='rotate(0 1973,895)' title='Foreign Key fk_command_parameter
+	command_parameter references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><!-- ============= Table 'controlled_vocab_values' ============= -->
 <rect class='table' x='45' y='1688' width='150' height='120' rx='7' ry='7' />
 <path d='M 45.50 1714.50 L 45.50 1695.50 Q 45.50 1688.50 52.50 1688.50 L 187.50 1688.50 Q 194.50 1688.50 194.50 1695.50 L 194.50 1714.50 L45.50 1714.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
 <a xlink:href='#controlled_vocab_values'><text x='53' y='1702' class='tableTitle'>controlled_vocab_values</text><title>Table qiita.controlled_vocab_values</title></a>
@@ -905,7 +915,8 @@ Available commands for jobs</title></a>
 <a xlink:href='#command.command_id'><text x='228' y='1312'>command_id</text><title>command_id bigserial not null
 Unique identifier for function</title></a>
 <a xlink:href='#command.command_id'><use id='ref' x='303' y='1301' xlink:href='#ref'/><title>Referred by command_data_type ( command_id ) 
-Referred by job ( command_id ) </title></a>
+Referred by job ( command_id ) 
+Referred by command_parameter ( command_id ) </title></a>
   <use id='nn' x='212' y='1317' xlink:href='#nn'/><a xlink:href='#command.name'><text x='228' y='1327'>name</text><title>name varchar not null</title></a>
   <use id='nn' x='212' y='1332' xlink:href='#nn'/><a xlink:href='#command.command'><text x='228' y='1342'>command</text><title>command varchar not null
 What command to call to run this function</title></a>
@@ -925,7 +936,6 @@ JSON of output options for the command</title></a>
   <use id='nn' x='737' y='1542' xlink:href='#nn'/><a xlink:href='#logging.logging_id'><use id='pk' x='737' y='1541' xlink:href='#pk'/><title>Primary Key  ( logging_id ) </title></a>
 <a xlink:href='#logging.logging_id'><text x='753' y='1552'>logging_id</text><title>logging_id bigserial not null</title></a>
 <a xlink:href='#logging.logging_id'><use id='ref' x='828' y='1541' xlink:href='#ref'/><title>Referred by job ( log_id -> logging_id ) 
-Referred by processing_job ( logging_id ) 
 Referred by processing_job ( logging_id ) </title></a>
   <use id='nn' x='737' y='1557' xlink:href='#nn'/><a xlink:href='#logging.time'><text x='753' y='1567'>time</text><title>time timestamp not null
 Time the error was thrown</title></a>
@@ -1024,9 +1034,9 @@ Referred by analysis_users ( email )
 Referred by collection ( email ) 
 Referred by collection_users ( email ) 
 Referred by message_user ( email ) 
+Referred by processing_job ( email ) 
 Referred by study ( email ) 
-Referred by study_users ( email ) 
-Referred by processing_job ( email ) </title></a>
+Referred by study_users ( email ) </title></a>
   <use id='nn' x='332' y='282' xlink:href='#nn'/><a xlink:href='#qiita_user.user_level_id'><use id='idx' x='332' y='281' xlink:href='#idx'/><title>Index  ( user_level_id ) </title></a>
 <a xlink:href='#qiita_user.user_level_id'><text x='348' y='292'>user_level_id</text><title>user_level_id integer not null default 5
 user level</title></a>
@@ -1741,7 +1751,11 @@ Type of artifact</title></a>
   <use id='nn' x='1742' y='807' xlink:href='#nn'/><a xlink:href='#software_command.command_id'><use id='pk' x='1742' y='806' xlink:href='#pk'/><title>Primary Key  ( command_id ) </title></a>
 <a xlink:href='#software_command.command_id'><text x='1758' y='817'>command_id</text><title>command_id bigserial not null</title></a>
 <a xlink:href='#software_command.command_id'><use id='ref' x='1863' y='806' xlink:href='#ref'/><title>Referred by artifact ( command_id ) 
-Referred by processing_job ( command_id ) </title></a>
+Referred by processing_job ( command_id ) 
+Referred by command_parameter ( command_id ) 
+Referred by command_parameter ( command_id ) 
+Referred by default_parameter_set ( command_id ) 
+Referred by default_parameter_set ( command_id ) </title></a>
   <use id='nn' x='1742' y='822' xlink:href='#nn'/><a xlink:href='#software_command.name'><text x='1758' y='832'>name</text><title>name varchar not null</title></a>
   <use id='nn' x='1742' y='837' xlink:href='#nn'/><a xlink:href='#software_command.software_id'><use id='idx' x='1742' y='836' xlink:href='#idx'/><title>Index  ( software_id ) </title></a>
 <a xlink:href='#software_command.software_id'><text x='1758' y='847'>software_id</text><title>software_id bigint not null</title></a>
@@ -1828,166 +1842,192 @@ If the artifact is sandbox&#044; awaiting&#095;for&#095;approval&#044; private o
   <use id='nn' x='1202' y='897' xlink:href='#nn'/><a xlink:href='#artifact.can_be_submitted_to_vamps'><text x='1218' y='907'>can_be_submitted_to_vamps</text><title>can_be_submitted_to_vamps bool not null default &#039;FALSE&#039;</title></a>
   <use id='nn' x='1202' y='912' xlink:href='#nn'/><a xlink:href='#artifact.submitted_to_vamps'><text x='1218' y='922'>submitted_to_vamps</text><title>submitted_to_vamps bool not null default &#039;FALSE&#039;</title></a>
 
-<!-- ============= Table 'reference' ============= -->
-<rect class='table' x='1725' y='1118' width='135' height='135' rx='7' ry='7' />
-<path d='M 1725.50 1144.50 L 1725.50 1125.50 Q 1725.50 1118.50 1732.50 1118.50 L 1852.50 1118.50 Q 1859.50 1118.50 1859.50 1125.50 L 1859.50 1144.50 L1725.50 1144.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
-<a xlink:href='#reference'><text x='1767' y='1132' class='tableTitle'>reference</text><title>Table qiita.reference</title></a>
-  <use id='nn' x='1727' y='1152' xlink:href='#nn'/><a xlink:href='#reference.reference_id'><use id='pk' x='1727' y='1151' xlink:href='#pk'/><title>Primary Key  ( reference_id ) </title></a>
-<a xlink:href='#reference.reference_id'><text x='1743' y='1162'>reference_id</text><title>reference_id bigserial not null</title></a>
-<a xlink:href='#reference.reference_id'><use id='ref' x='1848' y='1151' xlink:href='#ref'/><title>Referred by processed_params_sortmerna ( reference_id ) 
-Referred by processed_params_uclust ( reference_id ) </title></a>
-  <use id='nn' x='1727' y='1167' xlink:href='#nn'/><a xlink:href='#reference.reference_name'><text x='1743' y='1177'>reference_name</text><title>reference_name varchar not null</title></a>
-  <a xlink:href='#reference.reference_version'><text x='1743' y='1192'>reference_version</text><title>reference_version varchar</title></a>
-  <use id='nn' x='1727' y='1197' xlink:href='#nn'/><a xlink:href='#reference.sequence_filepath'><use id='idx' x='1727' y='1196' xlink:href='#idx'/><title>Index  ( sequence_filepath ) </title></a>
-<a xlink:href='#reference.sequence_filepath'><text x='1743' y='1207'>sequence_filepath</text><title>sequence_filepath bigint not null</title></a>
-<a xlink:href='#reference.sequence_filepath'><use id='fk' x='1848' y='1196' xlink:href='#fk'/><title>References filepath ( sequence_filepath -> filepath_id ) </title></a>
-  <a xlink:href='#reference.taxonomy_filepath'><use id='idx' x='1727' y='1211' xlink:href='#idx'/><title>Index  ( taxonomy_filepath ) </title></a>
-<a xlink:href='#reference.taxonomy_filepath'><text x='1743' y='1222'>taxonomy_filepath</text><title>taxonomy_filepath bigint</title></a>
-<a xlink:href='#reference.taxonomy_filepath'><use id='fk' x='1848' y='1211' xlink:href='#fk'/><title>References filepath ( taxonomy_filepath -> filepath_id ) </title></a>
-  <a xlink:href='#reference.tree_filepath'><use id='idx' x='1727' y='1226' xlink:href='#idx'/><title>Index  ( tree_filepath ) </title></a>
-<a xlink:href='#reference.tree_filepath'><text x='1743' y='1237'>tree_filepath</text><title>tree_filepath bigint</title></a>
-<a xlink:href='#reference.tree_filepath'><use id='fk' x='1848' y='1226' xlink:href='#fk'/><title>References filepath ( tree_filepath -> filepath_id ) </title></a>
+<!-- ============= Table 'preprocessed_spectra_params' ============= -->
+<rect class='table' x='1995' y='1823' width='180' height='75' rx='7' ry='7' />
+<path d='M 1995.50 1849.50 L 1995.50 1830.50 Q 1995.50 1823.50 2002.50 1823.50 L 2167.50 1823.50 Q 2174.50 1823.50 2174.50 1830.50 L 2174.50 1849.50 L1995.50 1849.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
+<a xlink:href='#preprocessed_spectra_params'><text x='2002' y='1837' class='tableTitle'>preprocessed_spectra_params</text><title>Table qiita.preprocessed_spectra_params
+Parameters used for processing spectra data&#046;</title></a>
+  <use id='nn' x='1997' y='1857' xlink:href='#nn'/><a xlink:href='#preprocessed_spectra_params.parameters_id'><use id='pk' x='1997' y='1856' xlink:href='#pk'/><title>Primary Key  ( parameters_id ) </title></a>
+<a xlink:href='#preprocessed_spectra_params.parameters_id'><text x='2013' y='1867'>parameters_id</text><title>parameters_id bigserial not null</title></a>
+  <a xlink:href='#preprocessed_spectra_params.col'><text x='2013' y='1882'>col</text><title>col varchar</title></a>
 
 <!-- ============= Table 'processed_params_uclust' ============= -->
-<rect class='table' x='1725' y='1283' width='180' height='120' rx='7' ry='7' />
-<path d='M 1725.50 1309.50 L 1725.50 1290.50 Q 1725.50 1283.50 1732.50 1283.50 L 1897.50 1283.50 Q 1904.50 1283.50 1904.50 1290.50 L 1904.50 1309.50 L1725.50 1309.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
-<a xlink:href='#processed_params_uclust'><text x='1744' y='1297' class='tableTitle'>processed_params_uclust</text><title>Table qiita.processed_params_uclust
+<rect class='table' x='1725' y='1463' width='180' height='120' rx='7' ry='7' />
+<path d='M 1725.50 1489.50 L 1725.50 1470.50 Q 1725.50 1463.50 1732.50 1463.50 L 1897.50 1463.50 Q 1904.50 1463.50 1904.50 1470.50 L 1904.50 1489.50 L1725.50 1489.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
+<a xlink:href='#processed_params_uclust'><text x='1744' y='1477' class='tableTitle'>processed_params_uclust</text><title>Table qiita.processed_params_uclust
 Parameters used for processing data using method uclust</title></a>
-  <use id='nn' x='1727' y='1317' xlink:href='#nn'/><a xlink:href='#processed_params_uclust.parameters_id'><use id='pk' x='1727' y='1316' xlink:href='#pk'/><title>Primary Key  ( parameters_id ) </title></a>
-<a xlink:href='#processed_params_uclust.parameters_id'><text x='1743' y='1327'>parameters_id</text><title>parameters_id bigserial not null</title></a>
-  <use id='nn' x='1727' y='1332' xlink:href='#nn'/><a xlink:href='#processed_params_uclust.reference_id'><use id='idx' x='1727' y='1331' xlink:href='#idx'/><title>Index  ( reference_id ) </title></a>
-<a xlink:href='#processed_params_uclust.reference_id'><text x='1743' y='1342'>reference_id</text><title>reference_id bigint not null
+  <use id='nn' x='1727' y='1497' xlink:href='#nn'/><a xlink:href='#processed_params_uclust.parameters_id'><use id='pk' x='1727' y='1496' xlink:href='#pk'/><title>Primary Key  ( parameters_id ) </title></a>
+<a xlink:href='#processed_params_uclust.parameters_id'><text x='1743' y='1507'>parameters_id</text><title>parameters_id bigserial not null</title></a>
+  <use id='nn' x='1727' y='1512' xlink:href='#nn'/><a xlink:href='#processed_params_uclust.reference_id'><use id='idx' x='1727' y='1511' xlink:href='#idx'/><title>Index  ( reference_id ) </title></a>
+<a xlink:href='#processed_params_uclust.reference_id'><text x='1743' y='1522'>reference_id</text><title>reference_id bigint not null
 What version of reference or type of reference used</title></a>
-<a xlink:href='#processed_params_uclust.reference_id'><use id='fk' x='1893' y='1331' xlink:href='#fk'/><title>References reference ( reference_id ) </title></a>
-  <use id='nn' x='1727' y='1347' xlink:href='#nn'/><a xlink:href='#processed_params_uclust.similarity'><text x='1743' y='1357'>similarity</text><title>similarity float8 not null default 0&#046;97</title></a>
-  <use id='nn' x='1727' y='1362' xlink:href='#nn'/><a xlink:href='#processed_params_uclust.enable_rev_strand_match'><text x='1743' y='1372'>enable_rev_strand_match</text><title>enable_rev_strand_match bool not null default TRUE</title></a>
-  <use id='nn' x='1727' y='1377' xlink:href='#nn'/><a xlink:href='#processed_params_uclust.suppress_new_clusters'><text x='1743' y='1387'>suppress_new_clusters</text><title>suppress_new_clusters bool not null default TRUE</title></a>
+<a xlink:href='#processed_params_uclust.reference_id'><use id='fk' x='1893' y='1511' xlink:href='#fk'/><title>References reference ( reference_id ) </title></a>
+  <use id='nn' x='1727' y='1527' xlink:href='#nn'/><a xlink:href='#processed_params_uclust.similarity'><text x='1743' y='1537'>similarity</text><title>similarity float8 not null default 0&#046;97</title></a>
+  <use id='nn' x='1727' y='1542' xlink:href='#nn'/><a xlink:href='#processed_params_uclust.enable_rev_strand_match'><text x='1743' y='1552'>enable_rev_strand_match</text><title>enable_rev_strand_match bool not null default TRUE</title></a>
+  <use id='nn' x='1727' y='1557' xlink:href='#nn'/><a xlink:href='#processed_params_uclust.suppress_new_clusters'><text x='1743' y='1567'>suppress_new_clusters</text><title>suppress_new_clusters bool not null default TRUE</title></a>
 
-<!-- ============= Table 'preprocessed_sequence_454_params' ============= -->
-<rect class='table' x='1725' y='1418' width='225' height='300' rx='7' ry='7' />
-<path d='M 1725.50 1444.50 L 1725.50 1425.50 Q 1725.50 1418.50 1732.50 1418.50 L 1942.50 1418.50 Q 1949.50 1418.50 1949.50 1425.50 L 1949.50 1444.50 L1725.50 1444.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
-<a xlink:href='#preprocessed_sequence_454_params'><text x='1735' y='1432' class='tableTitle'>preprocessed_sequence_454_params</text><title>Table qiita.preprocessed_sequence_454_params
-Parameters used for processing sequence data&#046;</title></a>
-  <use id='nn' x='1727' y='1452' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.parameters_id'><use id='pk' x='1727' y='1451' xlink:href='#pk'/><title>Primary Key  ( parameters_id ) </title></a>
-<a xlink:href='#preprocessed_sequence_454_params.parameters_id'><text x='1743' y='1462'>parameters_id</text><title>parameters_id bigserial not null</title></a>
-  <use id='nn' x='1727' y='1467' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.param_set_name'><text x='1743' y='1477'>param_set_name</text><title>param_set_name varchar&#040;100&#041; not null
-The name of the parameter set</title></a>
-  <use id='nn' x='1727' y='1482' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.min_seq_len'><text x='1743' y='1492'>min_seq_len</text><title>min_seq_len integer not null default 200
-The minimum sequence length</title></a>
-  <use id='nn' x='1727' y='1497' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.max_seq_len'><text x='1743' y='1507'>max_seq_len</text><title>max_seq_len integer not null default 1000
-The maximum sequence length</title></a>
-  <use id='nn' x='1727' y='1512' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.trim_seq_length'><text x='1743' y='1522'>trim_seq_length</text><title>trim_seq_length bool not null default f
-Whether to trim the sequence length or not</title></a>
-  <use id='nn' x='1727' y='1527' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.min_qual_score'><text x='1743' y='1537'>min_qual_score</text><title>min_qual_score integer not null default 25
-The minimum phred quality score</title></a>
-  <use id='nn' x='1727' y='1542' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.max_ambig'><text x='1743' y='1552'>max_ambig</text><title>max_ambig integer not null default 6
-The maximum number of ambiguous characters</title></a>
-  <use id='nn' x='1727' y='1557' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.max_homopolymer'><text x='1743' y='1567'>max_homopolymer</text><title>max_homopolymer integer not null default 6
-The maximum homopolymer run</title></a>
-  <use id='nn' x='1727' y='1572' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.max_primer_mismatch'><text x='1743' y='1582'>max_primer_mismatch</text><title>max_primer_mismatch integer not null default 0
-Maximum number of mismatches to the primer allowed</title></a>
-  <use id='nn' x='1727' y='1587' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.barcode_type'><text x='1743' y='1597'>barcode_type</text><title>barcode_type varchar not null default &#039;golay&#095;12&#039;
-The barcode type used</title></a>
-  <use id='nn' x='1727' y='1602' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.max_barcode_errors'><text x='1743' y='1612'>max_barcode_errors</text><title>max_barcode_errors real not null default 1&#046;5
-The maximum number of allowed barcode errors</title></a>
-  <use id='nn' x='1727' y='1617' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.disable_bc_correction'><text x='1743' y='1627'>disable_bc_correction</text><title>disable_bc_correction bool not null default f
-Disable barcode correction</title></a>
-  <use id='nn' x='1727' y='1632' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.qual_score_window'><text x='1743' y='1642'>qual_score_window</text><title>qual_score_window integer not null default 0
-Enable a sliding window quality score threshold&#044; this is the size of the window</title></a>
-  <use id='nn' x='1727' y='1647' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.disable_primers'><text x='1743' y='1657'>disable_primers</text><title>disable_primers bool not null default f
-Disable primer checking</title></a>
-  <use id='nn' x='1727' y='1662' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.reverse_primers'><text x='1743' y='1672'>reverse_primers</text><title>reverse_primers varchar not null default &#039;disable&#039;
-Check for reverse primers</title></a>
-  <use id='nn' x='1727' y='1677' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.reverse_primer_mismatches'><text x='1743' y='1687'>reverse_primer_mismatches</text><title>reverse_primer_mismatches integer not null default 0
-The number of allowed mismatches in the reverse primer</title></a>
-  <use id='nn' x='1727' y='1692' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.truncate_ambig_bases_bool'><text x='1743' y='1702'>truncate_ambig_bases_bool</text><title>truncate_ambig_bases_bool bool not null default f
-Truncate at the first ambiguous base</title></a>
-
-<!-- ============= Table 'preprocessed_spectra_params' ============= -->
-<rect class='table' x='2010' y='1583' width='180' height='75' rx='7' ry='7' />
-<path d='M 2010.50 1609.50 L 2010.50 1590.50 Q 2010.50 1583.50 2017.50 1583.50 L 2182.50 1583.50 Q 2189.50 1583.50 2189.50 1590.50 L 2189.50 1609.50 L2010.50 1609.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
-<a xlink:href='#preprocessed_spectra_params'><text x='2017' y='1597' class='tableTitle'>preprocessed_spectra_params</text><title>Table qiita.preprocessed_spectra_params
-Parameters used for processing spectra data&#046;</title></a>
-  <use id='nn' x='2012' y='1617' xlink:href='#nn'/><a xlink:href='#preprocessed_spectra_params.parameters_id'><use id='pk' x='2012' y='1616' xlink:href='#pk'/><title>Primary Key  ( parameters_id ) </title></a>
-<a xlink:href='#preprocessed_spectra_params.parameters_id'><text x='2028' y='1627'>parameters_id</text><title>parameters_id bigserial not null</title></a>
-  <a xlink:href='#preprocessed_spectra_params.col'><text x='2028' y='1642'>col</text><title>col varchar</title></a>
-
-<!-- ============= Table 'preprocessed_sequence_illumina_params' ============= -->
-<rect class='table' x='1980' y='1358' width='240' height='210' rx='7' ry='7' />
-<path d='M 1980.50 1384.50 L 1980.50 1365.50 Q 1980.50 1358.50 1987.50 1358.50 L 2212.50 1358.50 Q 2219.50 1358.50 2219.50 1365.50 L 2219.50 1384.50 L1980.50 1384.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
-<a xlink:href='#preprocessed_sequence_illumina_params'><text x='1987' y='1372' class='tableTitle'>preprocessed_sequence_illumina_params</text><title>Table qiita.preprocessed_sequence_illumina_params
-Parameters used for processing illumina sequence data&#046;</title></a>
-  <use id='nn' x='1982' y='1392' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.parameters_id'><use id='pk' x='1982' y='1391' xlink:href='#pk'/><title>Primary Key  ( parameters_id ) </title></a>
-<a xlink:href='#preprocessed_sequence_illumina_params.parameters_id'><text x='1998' y='1402'>parameters_id</text><title>parameters_id bigserial not null</title></a>
-  <use id='nn' x='1982' y='1407' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.max_bad_run_length'><text x='1998' y='1417'>max_bad_run_length</text><title>max_bad_run_length integer not null default 3</title></a>
-  <use id='nn' x='1982' y='1422' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.min_per_read_length_fraction'><text x='1998' y='1432'>min_per_read_length_fraction</text><title>min_per_read_length_fraction real not null default 0&#046;75</title></a>
-  <use id='nn' x='1982' y='1437' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.sequence_max_n'><text x='1998' y='1447'>sequence_max_n</text><title>sequence_max_n integer not null default 0</title></a>
-  <use id='nn' x='1982' y='1452' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.rev_comp_barcode'><text x='1998' y='1462'>rev_comp_barcode</text><title>rev_comp_barcode bool not null default FALSE</title></a>
-  <use id='nn' x='1982' y='1467' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.rev_comp_mapping_barcodes'><text x='1998' y='1477'>rev_comp_mapping_barcodes</text><title>rev_comp_mapping_barcodes bool not null default FALSE</title></a>
-  <use id='nn' x='1982' y='1482' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.rev_comp'><text x='1998' y='1492'>rev_comp</text><title>rev_comp bool not null default FALSE</title></a>
-  <use id='nn' x='1982' y='1497' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.phred_quality_threshold'><text x='1998' y='1507'>phred_quality_threshold</text><title>phred_quality_threshold integer not null default 3</title></a>
-  <use id='nn' x='1982' y='1512' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.barcode_type'><text x='1998' y='1522'>barcode_type</text><title>barcode_type varchar not null default &#039;golay&#095;12&#039;</title></a>
-  <use id='nn' x='1982' y='1527' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.max_barcode_errors'><text x='1998' y='1537'>max_barcode_errors</text><title>max_barcode_errors real not null default 1&#046;5</title></a>
-  <use id='nn' x='1982' y='1542' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.param_set_name'><text x='1998' y='1552'>param_set_name</text><title>param_set_name varchar&#040;100&#041; not null
-The name of the parameter set</title></a>
-
-<!-- ============= Table 'processed_params_sortmerna' ============= -->
-<rect class='table' x='1935' y='1178' width='180' height='165' rx='7' ry='7' />
-<path d='M 1935.50 1204.50 L 1935.50 1185.50 Q 1935.50 1178.50 1942.50 1178.50 L 2107.50 1178.50 Q 2114.50 1178.50 2114.50 1185.50 L 2114.50 1204.50 L1935.50 1204.50 ' style='fill:url(#tableHeaderGradient3); stroke:none;' />
-<a xlink:href='#processed_params_sortmerna'><text x='1943' y='1192' class='tableTitle'>processed_params_sortmerna</text><title>Table qiita.processed_params_sortmerna
-Parameters used for processing data using method sortmerna</title></a>
-  <use id='nn' x='1937' y='1212' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.parameters_id'><use id='pk' x='1937' y='1211' xlink:href='#pk'/><title>Primary Key  ( parameters_id ) </title></a>
-<a xlink:href='#processed_params_sortmerna.parameters_id'><text x='1953' y='1222'>parameters_id</text><title>parameters_id bigserial not null</title></a>
-  <use id='nn' x='1937' y='1227' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.reference_id'><use id='idx' x='1937' y='1226' xlink:href='#idx'/><title>Index  ( reference_id ) </title></a>
-<a xlink:href='#processed_params_sortmerna.reference_id'><text x='1953' y='1237'>reference_id</text><title>reference_id bigint not null
-What version of reference or type of reference used</title></a>
-<a xlink:href='#processed_params_sortmerna.reference_id'><use id='fk' x='2103' y='1226' xlink:href='#fk'/><title>References reference ( reference_id ) </title></a>
-  <use id='nn' x='1937' y='1242' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.sortmerna_e_value'><text x='1953' y='1252'>sortmerna_e_value</text><title>sortmerna_e_value float8 not null</title></a>
-  <use id='nn' x='1937' y='1257' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.sortmerna_max_pos'><text x='1953' y='1267'>sortmerna_max_pos</text><title>sortmerna_max_pos integer not null</title></a>
-  <use id='nn' x='1937' y='1272' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.similarity'><text x='1953' y='1282'>similarity</text><title>similarity float8 not null</title></a>
-  <use id='nn' x='1937' y='1287' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.sortmerna_coverage'><text x='1953' y='1297'>sortmerna_coverage</text><title>sortmerna_coverage float8 not null</title></a>
-  <use id='nn' x='1937' y='1302' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.threads'><text x='1953' y='1312'>threads</text><title>threads integer not null</title></a>
-  <use id='nn' x='1937' y='1317' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.param_set_name'><text x='1953' y='1327'>param_set_name</text><title>param_set_name varchar&#040;100&#041; not null default &#039;Default&#039;
-The name of the parameter set</title></a>
-
-<!-- ============= Table 'processing_job' ============= -->
-<rect class='table' x='1935' y='908' width='180' height='165' rx='7' ry='7' />
-<path d='M 1935.50 934.50 L 1935.50 915.50 Q 1935.50 908.50 1942.50 908.50 L 2107.50 908.50 Q 2114.50 908.50 2114.50 915.50 L 2114.50 934.50 L1935.50 934.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#processing_job'><text x='1983' y='922' class='tableTitle'>processing_job</text><title>Table qiita.processing_job</title></a>
-  <use id='nn' x='1937' y='942' xlink:href='#nn'/><a xlink:href='#processing_job.processing_job_id'><use id='pk' x='1937' y='941' xlink:href='#pk'/><title>Primary Key  ( processing_job_id ) </title></a>
-<a xlink:href='#processing_job.processing_job_id'><text x='1953' y='952'>processing_job_id</text><title>processing_job_id bigserial not null
-Using bigserial in DBSchema &#045; however in the postgres DB this column is of type UUID&#046;</title></a>
-  <use id='nn' x='1937' y='957' xlink:href='#nn'/><a xlink:href='#processing_job.email'><use id='idx' x='1937' y='956' xlink:href='#idx'/><title>Index  ( email ) </title></a>
-<a xlink:href='#processing_job.email'><text x='1953' y='967'>email</text><title>email varchar not null
-The user that launched the job</title></a>
-<a xlink:href='#processing_job.email'><use id='fk' x='2103' y='956' xlink:href='#fk'/><title>References qiita_user ( email ) </title></a>
-  <use id='nn' x='1937' y='972' xlink:href='#nn'/><a xlink:href='#processing_job.command_id'><use id='idx' x='1937' y='971' xlink:href='#idx'/><title>Index  ( command_id ) </title></a>
-<a xlink:href='#processing_job.command_id'><text x='1953' y='982'>command_id</text><title>command_id bigint not null
-The command launched</title></a>
-<a xlink:href='#processing_job.command_id'><use id='fk' x='2103' y='971' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
-  <use id='nn' x='1937' y='987' xlink:href='#nn'/><a xlink:href='#processing_job.command_parameters_id'><text x='1953' y='997'>command_parameters_id</text><title>command_parameters_id bigint not null
-The parameters used in the command</title></a>
-  <use id='nn' x='1937' y='1002' xlink:href='#nn'/><a xlink:href='#processing_job.processing_job_status_id'><use id='idx' x='1937' y='1001' xlink:href='#idx'/><title>Index  ( processing_job_status_id ) </title></a>
-<a xlink:href='#processing_job.processing_job_status_id'><text x='1953' y='1012'>processing_job_status_id</text><title>processing_job_status_id bigint not null</title></a>
-<a xlink:href='#processing_job.processing_job_status_id'><use id='fk' x='2103' y='1001' xlink:href='#fk'/><title>References processing_job_status ( processing_job_status_id ) </title></a>
-  <a xlink:href='#processing_job.logging_id'><use id='idx' x='1937' y='1016' xlink:href='#idx'/><title>Index  ( logging_id ) </title></a>
-<a xlink:href='#processing_job.logging_id'><text x='1953' y='1027'>logging_id</text><title>logging_id bigint
-In case of failure&#044; point to the log entry that holds more information about the error</title></a>
-<a xlink:href='#processing_job.logging_id'><use id='fk' x='2103' y='1016' xlink:href='#fk'/><title>References logging ( logging_id ) </title></a>
-  <a xlink:href='#processing_job.heartbeat'><text x='1953' y='1042'>heartbeat</text><title>heartbeat timestamp
-The last heartbeat received by this job</title></a>
-  <a xlink:href='#processing_job.step'><text x='1953' y='1057'>step</text><title>step varchar</title></a>
+<!-- ============= Table 'reference' ============= -->
+<rect class='table' x='1725' y='1283' width='135' height='135' rx='7' ry='7' />
+<path d='M 1725.50 1309.50 L 1725.50 1290.50 Q 1725.50 1283.50 1732.50 1283.50 L 1852.50 1283.50 Q 1859.50 1283.50 1859.50 1290.50 L 1859.50 1309.50 L1725.50 1309.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
+<a xlink:href='#reference'><text x='1767' y='1297' class='tableTitle'>reference</text><title>Table qiita.reference</title></a>
+  <use id='nn' x='1727' y='1317' xlink:href='#nn'/><a xlink:href='#reference.reference_id'><use id='pk' x='1727' y='1316' xlink:href='#pk'/><title>Primary Key  ( reference_id ) </title></a>
+<a xlink:href='#reference.reference_id'><text x='1743' y='1327'>reference_id</text><title>reference_id bigserial not null</title></a>
+<a xlink:href='#reference.reference_id'><use id='ref' x='1848' y='1316' xlink:href='#ref'/><title>Referred by processed_params_sortmerna ( reference_id ) 
+Referred by processed_params_uclust ( reference_id ) </title></a>
+  <use id='nn' x='1727' y='1332' xlink:href='#nn'/><a xlink:href='#reference.reference_name'><text x='1743' y='1342'>reference_name</text><title>reference_name varchar not null</title></a>
+  <a xlink:href='#reference.reference_version'><text x='1743' y='1357'>reference_version</text><title>reference_version varchar</title></a>
+  <use id='nn' x='1727' y='1362' xlink:href='#nn'/><a xlink:href='#reference.sequence_filepath'><use id='idx' x='1727' y='1361' xlink:href='#idx'/><title>Index  ( sequence_filepath ) </title></a>
+<a xlink:href='#reference.sequence_filepath'><text x='1743' y='1372'>sequence_filepath</text><title>sequence_filepath bigint not null</title></a>
+<a xlink:href='#reference.sequence_filepath'><use id='fk' x='1848' y='1361' xlink:href='#fk'/><title>References filepath ( sequence_filepath -> filepath_id ) </title></a>
+  <a xlink:href='#reference.taxonomy_filepath'><use id='idx' x='1727' y='1376' xlink:href='#idx'/><title>Index  ( taxonomy_filepath ) </title></a>
+<a xlink:href='#reference.taxonomy_filepath'><text x='1743' y='1387'>taxonomy_filepath</text><title>taxonomy_filepath bigint</title></a>
+<a xlink:href='#reference.taxonomy_filepath'><use id='fk' x='1848' y='1376' xlink:href='#fk'/><title>References filepath ( taxonomy_filepath -> filepath_id ) </title></a>
+  <a xlink:href='#reference.tree_filepath'><use id='idx' x='1727' y='1391' xlink:href='#idx'/><title>Index  ( tree_filepath ) </title></a>
+<a xlink:href='#reference.tree_filepath'><text x='1743' y='1402'>tree_filepath</text><title>tree_filepath bigint</title></a>
+<a xlink:href='#reference.tree_filepath'><use id='fk' x='1848' y='1391' xlink:href='#fk'/><title>References filepath ( tree_filepath -> filepath_id ) </title></a>
 
 <!-- ============= Table 'processing_job_status' ============= -->
-<rect class='table' x='1995' y='1088' width='225' height='90' rx='7' ry='7' />
-<path d='M 1995.50 1114.50 L 1995.50 1095.50 Q 1995.50 1088.50 2002.50 1088.50 L 2212.50 1088.50 Q 2219.50 1088.50 2219.50 1095.50 L 2219.50 1114.50 L1995.50 1114.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#processing_job_status'><text x='2046' y='1102' class='tableTitle'>processing_job_status</text><title>Table qiita.processing_job_status</title></a>
-  <use id='nn' x='1997' y='1122' xlink:href='#nn'/><a xlink:href='#processing_job_status.processing_job_status_id'><use id='pk' x='1997' y='1121' xlink:href='#pk'/><title>Primary Key  ( processing_job_status_id ) </title></a>
-<a xlink:href='#processing_job_status.processing_job_status_id'><text x='2013' y='1132'>processing_job_status_id</text><title>processing_job_status_id bigserial not null</title></a>
-<a xlink:href='#processing_job_status.processing_job_status_id'><use id='ref' x='2208' y='1121' xlink:href='#ref'/><title>Referred by processing_job ( processing_job_status_id ) 
-Referred by processing_job ( processing_job_status_id ) </title></a>
-  <use id='nn' x='1997' y='1137' xlink:href='#nn'/><a xlink:href='#processing_job_status.processing_job_status'><text x='2013' y='1147'>processing_job_status</text><title>processing_job_status varchar not null</title></a>
-  <use id='nn' x='1997' y='1152' xlink:href='#nn'/><a xlink:href='#processing_job_status.processing_job_status_description'><text x='2013' y='1162'>processing_job_status_description</text><title>processing_job_status_description varchar not null</title></a>
+<rect class='table' x='1740' y='1163' width='225' height='90' rx='7' ry='7' />
+<path d='M 1740.50 1189.50 L 1740.50 1170.50 Q 1740.50 1163.50 1747.50 1163.50 L 1957.50 1163.50 Q 1964.50 1163.50 1964.50 1170.50 L 1964.50 1189.50 L1740.50 1189.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#processing_job_status'><text x='1791' y='1177' class='tableTitle'>processing_job_status</text><title>Table qiita.processing_job_status</title></a>
+  <use id='nn' x='1742' y='1197' xlink:href='#nn'/><a xlink:href='#processing_job_status.processing_job_status_id'><use id='pk' x='1742' y='1196' xlink:href='#pk'/><title>Primary Key  ( processing_job_status_id ) </title></a>
+<a xlink:href='#processing_job_status.processing_job_status_id'><text x='1758' y='1207'>processing_job_status_id</text><title>processing_job_status_id bigserial not null</title></a>
+<a xlink:href='#processing_job_status.processing_job_status_id'><use id='ref' x='1953' y='1196' xlink:href='#ref'/><title>Referred by processing_job ( processing_job_status_id ) </title></a>
+  <use id='nn' x='1742' y='1212' xlink:href='#nn'/><a xlink:href='#processing_job_status.processing_job_status'><text x='1758' y='1222'>processing_job_status</text><title>processing_job_status varchar not null</title></a>
+  <use id='nn' x='1742' y='1227' xlink:href='#nn'/><a xlink:href='#processing_job_status.processing_job_status_description'><text x='1758' y='1237'>processing_job_status_description</text><title>processing_job_status_description varchar not null</title></a>
+
+<!-- ============= Table 'default_parameter_set' ============= -->
+<rect class='table' x='2025' y='1058' width='165' height='105' rx='7' ry='7' />
+<path d='M 2025.50 1084.50 L 2025.50 1065.50 Q 2025.50 1058.50 2032.50 1058.50 L 2182.50 1058.50 Q 2189.50 1058.50 2189.50 1065.50 L 2189.50 1084.50 L2025.50 1084.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#default_parameter_set'><text x='2047' y='1072' class='tableTitle'>default_parameter_set</text><title>Table qiita.default_parameter_set</title></a>
+  <use id='nn' x='2027' y='1092' xlink:href='#nn'/><a xlink:href='#default_parameter_set.default_parameter_set_id'><use id='pk' x='2027' y='1091' xlink:href='#pk'/><title>Primary Key  ( default_parameter_set_id ) </title></a>
+<a xlink:href='#default_parameter_set.default_parameter_set_id'><text x='2043' y='1102'>default_parameter_set_id</text><title>default_parameter_set_id bigserial not null</title></a>
+  <use id='nn' x='2027' y='1107' xlink:href='#nn'/><a xlink:href='#default_parameter_set.command_id'><use id='unq' x='2027' y='1106' xlink:href='#unq'/><title>Index  ( command_id ) Unique Index  ( command_id, parameter_set_name ) </title></a>
+<a xlink:href='#default_parameter_set.command_id'><text x='2043' y='1117'>command_id</text><title>command_id bigint not null</title></a>
+<a xlink:href='#default_parameter_set.command_id'><use id='fk' x='2178' y='1106' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
+  <use id='nn' x='2027' y='1122' xlink:href='#nn'/><a xlink:href='#default_parameter_set.parameter_set_name'><use id='unq' x='2027' y='1121' xlink:href='#unq'/><title>Unique Index  ( command_id, parameter_set_name ) </title></a>
+<a xlink:href='#default_parameter_set.parameter_set_name'><text x='2043' y='1132'>parameter_set_name</text><title>parameter_set_name varchar not null</title></a>
+  <use id='nn' x='2027' y='1137' xlink:href='#nn'/><a xlink:href='#default_parameter_set.parameter_set'><text x='2043' y='1147'>parameter_set</text><title>parameter_set varchar not null
+This is a varchar here &#045; but is of type JSON in postgresql&#046;</title></a>
+
+<!-- ============= Table 'processing_job' ============= -->
+<rect class='table' x='1740' y='968' width='180' height='165' rx='7' ry='7' />
+<path d='M 1740.50 994.50 L 1740.50 975.50 Q 1740.50 968.50 1747.50 968.50 L 1912.50 968.50 Q 1919.50 968.50 1919.50 975.50 L 1919.50 994.50 L1740.50 994.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#processing_job'><text x='1788' y='982' class='tableTitle'>processing_job</text><title>Table qiita.processing_job</title></a>
+  <use id='nn' x='1742' y='1002' xlink:href='#nn'/><a xlink:href='#processing_job.processing_job_id'><use id='pk' x='1742' y='1001' xlink:href='#pk'/><title>Primary Key  ( processing_job_id ) </title></a>
+<a xlink:href='#processing_job.processing_job_id'><text x='1758' y='1012'>processing_job_id</text><title>processing_job_id bigserial not null
+Using bigserial in DBSchema &#045; however in the postgres DB this column is of type UUID&#046;</title></a>
+  <use id='nn' x='1742' y='1017' xlink:href='#nn'/><a xlink:href='#processing_job.email'><use id='idx' x='1742' y='1016' xlink:href='#idx'/><title>Index  ( email ) </title></a>
+<a xlink:href='#processing_job.email'><text x='1758' y='1027'>email</text><title>email varchar not null
+The user that launched the job</title></a>
+<a xlink:href='#processing_job.email'><use id='fk' x='1908' y='1016' xlink:href='#fk'/><title>References qiita_user ( email ) </title></a>
+  <use id='nn' x='1742' y='1032' xlink:href='#nn'/><a xlink:href='#processing_job.command_id'><use id='idx' x='1742' y='1031' xlink:href='#idx'/><title>Index  ( command_id ) </title></a>
+<a xlink:href='#processing_job.command_id'><text x='1758' y='1042'>command_id</text><title>command_id bigint not null
+The command launched</title></a>
+<a xlink:href='#processing_job.command_id'><use id='fk' x='1908' y='1031' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
+  <use id='nn' x='1742' y='1047' xlink:href='#nn'/><a xlink:href='#processing_job.command_parameters_id'><text x='1758' y='1057'>command_parameters_id</text><title>command_parameters_id bigint not null
+The parameters used in the command</title></a>
+  <use id='nn' x='1742' y='1062' xlink:href='#nn'/><a xlink:href='#processing_job.processing_job_status_id'><use id='idx' x='1742' y='1061' xlink:href='#idx'/><title>Index  ( processing_job_status_id ) </title></a>
+<a xlink:href='#processing_job.processing_job_status_id'><text x='1758' y='1072'>processing_job_status_id</text><title>processing_job_status_id bigint not null</title></a>
+<a xlink:href='#processing_job.processing_job_status_id'><use id='fk' x='1908' y='1061' xlink:href='#fk'/><title>References processing_job_status ( processing_job_status_id ) </title></a>
+  <a xlink:href='#processing_job.logging_id'><use id='idx' x='1742' y='1076' xlink:href='#idx'/><title>Index  ( logging_id ) </title></a>
+<a xlink:href='#processing_job.logging_id'><text x='1758' y='1087'>logging_id</text><title>logging_id bigint
+In case of failure&#044; point to the log entry that holds more information about the error</title></a>
+<a xlink:href='#processing_job.logging_id'><use id='fk' x='1908' y='1076' xlink:href='#fk'/><title>References logging ( logging_id ) </title></a>
+  <a xlink:href='#processing_job.heartbeat'><text x='1758' y='1102'>heartbeat</text><title>heartbeat timestamp
+The last heartbeat received by this job</title></a>
+  <a xlink:href='#processing_job.step'><text x='1758' y='1117'>step</text><title>step varchar</title></a>
+
+<!-- ============= Table 'preprocessed_sequence_454_params' ============= -->
+<rect class='table' x='1725' y='1598' width='225' height='300' rx='7' ry='7' />
+<path d='M 1725.50 1624.50 L 1725.50 1605.50 Q 1725.50 1598.50 1732.50 1598.50 L 1942.50 1598.50 Q 1949.50 1598.50 1949.50 1605.50 L 1949.50 1624.50 L1725.50 1624.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
+<a xlink:href='#preprocessed_sequence_454_params'><text x='1735' y='1612' class='tableTitle'>preprocessed_sequence_454_params</text><title>Table qiita.preprocessed_sequence_454_params
+Parameters used for processing sequence data&#046;</title></a>
+  <use id='nn' x='1727' y='1632' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.parameters_id'><use id='pk' x='1727' y='1631' xlink:href='#pk'/><title>Primary Key  ( parameters_id ) </title></a>
+<a xlink:href='#preprocessed_sequence_454_params.parameters_id'><text x='1743' y='1642'>parameters_id</text><title>parameters_id bigserial not null</title></a>
+  <use id='nn' x='1727' y='1647' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.param_set_name'><text x='1743' y='1657'>param_set_name</text><title>param_set_name varchar&#040;100&#041; not null
+The name of the parameter set</title></a>
+  <use id='nn' x='1727' y='1662' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.min_seq_len'><text x='1743' y='1672'>min_seq_len</text><title>min_seq_len integer not null default 200
+The minimum sequence length</title></a>
+  <use id='nn' x='1727' y='1677' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.max_seq_len'><text x='1743' y='1687'>max_seq_len</text><title>max_seq_len integer not null default 1000
+The maximum sequence length</title></a>
+  <use id='nn' x='1727' y='1692' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.trim_seq_length'><text x='1743' y='1702'>trim_seq_length</text><title>trim_seq_length bool not null default f
+Whether to trim the sequence length or not</title></a>
+  <use id='nn' x='1727' y='1707' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.min_qual_score'><text x='1743' y='1717'>min_qual_score</text><title>min_qual_score integer not null default 25
+The minimum phred quality score</title></a>
+  <use id='nn' x='1727' y='1722' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.max_ambig'><text x='1743' y='1732'>max_ambig</text><title>max_ambig integer not null default 6
+The maximum number of ambiguous characters</title></a>
+  <use id='nn' x='1727' y='1737' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.max_homopolymer'><text x='1743' y='1747'>max_homopolymer</text><title>max_homopolymer integer not null default 6
+The maximum homopolymer run</title></a>
+  <use id='nn' x='1727' y='1752' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.max_primer_mismatch'><text x='1743' y='1762'>max_primer_mismatch</text><title>max_primer_mismatch integer not null default 0
+Maximum number of mismatches to the primer allowed</title></a>
+  <use id='nn' x='1727' y='1767' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.barcode_type'><text x='1743' y='1777'>barcode_type</text><title>barcode_type varchar not null default &#039;golay&#095;12&#039;
+The barcode type used</title></a>
+  <use id='nn' x='1727' y='1782' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.max_barcode_errors'><text x='1743' y='1792'>max_barcode_errors</text><title>max_barcode_errors real not null default 1&#046;5
+The maximum number of allowed barcode errors</title></a>
+  <use id='nn' x='1727' y='1797' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.disable_bc_correction'><text x='1743' y='1807'>disable_bc_correction</text><title>disable_bc_correction bool not null default f
+Disable barcode correction</title></a>
+  <use id='nn' x='1727' y='1812' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.qual_score_window'><text x='1743' y='1822'>qual_score_window</text><title>qual_score_window integer not null default 0
+Enable a sliding window quality score threshold&#044; this is the size of the window</title></a>
+  <use id='nn' x='1727' y='1827' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.disable_primers'><text x='1743' y='1837'>disable_primers</text><title>disable_primers bool not null default f
+Disable primer checking</title></a>
+  <use id='nn' x='1727' y='1842' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.reverse_primers'><text x='1743' y='1852'>reverse_primers</text><title>reverse_primers varchar not null default &#039;disable&#039;
+Check for reverse primers</title></a>
+  <use id='nn' x='1727' y='1857' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.reverse_primer_mismatches'><text x='1743' y='1867'>reverse_primer_mismatches</text><title>reverse_primer_mismatches integer not null default 0
+The number of allowed mismatches in the reverse primer</title></a>
+  <use id='nn' x='1727' y='1872' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.truncate_ambig_bases_bool'><text x='1743' y='1882'>truncate_ambig_bases_bool</text><title>truncate_ambig_bases_bool bool not null default f
+Truncate at the first ambiguous base</title></a>
+
+<!-- ============= Table 'processed_params_sortmerna' ============= -->
+<rect class='table' x='1980' y='1418' width='180' height='165' rx='7' ry='7' />
+<path d='M 1980.50 1444.50 L 1980.50 1425.50 Q 1980.50 1418.50 1987.50 1418.50 L 2152.50 1418.50 Q 2159.50 1418.50 2159.50 1425.50 L 2159.50 1444.50 L1980.50 1444.50 ' style='fill:url(#tableHeaderGradient3); stroke:none;' />
+<a xlink:href='#processed_params_sortmerna'><text x='1988' y='1432' class='tableTitle'>processed_params_sortmerna</text><title>Table qiita.processed_params_sortmerna
+Parameters used for processing data using method sortmerna</title></a>
+  <use id='nn' x='1982' y='1452' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.parameters_id'><use id='pk' x='1982' y='1451' xlink:href='#pk'/><title>Primary Key  ( parameters_id ) </title></a>
+<a xlink:href='#processed_params_sortmerna.parameters_id'><text x='1998' y='1462'>parameters_id</text><title>parameters_id bigserial not null</title></a>
+  <use id='nn' x='1982' y='1467' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.reference_id'><use id='idx' x='1982' y='1466' xlink:href='#idx'/><title>Index  ( reference_id ) </title></a>
+<a xlink:href='#processed_params_sortmerna.reference_id'><text x='1998' y='1477'>reference_id</text><title>reference_id bigint not null
+What version of reference or type of reference used</title></a>
+<a xlink:href='#processed_params_sortmerna.reference_id'><use id='fk' x='2148' y='1466' xlink:href='#fk'/><title>References reference ( reference_id ) </title></a>
+  <use id='nn' x='1982' y='1482' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.sortmerna_e_value'><text x='1998' y='1492'>sortmerna_e_value</text><title>sortmerna_e_value float8 not null</title></a>
+  <use id='nn' x='1982' y='1497' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.sortmerna_max_pos'><text x='1998' y='1507'>sortmerna_max_pos</text><title>sortmerna_max_pos integer not null</title></a>
+  <use id='nn' x='1982' y='1512' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.similarity'><text x='1998' y='1522'>similarity</text><title>similarity float8 not null</title></a>
+  <use id='nn' x='1982' y='1527' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.sortmerna_coverage'><text x='1998' y='1537'>sortmerna_coverage</text><title>sortmerna_coverage float8 not null</title></a>
+  <use id='nn' x='1982' y='1542' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.threads'><text x='1998' y='1552'>threads</text><title>threads integer not null</title></a>
+  <use id='nn' x='1982' y='1557' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.param_set_name'><text x='1998' y='1567'>param_set_name</text><title>param_set_name varchar&#040;100&#041; not null default &#039;Default&#039;
+The name of the parameter set</title></a>
+
+<!-- ============= Table 'command_parameter' ============= -->
+<rect class='table' x='2055' y='893' width='135' height='120' rx='7' ry='7' />
+<path d='M 2055.50 919.50 L 2055.50 900.50 Q 2055.50 893.50 2062.50 893.50 L 2182.50 893.50 Q 2189.50 893.50 2189.50 900.50 L 2189.50 919.50 L2055.50 919.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#command_parameter'><text x='2065' y='907' class='tableTitle'>command_parameter</text><title>Table qiita.command_parameter</title></a>
+  <use id='nn' x='2057' y='927' xlink:href='#nn'/><a xlink:href='#command_parameter.command_id'><use id='pk' x='2057' y='926' xlink:href='#pk'/><title>Index  ( command_id ) Primary Key  ( command_id, parameter_name ) </title></a>
+<a xlink:href='#command_parameter.command_id'><text x='2073' y='937'>command_id</text><title>command_id bigint not null</title></a>
+<a xlink:href='#command_parameter.command_id'><use id='fk' x='2178' y='926' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
+  <use id='nn' x='2057' y='942' xlink:href='#nn'/><a xlink:href='#command_parameter.parameter_name'><use id='pk' x='2057' y='941' xlink:href='#pk'/><title>Primary Key  ( command_id, parameter_name ) </title></a>
+<a xlink:href='#command_parameter.parameter_name'><text x='2073' y='952'>parameter_name</text><title>parameter_name varchar not null</title></a>
+  <use id='nn' x='2057' y='957' xlink:href='#nn'/><a xlink:href='#command_parameter.parameter_type'><text x='2073' y='967'>parameter_type</text><title>parameter_type varchar not null</title></a>
+  <use id='nn' x='2057' y='972' xlink:href='#nn'/><a xlink:href='#command_parameter.required'><text x='2073' y='982'>required</text><title>required bool not null</title></a>
+  <a xlink:href='#command_parameter.default_value'><text x='2073' y='997'>default_value</text><title>default_value varchar</title></a>
+
+<!-- ============= Table 'preprocessed_sequence_illumina_params' ============= -->
+<rect class='table' x='1980' y='1598' width='240' height='210' rx='7' ry='7' />
+<path d='M 1980.50 1624.50 L 1980.50 1605.50 Q 1980.50 1598.50 1987.50 1598.50 L 2212.50 1598.50 Q 2219.50 1598.50 2219.50 1605.50 L 2219.50 1624.50 L1980.50 1624.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
+<a xlink:href='#preprocessed_sequence_illumina_params'><text x='1987' y='1612' class='tableTitle'>preprocessed_sequence_illumina_params</text><title>Table qiita.preprocessed_sequence_illumina_params
+Parameters used for processing illumina sequence data&#046;</title></a>
+  <use id='nn' x='1982' y='1632' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.parameters_id'><use id='pk' x='1982' y='1631' xlink:href='#pk'/><title>Primary Key  ( parameters_id ) </title></a>
+<a xlink:href='#preprocessed_sequence_illumina_params.parameters_id'><text x='1998' y='1642'>parameters_id</text><title>parameters_id bigserial not null</title></a>
+  <use id='nn' x='1982' y='1647' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.max_bad_run_length'><text x='1998' y='1657'>max_bad_run_length</text><title>max_bad_run_length integer not null default 3</title></a>
+  <use id='nn' x='1982' y='1662' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.min_per_read_length_fraction'><text x='1998' y='1672'>min_per_read_length_fraction</text><title>min_per_read_length_fraction real not null default 0&#046;75</title></a>
+  <use id='nn' x='1982' y='1677' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.sequence_max_n'><text x='1998' y='1687'>sequence_max_n</text><title>sequence_max_n integer not null default 0</title></a>
+  <use id='nn' x='1982' y='1692' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.rev_comp_barcode'><text x='1998' y='1702'>rev_comp_barcode</text><title>rev_comp_barcode bool not null default FALSE</title></a>
+  <use id='nn' x='1982' y='1707' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.rev_comp_mapping_barcodes'><text x='1998' y='1717'>rev_comp_mapping_barcodes</text><title>rev_comp_mapping_barcodes bool not null default FALSE</title></a>
+  <use id='nn' x='1982' y='1722' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.rev_comp'><text x='1998' y='1732'>rev_comp</text><title>rev_comp bool not null default FALSE</title></a>
+  <use id='nn' x='1982' y='1737' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.phred_quality_threshold'><text x='1998' y='1747'>phred_quality_threshold</text><title>phred_quality_threshold integer not null default 3</title></a>
+  <use id='nn' x='1982' y='1752' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.barcode_type'><text x='1998' y='1762'>barcode_type</text><title>barcode_type varchar not null default &#039;golay&#095;12&#039;</title></a>
+  <use id='nn' x='1982' y='1767' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.max_barcode_errors'><text x='1998' y='1777'>max_barcode_errors</text><title>max_barcode_errors real not null default 1&#046;5</title></a>
+  <use id='nn' x='1982' y='1782' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.param_set_name'><text x='1998' y='1792'>param_set_name</text><title>param_set_name varchar&#040;100&#041; not null
+The name of the parameter set</title></a>
 
 </g></svg>
 
@@ -5215,6 +5255,81 @@ Controlled Vocabulary </td>
 <br/><br/>
 <table class='bordered'>
 <thead>
+<tr><th colspan='3'><a name='preprocessed_spectra_params'>Table preprocessed_spectra_params</a></th></tr>
+<tr><td colspan='3'>Parameters used for processing spectra data&#046; </td></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='preprocessed_spectra_params.parameters_id'>parameters&#095;id</a></td>
+		<td> bigserial  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='preprocessed_spectra_params.col'>col</a></td>
+		<td> varchar   </td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Indexes</b></th></tr>
+	<tr>		<td>pk&#095;preprocessed&#095;spectra&#095;params primary key</td>
+		<td> ON parameters&#095;id</td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table class='bordered'>
+<thead>
+<tr><th colspan='3'><a name='processed_params_uclust'>Table processed_params_uclust</a></th></tr>
+<tr><td colspan='3'>Parameters used for processing data using method uclust </td></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='processed_params_uclust.parameters_id'>parameters&#095;id</a></td>
+		<td> bigserial  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='processed_params_uclust.reference_id'>reference&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td> What version of reference or type of reference used </td>
+	</tr>
+	<tr>
+		<td><a name='processed_params_uclust.similarity'>similarity</a></td>
+		<td> float8  NOT NULL  DEFO 0.97 </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='processed_params_uclust.enable_rev_strand_match'>enable&#095;rev&#095;strand&#095;match</a></td>
+		<td> bool  NOT NULL  DEFO TRUE </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='processed_params_uclust.suppress_new_clusters'>suppress&#095;new&#095;clusters</a></td>
+		<td> bool  NOT NULL  DEFO TRUE </td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Indexes</b></th></tr>
+	<tr>		<td>pk&#095;processed&#095;params&#095;uclust primary key</td>
+		<td> ON parameters&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;processed&#095;params&#095;uclust </td>
+		<td> ON reference&#095;id</td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
+	<tr>
+		<td>fk_processed_params_uclust</td>
+		<td > ( reference&#095;id ) ref <a href='#reference'>reference</a> (reference&#095;id) </td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table class='bordered'>
+<thead>
 <tr><th colspan='3'><a name='reference'>Table reference</a></th></tr>
 </thead>
 <tbody>
@@ -5287,48 +5402,166 @@ Controlled Vocabulary </td>
 <br/><br/>
 <table class='bordered'>
 <thead>
-<tr><th colspan='3'><a name='processed_params_uclust'>Table processed_params_uclust</a></th></tr>
-<tr><td colspan='3'>Parameters used for processing data using method uclust </td></tr>
+<tr><th colspan='3'><a name='processing_job_status'>Table processing_job_status</a></th></tr>
 </thead>
 <tbody>
 	<tr>
-		<td><a name='processed_params_uclust.parameters_id'>parameters&#095;id</a></td>
+		<td><a name='processing_job_status.processing_job_status_id'>processing&#095;job&#095;status&#095;id</a></td>
 		<td> bigserial  NOT NULL  </td>
 		<td>  </td>
 	</tr>
 	<tr>
-		<td><a name='processed_params_uclust.reference_id'>reference&#095;id</a></td>
-		<td> bigint  NOT NULL  </td>
-		<td> What version of reference or type of reference used </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_uclust.similarity'>similarity</a></td>
-		<td> float8  NOT NULL  DEFO 0.97 </td>
+		<td><a name='processing_job_status.processing_job_status'>processing&#095;job&#095;status</a></td>
+		<td> varchar  NOT NULL  </td>
 		<td>  </td>
 	</tr>
 	<tr>
-		<td><a name='processed_params_uclust.enable_rev_strand_match'>enable&#095;rev&#095;strand&#095;match</a></td>
-		<td> bool  NOT NULL  DEFO TRUE </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_uclust.suppress_new_clusters'>suppress&#095;new&#095;clusters</a></td>
-		<td> bool  NOT NULL  DEFO TRUE </td>
+		<td><a name='processing_job_status.processing_job_status_description'>processing&#095;job&#095;status&#095;description</a></td>
+		<td> varchar  NOT NULL  </td>
 		<td>  </td>
 	</tr>
 <tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>pk&#095;processed&#095;params&#095;uclust primary key</td>
-		<td> ON parameters&#095;id</td>
+	<tr>		<td>pk&#095;processing&#095;job&#095;status primary key</td>
+		<td> ON processing&#095;job&#095;status&#095;id</td>
 		<td>  </td>
 	</tr>
-	<tr>		<td>idx&#095;processed&#095;params&#095;uclust </td>
-		<td> ON reference&#095;id</td>
+</tbody>
+</table>
+
+<br/><br/>
+<table class='bordered'>
+<thead>
+<tr><th colspan='3'><a name='default_parameter_set'>Table default_parameter_set</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='default_parameter_set.default_parameter_set_id'>default&#095;parameter&#095;set&#095;id</a></td>
+		<td> bigserial  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='default_parameter_set.command_id'>command&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='default_parameter_set.parameter_set_name'>parameter&#095;set&#095;name</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='default_parameter_set.parameter_set'>parameter&#095;set</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td> This is a varchar here &#045; but is of type JSON in postgresql&#046; </td>
+	</tr>
+<tr><th colspan='3'><b>Indexes</b></th></tr>
+	<tr>		<td>pk&#095;default&#095;parameter&#095;set primary key</td>
+		<td> ON default&#095;parameter&#095;set&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;default&#095;parameter&#095;set </td>
+		<td> ON command&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;default&#095;parameter&#095;set&#095;0 unique</td>
+		<td> ON command&#095;id&#044; parameter&#095;set&#095;name</td>
 		<td>  </td>
 	</tr>
 <tr><th colspan='3'><b>Foreign Keys</b></th></tr>
 	<tr>
-		<td>fk_processed_params_uclust</td>
-		<td > ( reference&#095;id ) ref <a href='#reference'>reference</a> (reference&#095;id) </td>
+		<td>fk_default_parameter_set</td>
+		<td > ( command&#095;id ) ref <a href='#software&#095;command'>software&#095;command</a> (command&#095;id) </td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table class='bordered'>
+<thead>
+<tr><th colspan='3'><a name='processing_job'>Table processing_job</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='processing_job.processing_job_id'>processing&#095;job&#095;id</a></td>
+		<td> bigserial  NOT NULL  </td>
+		<td> Using bigserial in DBSchema &#045; however in the postgres DB this column is of type UUID&#046; </td>
+	</tr>
+	<tr>
+		<td><a name='processing_job.email'>email</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td> The user that launched the job </td>
+	</tr>
+	<tr>
+		<td><a name='processing_job.command_id'>command&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td> The command launched </td>
+	</tr>
+	<tr>
+		<td><a name='processing_job.command_parameters_id'>command&#095;parameters&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td> The parameters used in the command </td>
+	</tr>
+	<tr>
+		<td><a name='processing_job.processing_job_status_id'>processing&#095;job&#095;status&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='processing_job.logging_id'>logging&#095;id</a></td>
+		<td> bigint   </td>
+		<td> In case of failure&#044; point to the log entry that holds more information about the error </td>
+	</tr>
+	<tr>
+		<td><a name='processing_job.heartbeat'>heartbeat</a></td>
+		<td> timestamp   </td>
+		<td> The last heartbeat received by this job </td>
+	</tr>
+	<tr>
+		<td><a name='processing_job.step'>step</a></td>
+		<td> varchar   </td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Indexes</b></th></tr>
+	<tr>		<td>pk&#095;processing&#095;job primary key</td>
+		<td> ON processing&#095;job&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;processing&#095;job </td>
+		<td> ON email</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;processing&#095;job </td>
+		<td> ON command&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;processing&#095;job&#095;0 </td>
+		<td> ON processing&#095;job&#095;status&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;processing&#095;job&#095;1 </td>
+		<td> ON logging&#095;id</td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
+	<tr>
+		<td>fk_processing_job_qiita_user</td>
+		<td > ( email ) ref <a href='#qiita&#095;user'>qiita&#095;user</a> (email) </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td>fk_processing_job</td>
+		<td > ( command&#095;id ) ref <a href='#software&#095;command'>software&#095;command</a> (command&#095;id) </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td>fk_processing_job_status</td>
+		<td > ( processing&#095;job&#095;status&#095;id ) ref <a href='#processing&#095;job&#095;status'>processing&#095;job&#095;status</a> (processing&#095;job&#095;status&#095;id) </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td>fk_processing_job_logging</td>
+		<td > ( logging&#095;id ) ref <a href='#logging'>logging</a> (logging&#095;id) </td>
 		<td>  </td>
 	</tr>
 </tbody>
@@ -5437,23 +5670,112 @@ Controlled Vocabulary </td>
 <br/><br/>
 <table class='bordered'>
 <thead>
-<tr><th colspan='3'><a name='preprocessed_spectra_params'>Table preprocessed_spectra_params</a></th></tr>
-<tr><td colspan='3'>Parameters used for processing spectra data&#046; </td></tr>
+<tr><th colspan='3'><a name='processed_params_sortmerna'>Table processed_params_sortmerna</a></th></tr>
+<tr><td colspan='3'>Parameters used for processing data using method sortmerna </td></tr>
 </thead>
 <tbody>
 	<tr>
-		<td><a name='preprocessed_spectra_params.parameters_id'>parameters&#095;id</a></td>
+		<td><a name='processed_params_sortmerna.parameters_id'>parameters&#095;id</a></td>
 		<td> bigserial  NOT NULL  </td>
 		<td>  </td>
 	</tr>
 	<tr>
-		<td><a name='preprocessed_spectra_params.col'>col</a></td>
+		<td><a name='processed_params_sortmerna.reference_id'>reference&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td> What version of reference or type of reference used </td>
+	</tr>
+	<tr>
+		<td><a name='processed_params_sortmerna.sortmerna_e_value'>sortmerna&#095;e&#095;value</a></td>
+		<td> float8  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='processed_params_sortmerna.sortmerna_max_pos'>sortmerna&#095;max&#095;pos</a></td>
+		<td> integer  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='processed_params_sortmerna.similarity'>similarity</a></td>
+		<td> float8  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='processed_params_sortmerna.sortmerna_coverage'>sortmerna&#095;coverage</a></td>
+		<td> float8  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='processed_params_sortmerna.threads'>threads</a></td>
+		<td> integer  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='processed_params_sortmerna.param_set_name'>param&#095;set&#095;name</a></td>
+		<td> varchar&#040; 100 &#041;  NOT NULL  DEFO 'Default' </td>
+		<td> The name of the parameter set </td>
+	</tr>
+<tr><th colspan='3'><b>Indexes</b></th></tr>
+	<tr>		<td>pk&#095;processed&#095;params&#095;sortmerna primary key</td>
+		<td> ON parameters&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;processed&#095;params&#095;sortmerna </td>
+		<td> ON reference&#095;id</td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
+	<tr>
+		<td>fk_processed_params_sortmerna</td>
+		<td > ( reference&#095;id ) ref <a href='#reference'>reference</a> (reference&#095;id) </td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table class='bordered'>
+<thead>
+<tr><th colspan='3'><a name='command_parameter'>Table command_parameter</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='command_parameter.command_id'>command&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='command_parameter.parameter_name'>parameter&#095;name</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='command_parameter.parameter_type'>parameter&#095;type</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='command_parameter.required'>required</a></td>
+		<td> bool  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='command_parameter.default_value'>default&#095;value</a></td>
 		<td> varchar   </td>
 		<td>  </td>
 	</tr>
 <tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>pk&#095;preprocessed&#095;spectra&#095;params primary key</td>
-		<td> ON parameters&#095;id</td>
+	<tr>		<td>idx&#095;command&#095;parameter </td>
+		<td> ON command&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;command&#095;parameter&#095;0 primary key</td>
+		<td> ON command&#095;id&#044; parameter&#095;name</td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
+	<tr>
+		<td>fk_command_parameter</td>
+		<td > ( command&#095;id ) ref <a href='#software&#095;command'>software&#095;command</a> (command&#095;id) </td>
 		<td>  </td>
 	</tr>
 </tbody>
@@ -5524,191 +5846,6 @@ Controlled Vocabulary </td>
 <tr><th colspan='3'><b>Indexes</b></th></tr>
 	<tr>		<td>pk&#095;preprocessed&#095;sequence&#095;illumina&#095;params primary key</td>
 		<td> ON parameters&#095;id</td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table class='bordered'>
-<thead>
-<tr><th colspan='3'><a name='processed_params_sortmerna'>Table processed_params_sortmerna</a></th></tr>
-<tr><td colspan='3'>Parameters used for processing data using method sortmerna </td></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='processed_params_sortmerna.parameters_id'>parameters&#095;id</a></td>
-		<td> bigserial  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_sortmerna.reference_id'>reference&#095;id</a></td>
-		<td> bigint  NOT NULL  </td>
-		<td> What version of reference or type of reference used </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_sortmerna.sortmerna_e_value'>sortmerna&#095;e&#095;value</a></td>
-		<td> float8  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_sortmerna.sortmerna_max_pos'>sortmerna&#095;max&#095;pos</a></td>
-		<td> integer  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_sortmerna.similarity'>similarity</a></td>
-		<td> float8  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_sortmerna.sortmerna_coverage'>sortmerna&#095;coverage</a></td>
-		<td> float8  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_sortmerna.threads'>threads</a></td>
-		<td> integer  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_sortmerna.param_set_name'>param&#095;set&#095;name</a></td>
-		<td> varchar&#040; 100 &#041;  NOT NULL  DEFO 'Default' </td>
-		<td> The name of the parameter set </td>
-	</tr>
-<tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>pk&#095;processed&#095;params&#095;sortmerna primary key</td>
-		<td> ON parameters&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;processed&#095;params&#095;sortmerna </td>
-		<td> ON reference&#095;id</td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
-	<tr>
-		<td>fk_processed_params_sortmerna</td>
-		<td > ( reference&#095;id ) ref <a href='#reference'>reference</a> (reference&#095;id) </td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table class='bordered'>
-<thead>
-<tr><th colspan='3'><a name='processing_job'>Table processing_job</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='processing_job.processing_job_id'>processing&#095;job&#095;id</a></td>
-		<td> bigserial  NOT NULL  </td>
-		<td> Using bigserial in DBSchema &#045; however in the postgres DB this column is of type UUID&#046; </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job.email'>email</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td> The user that launched the job </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job.command_id'>command&#095;id</a></td>
-		<td> bigint  NOT NULL  </td>
-		<td> The command launched </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job.command_parameters_id'>command&#095;parameters&#095;id</a></td>
-		<td> bigint  NOT NULL  </td>
-		<td> The parameters used in the command </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job.processing_job_status_id'>processing&#095;job&#095;status&#095;id</a></td>
-		<td> bigint  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job.logging_id'>logging&#095;id</a></td>
-		<td> bigint   </td>
-		<td> In case of failure&#044; point to the log entry that holds more information about the error </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job.heartbeat'>heartbeat</a></td>
-		<td> timestamp   </td>
-		<td> The last heartbeat received by this job </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job.step'>step</a></td>
-		<td> varchar   </td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>pk&#095;processing&#095;job primary key</td>
-		<td> ON processing&#095;job&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;processing&#095;job </td>
-		<td> ON email</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;processing&#095;job </td>
-		<td> ON command&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;processing&#095;job&#095;0 </td>
-		<td> ON processing&#095;job&#095;status&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;processing&#095;job&#095;1 </td>
-		<td> ON logging&#095;id</td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
-	<tr>
-		<td>fk_processing_job_qiita_user</td>
-		<td > ( email ) ref <a href='#qiita&#095;user'>qiita&#095;user</a> (email) </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td>fk_processing_job</td>
-		<td > ( command&#095;id ) ref <a href='#software&#095;command'>software&#095;command</a> (command&#095;id) </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td>fk_processing_job_status</td>
-		<td > ( processing&#095;job&#095;status&#095;id ) ref <a href='#processing&#095;job&#095;status'>processing&#095;job&#095;status</a> (processing&#095;job&#095;status&#095;id) </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td>fk_processing_job_logging</td>
-		<td > ( logging&#095;id ) ref <a href='#logging'>logging</a> (logging&#095;id) </td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table class='bordered'>
-<thead>
-<tr><th colspan='3'><a name='processing_job_status'>Table processing_job_status</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='processing_job_status.processing_job_status_id'>processing&#095;job&#095;status&#095;id</a></td>
-		<td> bigserial  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job_status.processing_job_status'>processing&#095;job&#095;status</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job_status.processing_job_status_description'>processing&#095;job&#095;status&#095;description</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>pk&#095;processing&#095;job&#095;status primary key</td>
-		<td> ON processing&#095;job&#095;status&#095;id</td>
 		<td>  </td>
 	</tr>
 </tbody>

--- a/qiita_db/support_files/qiita-db.html
+++ b/qiita_db/support_files/qiita-db.html
@@ -313,9 +313,9 @@ table {
 <rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='1045' y='133' width='760' height='2' />
 
 <!-- ============= Group 'Group_processing' ============= -->
-<rect class='grp' style='fill:#c4e0f9;stroke:#c5d4e0' x='1709' y='715' width='527' height='1205' />
-<text x='1720' y='730'>Group_processing</text>
-<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='1720' y='733' width='505' height='2' />
+<rect class='grp' style='fill:#c4e0f9;stroke:#c5d4e0' x='1769' y='715' width='512' height='725' />
+<text x='1780' y='730'>Group_processing</text>
+<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='1780' y='733' width='490' height='2' />
 
 <!-- ============= Group 'Group_publication' ============= -->
 <rect class='grp' style='fill:#ffccff;stroke:#e0c5e0' x='2324' y='670' width='317' height='215' />
@@ -572,16 +572,16 @@ table {
 	sample_template_filepath references study ( study_id )</title>
 </path>
 <text x='1207' y='595' transform='rotate(0 1207,595)' title='Foreign Key fk_study_id
-	sample_template_filepath references study ( study_id )' style='fill:#a1a0a0;'>study_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1035 630 L 802,630 Q 795,630 795,637 L 795,810' >
+	sample_template_filepath references study ( study_id )' style='fill:#a1a0a0;'>study_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1035 630 L 787,630 Q 780,630 780,637 L 780,810' >
 	<title>Foreign Key fk_filepath_id
 	sample_template_filepath references filepath ( filepath_id )</title>
 </path>
 <text x='981' y='625' transform='rotate(0 981,625)' title='Foreign Key fk_filepath_id
-	sample_template_filepath references filepath ( filepath_id )' style='fill:#a1a0a0;'>filepath_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1455 540 L 1552,540 Q 1560,540 1560,547 L 1560,1177 Q 1560,1185 1552,1185 L 795,1185' >
+	sample_template_filepath references filepath ( filepath_id )' style='fill:#a1a0a0;'>filepath_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1290 525 L 877,525 Q 870,525 870,532 L 870,682 Q 870,690 862,690 L 622,690 Q 615,690 615,697 L 615,997 Q 615,1005 622,1005 L 952,1005 Q 960,1005 960,1012 L 960,1177 Q 960,1185 952,1185 L 795,1185' >
 	<title>Foreign Key fk_prep_template_data_type
 	prep_template references data_type ( data_type_id )</title>
 </path>
-<text x='1462' y='535' transform='rotate(0 1462,535)' title='Foreign Key fk_prep_template_data_type
+<text x='1224' y='520' transform='rotate(0 1224,520)' title='Foreign Key fk_prep_template_data_type
 	prep_template references data_type ( data_type_id )' style='fill:#a1a0a0;'>data_type_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1320 555 L 1320,735' >
 	<title>Foreign Key fk_prep_template_artifact
 	prep_template references artifact ( artifact_id )</title>
@@ -702,12 +702,12 @@ table {
 	study_artifact references study ( study_id )</title>
 </path>
 <text x='1702' y='715' transform='rotate(0 1702,715)' title='Foreign Key fk_study_artifact_study
-	study_artifact references study ( study_id )' style='fill:#a1a0a0;'>study_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1590 705 L 1387,705 Q 1380,705 1380,712 L 1380,735' >
+	study_artifact references study ( study_id )' style='fill:#a1a0a0;'>study_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1590 750 L 1567,750 Q 1560,750 1560,757 L 1560,832 Q 1560,840 1552,840 L 1395,840' >
 	<title>Foreign Key fk_study_artifact_artifact
 	study_artifact references artifact ( artifact_id )</title>
 </path>
-<text x='1538' y='700' transform='rotate(0 1538,700)' title='Foreign Key fk_study_artifact_artifact
-	study_artifact references artifact ( artifact_id )' style='fill:#a1a0a0;'>artifact_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2325 795 L 2145,795' >
+<text x='1538' y='745' transform='rotate(0 1538,745)' title='Foreign Key fk_study_artifact_artifact
+	study_artifact references artifact ( artifact_id )' style='fill:#a1a0a0;'>artifact_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2325 795 L 2205,795' >
 	<title>Foreign Key fk_software_publication
 	software_publication references software ( software_id )</title>
 </path>
@@ -737,77 +737,37 @@ table {
 	study_publication references publication ( publication_doi -> doi )</title>
 </path>
 <text x='2467' y='760' transform='rotate(0 2467,760)' title='Foreign Key fk_study_publication
-	study_publication references publication ( publication_doi -> doi )' style='fill:#a1a0a0;'>publication_doi</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1740 1455 L 1740,1425' >
-	<title>Foreign Key fk_processed_params_uclust
-	processed_params_uclust references reference ( reference_id )</title>
-</path>
-<text x='1742' y='1450' transform='rotate(270 1742,1450)' title='Foreign Key fk_processed_params_uclust
-	processed_params_uclust references reference ( reference_id )' style='fill:#a1a0a0;'>reference_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1710 1290 L 952,1290 Q 945,1290 945,1282 L 945,937 Q 945,930 937,930 L 810,930' >
+	study_publication references publication ( publication_doi -> doi )' style='fill:#a1a0a0;'>publication_doi</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1770 1290 L 937,1290 Q 930,1290 930,1282 L 930,937 Q 930,930 922,930 L 810,930' >
 	<title>Foreign Key fk_reference_sequence_filepath
 	reference references filepath ( sequence_filepath -> filepath_id )</title>
 </path>
-<text x='1615' y='1285' transform='rotate(0 1615,1285)' title='Foreign Key fk_reference_sequence_filepath
-	reference references filepath ( sequence_filepath -> filepath_id )' style='fill:#a1a0a0;'>sequence_filepath</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1710 1305 L 1357,1305 Q 1350,1305 1350,1297 L 1350,1072 Q 1350,1065 1342,1065 L 937,1065 Q 930,1065 930,1057 L 930,922 Q 930,915 922,915 L 810,915' >
+<text x='1675' y='1285' transform='rotate(0 1675,1285)' title='Foreign Key fk_reference_sequence_filepath
+	reference references filepath ( sequence_filepath -> filepath_id )' style='fill:#a1a0a0;'>sequence_filepath</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1770 1305 L 1552,1305 Q 1545,1305 1545,1297 L 1545,712 Q 1545,705 1537,705 L 802,705 Q 795,705 795,712 L 795,810' >
 	<title>Foreign Key fk_reference_taxonomy_filepath
 	reference references filepath ( taxonomy_filepath -> filepath_id )</title>
 </path>
-<text x='1612' y='1300' transform='rotate(0 1612,1300)' title='Foreign Key fk_reference_taxonomy_filepath
-	reference references filepath ( taxonomy_filepath -> filepath_id )' style='fill:#a1a0a0;'>taxonomy_filepath</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1710 1320 L 1552,1320 Q 1545,1320 1545,1312 L 1545,1087 Q 1545,1080 1537,1080 L 967,1080 Q 960,1080 960,1072 L 960,982 Q 960,975 952,975 L 802,975 Q 795,975 795,967 L 795,960' >
+<text x='1672' y='1300' transform='rotate(0 1672,1300)' title='Foreign Key fk_reference_taxonomy_filepath
+	reference references filepath ( taxonomy_filepath -> filepath_id )' style='fill:#a1a0a0;'>taxonomy_filepath</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1770 1320 L 1567,1320 Q 1560,1320 1560,1312 L 1560,1057 Q 1560,1050 1552,1050 L 952,1050 Q 945,1050 945,1042 L 945,922 Q 945,915 937,915 L 810,915' >
 	<title>Foreign Key fk_reference_tree_filepath
 	reference references filepath ( tree_filepath -> filepath_id )</title>
 </path>
-<text x='1645' y='1315' transform='rotate(0 1645,1315)' title='Foreign Key fk_reference_tree_filepath
-	reference references filepath ( tree_filepath -> filepath_id )' style='fill:#a1a0a0;'>tree_filepath</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1725 1050 L 1012,1050 Q 1005,1050 1005,1042 L 1005,412 Q 1005,405 997,405 L 480,405' >
-	<title>Foreign Key fk_processing_job_qiita_user
-	processing_job references qiita_user ( email )</title>
-</path>
-<text x='1699' y='1045' transform='rotate(0 1699,1045)' title='Foreign Key fk_processing_job_qiita_user
-	processing_job references qiita_user ( email )' style='fill:#a1a0a0;'>email</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1860 960 L 1860,855' >
-	<title>Foreign Key fk_processing_job
-	processing_job references software_command ( command_id )</title>
-</path>
-<text x='1862' y='955' transform='rotate(270 1862,955)' title='Foreign Key fk_processing_job
-	processing_job references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1755 1140 L 1755,1155' >
-	<title>Foreign Key fk_processing_job_status
-	processing_job references processing_job_status ( processing_job_status_id )</title>
-</path>
-<text x='1768' y='1140' transform='rotate(90 1768,1140)' title='Foreign Key fk_processing_job_status
-	processing_job references processing_job_status ( processing_job_status_id )' style='fill:#a1a0a0;'>processing_job_status_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1725 1110 L 937,1110 Q 930,1110 930,1117 L 930,1477 Q 930,1485 922,1485 L 832,1485 Q 825,1485 825,1492 L 825,1500' >
-	<title>Foreign Key fk_processing_job_logging
-	processing_job references logging ( logging_id )</title>
-</path>
-<text x='1670' y='1105' transform='rotate(0 1670,1105)' title='Foreign Key fk_processing_job_logging
-	processing_job references logging ( logging_id )' style='fill:#a1a0a0;'>logging_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1965 1440 L 1852,1440 Q 1845,1440 1845,1432 L 1845,1425' >
-	<title>Foreign Key fk_processed_params_sortmerna
-	processed_params_sortmerna references reference ( reference_id )</title>
-</path>
-<text x='1900' y='1435' transform='rotate(0 1900,1435)' title='Foreign Key fk_processed_params_sortmerna
-	processed_params_sortmerna references reference ( reference_id )' style='fill:#a1a0a0;'>reference_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2040 870 L 1957,870 Q 1950,870 1950,862 L 1950,855' >
-	<title>Foreign Key fk_command_parameter
-	command_parameter references software_command ( command_id )</title>
-</path>
-<text x='1973' y='865' transform='rotate(0 1973,865)' title='Foreign Key fk_command_parameter
-	command_parameter references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2010 1005 L 1942,1005 Q 1935,1005 1935,997 L 1935,855' >
-	<title>Foreign Key fk_default_parameter_set
-	default_parameter_set references software_command ( command_id )</title>
-</path>
-<text x='1943' y='1000' transform='rotate(0 1943,1000)' title='Foreign Key fk_default_parameter_set
-	default_parameter_set references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1965 765 L 2025,765' >
+<text x='1705' y='1315' transform='rotate(0 1705,1315)' title='Foreign Key fk_reference_tree_filepath
+	reference references filepath ( tree_filepath -> filepath_id )' style='fill:#a1a0a0;'>tree_filepath</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2025 765 L 2085,765' >
 	<title>Foreign Key fk_soft_command_software
 	software_command references software ( software_id )</title>
 </path>
-<text x='1972' y='760' transform='rotate(0 1972,760)' title='Foreign Key fk_soft_command_software
+<text x='2032' y='760' transform='rotate(0 2032,760)' title='Foreign Key fk_soft_command_software
 	software_command references software ( software_id )' style='fill:#a1a0a0;'>software_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1185 915 L 1177,915 Q 1170,915 1170,922 L 1170,930' >
 	<title>Foreign Key fk_artifact_visibility
 	artifact references visibility ( visibility_id )</title>
 </path>
 <text x='1127' y='910' transform='rotate(0 1127,910)' title='Foreign Key fk_artifact_visibility
-	artifact references visibility ( visibility_id )' style='fill:#a1a0a0;'>visibility_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1395 840 L 1417,840 Q 1425,840 1425,832 L 1425,825' >
+	artifact references visibility ( visibility_id )' style='fill:#a1a0a0;'>visibility_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1395 855 L 1417,855 Q 1425,855 1425,847 L 1425,825' >
 	<title>Foreign Key fk_artifact_filetype
 	artifact references artifact_type ( artifact_type_id )</title>
 </path>
-<text x='1402' y='835' transform='rotate(0 1402,835)' title='Foreign Key fk_artifact_filetype
-	artifact references artifact_type ( artifact_type_id )' style='fill:#a1a0a0;'>artifact_type_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1395 870 L 1867,870 Q 1875,870 1875,862 L 1875,855' >
+<text x='1402' y='850' transform='rotate(0 1402,850)' title='Foreign Key fk_artifact_filetype
+	artifact references artifact_type ( artifact_type_id )' style='fill:#a1a0a0;'>artifact_type_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1395 870 L 1912,870 Q 1920,870 1920,862 L 1920,855' >
 	<title>Foreign Key fk_artifact_soft_command
 	artifact references software_command ( command_id )</title>
 </path>
@@ -817,7 +777,37 @@ table {
 	artifact references data_type ( data_type_id )</title>
 </path>
 <text x='1228' y='945' transform='rotate(90 1228,945)' title='Foreign Key fk_artifact_data_type
-	artifact references data_type ( data_type_id )' style='fill:#a1a0a0;'>data_type_id</text><!-- ============= Table 'controlled_vocab_values' ============= -->
+	artifact references data_type ( data_type_id )' style='fill:#a1a0a0;'>data_type_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1785 1095 L 1012,1095 Q 1005,1095 1005,1087 L 1005,412 Q 1005,405 997,405 L 480,405' >
+	<title>Foreign Key fk_processing_job_qiita_user
+	processing_job references qiita_user ( email )</title>
+</path>
+<text x='1759' y='1090' transform='rotate(0 1759,1090)' title='Foreign Key fk_processing_job_qiita_user
+	processing_job references qiita_user ( email )' style='fill:#a1a0a0;'>email</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1875 1080 L 1875,832 Q 1875,825 1882,825 L 1890,825' >
+	<title>Foreign Key fk_processing_job
+	processing_job references software_command ( command_id )</title>
+</path>
+<text x='1877' y='1075' transform='rotate(270 1877,1075)' title='Foreign Key fk_processing_job
+	processing_job references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1980 1140 L 2010,1140' >
+	<title>Foreign Key fk_processing_job_status
+	processing_job references processing_job_status ( processing_job_status_id )</title>
+</path>
+<text x='1987' y='1135' transform='rotate(0 1987,1135)' title='Foreign Key fk_processing_job_status
+	processing_job references processing_job_status ( processing_job_status_id )' style='fill:#a1a0a0;'>processing_job_status_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 1785 1230 L 832,1230 Q 825,1230 825,1237 L 825,1500' >
+	<title>Foreign Key fk_processing_job_logging
+	processing_job references logging ( logging_id )</title>
+</path>
+<text x='1730' y='1225' transform='rotate(0 1730,1225)' title='Foreign Key fk_processing_job_logging
+	processing_job references logging ( logging_id )' style='fill:#a1a0a0;'>logging_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2085 930 L 2077,930 Q 2070,930 2070,922 L 2070,847 Q 2070,840 2062,840 L 2025,840' >
+	<title>Foreign Key fk_default_parameter_set
+	default_parameter_set references software_command ( command_id )</title>
+</path>
+<text x='2018' y='925' transform='rotate(0 2018,925)' title='Foreign Key fk_default_parameter_set
+	default_parameter_set references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1935 930 L 1935,855' >
+	<title>Foreign Key fk_command_parameter
+	command_parameter references software_command ( command_id )</title>
+</path>
+<text x='1937' y='925' transform='rotate(270 1937,925)' title='Foreign Key fk_command_parameter
+	command_parameter references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><!-- ============= Table 'controlled_vocab_values' ============= -->
 <rect class='table' x='45' y='1688' width='150' height='120' rx='7' ry='7' />
 <path d='M 45.50 1714.50 L 45.50 1695.50 Q 45.50 1688.50 52.50 1688.50 L 187.50 1688.50 Q 194.50 1688.50 194.50 1695.50 L 194.50 1714.50 L45.50 1714.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
 <a xlink:href='#controlled_vocab_values'><text x='53' y='1702' class='tableTitle'>controlled_vocab_values</text><title>Table qiita.controlled_vocab_values</title></a>
@@ -915,8 +905,7 @@ Available commands for jobs</title></a>
 <a xlink:href='#command.command_id'><text x='228' y='1312'>command_id</text><title>command_id bigserial not null
 Unique identifier for function</title></a>
 <a xlink:href='#command.command_id'><use id='ref' x='303' y='1301' xlink:href='#ref'/><title>Referred by command_data_type ( command_id ) 
-Referred by job ( command_id ) 
-Referred by command_parameter ( command_id ) </title></a>
+Referred by job ( command_id ) </title></a>
   <use id='nn' x='212' y='1317' xlink:href='#nn'/><a xlink:href='#command.name'><text x='228' y='1327'>name</text><title>name varchar not null</title></a>
   <use id='nn' x='212' y='1332' xlink:href='#nn'/><a xlink:href='#command.command'><text x='228' y='1342'>command</text><title>command varchar not null
 What command to call to run this function</title></a>
@@ -1777,222 +1766,51 @@ Referred by study_publication ( publication_doi -> doi ) </title></a>
   <use id='nn' x='842' y='807' xlink:href='#nn'/><a xlink:href='#data_directory.subdirectory'><text x='858' y='817'>subdirectory</text><title>subdirectory bool not null default FALSE</title></a>
   <use id='nn' x='842' y='822' xlink:href='#nn'/><a xlink:href='#data_directory.active'><text x='858' y='832'>active</text><title>active bool not null</title></a>
 
-<!-- ============= Table 'preprocessed_spectra_params' ============= -->
-<rect class='table' x='1995' y='1823' width='180' height='75' rx='7' ry='7' />
-<path d='M 1995.50 1849.50 L 1995.50 1830.50 Q 1995.50 1823.50 2002.50 1823.50 L 2167.50 1823.50 Q 2174.50 1823.50 2174.50 1830.50 L 2174.50 1849.50 L1995.50 1849.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
-<a xlink:href='#preprocessed_spectra_params'><text x='2002' y='1837' class='tableTitle'>preprocessed_spectra_params</text><title>Table qiita.preprocessed_spectra_params
-Parameters used for processing spectra data&#046;</title></a>
-  <use id='nn' x='1997' y='1857' xlink:href='#nn'/><a xlink:href='#preprocessed_spectra_params.parameters_id'><use id='pk' x='1997' y='1856' xlink:href='#pk'/><title>Primary Key  ( parameters_id ) </title></a>
-<a xlink:href='#preprocessed_spectra_params.parameters_id'><text x='2013' y='1867'>parameters_id</text><title>parameters_id bigserial not null</title></a>
-  <a xlink:href='#preprocessed_spectra_params.col'><text x='2013' y='1882'>col</text><title>col varchar</title></a>
-
-<!-- ============= Table 'processed_params_uclust' ============= -->
-<rect class='table' x='1725' y='1463' width='180' height='120' rx='7' ry='7' />
-<path d='M 1725.50 1489.50 L 1725.50 1470.50 Q 1725.50 1463.50 1732.50 1463.50 L 1897.50 1463.50 Q 1904.50 1463.50 1904.50 1470.50 L 1904.50 1489.50 L1725.50 1489.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
-<a xlink:href='#processed_params_uclust'><text x='1744' y='1477' class='tableTitle'>processed_params_uclust</text><title>Table qiita.processed_params_uclust
-Parameters used for processing data using method uclust</title></a>
-  <use id='nn' x='1727' y='1497' xlink:href='#nn'/><a xlink:href='#processed_params_uclust.parameters_id'><use id='pk' x='1727' y='1496' xlink:href='#pk'/><title>Primary Key  ( parameters_id ) </title></a>
-<a xlink:href='#processed_params_uclust.parameters_id'><text x='1743' y='1507'>parameters_id</text><title>parameters_id bigserial not null</title></a>
-  <use id='nn' x='1727' y='1512' xlink:href='#nn'/><a xlink:href='#processed_params_uclust.reference_id'><use id='idx' x='1727' y='1511' xlink:href='#idx'/><title>Index  ( reference_id ) </title></a>
-<a xlink:href='#processed_params_uclust.reference_id'><text x='1743' y='1522'>reference_id</text><title>reference_id bigint not null
-What version of reference or type of reference used</title></a>
-<a xlink:href='#processed_params_uclust.reference_id'><use id='fk' x='1893' y='1511' xlink:href='#fk'/><title>References reference ( reference_id ) </title></a>
-  <use id='nn' x='1727' y='1527' xlink:href='#nn'/><a xlink:href='#processed_params_uclust.similarity'><text x='1743' y='1537'>similarity</text><title>similarity float8 not null default 0&#046;97</title></a>
-  <use id='nn' x='1727' y='1542' xlink:href='#nn'/><a xlink:href='#processed_params_uclust.enable_rev_strand_match'><text x='1743' y='1552'>enable_rev_strand_match</text><title>enable_rev_strand_match bool not null default TRUE</title></a>
-  <use id='nn' x='1727' y='1557' xlink:href='#nn'/><a xlink:href='#processed_params_uclust.suppress_new_clusters'><text x='1743' y='1567'>suppress_new_clusters</text><title>suppress_new_clusters bool not null default TRUE</title></a>
-
 <!-- ============= Table 'reference' ============= -->
-<rect class='table' x='1725' y='1283' width='135' height='135' rx='7' ry='7' />
-<path d='M 1725.50 1309.50 L 1725.50 1290.50 Q 1725.50 1283.50 1732.50 1283.50 L 1852.50 1283.50 Q 1859.50 1283.50 1859.50 1290.50 L 1859.50 1309.50 L1725.50 1309.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
-<a xlink:href='#reference'><text x='1767' y='1297' class='tableTitle'>reference</text><title>Table qiita.reference</title></a>
-  <use id='nn' x='1727' y='1317' xlink:href='#nn'/><a xlink:href='#reference.reference_id'><use id='pk' x='1727' y='1316' xlink:href='#pk'/><title>Primary Key  ( reference_id ) </title></a>
-<a xlink:href='#reference.reference_id'><text x='1743' y='1327'>reference_id</text><title>reference_id bigserial not null</title></a>
-<a xlink:href='#reference.reference_id'><use id='ref' x='1848' y='1316' xlink:href='#ref'/><title>Referred by processed_params_sortmerna ( reference_id ) 
-Referred by processed_params_uclust ( reference_id ) </title></a>
-  <use id='nn' x='1727' y='1332' xlink:href='#nn'/><a xlink:href='#reference.reference_name'><text x='1743' y='1342'>reference_name</text><title>reference_name varchar not null</title></a>
-  <a xlink:href='#reference.reference_version'><text x='1743' y='1357'>reference_version</text><title>reference_version varchar</title></a>
-  <use id='nn' x='1727' y='1362' xlink:href='#nn'/><a xlink:href='#reference.sequence_filepath'><use id='idx' x='1727' y='1361' xlink:href='#idx'/><title>Index  ( sequence_filepath ) </title></a>
-<a xlink:href='#reference.sequence_filepath'><text x='1743' y='1372'>sequence_filepath</text><title>sequence_filepath bigint not null</title></a>
-<a xlink:href='#reference.sequence_filepath'><use id='fk' x='1848' y='1361' xlink:href='#fk'/><title>References filepath ( sequence_filepath -> filepath_id ) </title></a>
-  <a xlink:href='#reference.taxonomy_filepath'><use id='idx' x='1727' y='1376' xlink:href='#idx'/><title>Index  ( taxonomy_filepath ) </title></a>
-<a xlink:href='#reference.taxonomy_filepath'><text x='1743' y='1387'>taxonomy_filepath</text><title>taxonomy_filepath bigint</title></a>
-<a xlink:href='#reference.taxonomy_filepath'><use id='fk' x='1848' y='1376' xlink:href='#fk'/><title>References filepath ( taxonomy_filepath -> filepath_id ) </title></a>
-  <a xlink:href='#reference.tree_filepath'><use id='idx' x='1727' y='1391' xlink:href='#idx'/><title>Index  ( tree_filepath ) </title></a>
-<a xlink:href='#reference.tree_filepath'><text x='1743' y='1402'>tree_filepath</text><title>tree_filepath bigint</title></a>
-<a xlink:href='#reference.tree_filepath'><use id='fk' x='1848' y='1391' xlink:href='#fk'/><title>References filepath ( tree_filepath -> filepath_id ) </title></a>
-
-<!-- ============= Table 'processing_job_status' ============= -->
-<rect class='table' x='1740' y='1163' width='225' height='90' rx='7' ry='7' />
-<path d='M 1740.50 1189.50 L 1740.50 1170.50 Q 1740.50 1163.50 1747.50 1163.50 L 1957.50 1163.50 Q 1964.50 1163.50 1964.50 1170.50 L 1964.50 1189.50 L1740.50 1189.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#processing_job_status'><text x='1791' y='1177' class='tableTitle'>processing_job_status</text><title>Table qiita.processing_job_status</title></a>
-  <use id='nn' x='1742' y='1197' xlink:href='#nn'/><a xlink:href='#processing_job_status.processing_job_status_id'><use id='pk' x='1742' y='1196' xlink:href='#pk'/><title>Primary Key  ( processing_job_status_id ) </title></a>
-<a xlink:href='#processing_job_status.processing_job_status_id'><text x='1758' y='1207'>processing_job_status_id</text><title>processing_job_status_id bigserial not null</title></a>
-<a xlink:href='#processing_job_status.processing_job_status_id'><use id='ref' x='1953' y='1196' xlink:href='#ref'/><title>Referred by processing_job ( processing_job_status_id ) </title></a>
-  <use id='nn' x='1742' y='1212' xlink:href='#nn'/><a xlink:href='#processing_job_status.processing_job_status'><text x='1758' y='1222'>processing_job_status</text><title>processing_job_status varchar not null</title></a>
-  <use id='nn' x='1742' y='1227' xlink:href='#nn'/><a xlink:href='#processing_job_status.processing_job_status_description'><text x='1758' y='1237'>processing_job_status_description</text><title>processing_job_status_description varchar not null</title></a>
-
-<!-- ============= Table 'processing_job' ============= -->
-<rect class='table' x='1740' y='968' width='180' height='165' rx='7' ry='7' />
-<path d='M 1740.50 994.50 L 1740.50 975.50 Q 1740.50 968.50 1747.50 968.50 L 1912.50 968.50 Q 1919.50 968.50 1919.50 975.50 L 1919.50 994.50 L1740.50 994.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#processing_job'><text x='1788' y='982' class='tableTitle'>processing_job</text><title>Table qiita.processing_job</title></a>
-  <use id='nn' x='1742' y='1002' xlink:href='#nn'/><a xlink:href='#processing_job.processing_job_id'><use id='pk' x='1742' y='1001' xlink:href='#pk'/><title>Primary Key  ( processing_job_id ) </title></a>
-<a xlink:href='#processing_job.processing_job_id'><text x='1758' y='1012'>processing_job_id</text><title>processing_job_id bigserial not null
-Using bigserial in DBSchema &#045; however in the postgres DB this column is of type UUID&#046;</title></a>
-  <use id='nn' x='1742' y='1017' xlink:href='#nn'/><a xlink:href='#processing_job.email'><use id='idx' x='1742' y='1016' xlink:href='#idx'/><title>Index  ( email ) </title></a>
-<a xlink:href='#processing_job.email'><text x='1758' y='1027'>email</text><title>email varchar not null
-The user that launched the job</title></a>
-<a xlink:href='#processing_job.email'><use id='fk' x='1908' y='1016' xlink:href='#fk'/><title>References qiita_user ( email ) </title></a>
-  <use id='nn' x='1742' y='1032' xlink:href='#nn'/><a xlink:href='#processing_job.command_id'><use id='idx' x='1742' y='1031' xlink:href='#idx'/><title>Index  ( command_id ) </title></a>
-<a xlink:href='#processing_job.command_id'><text x='1758' y='1042'>command_id</text><title>command_id bigint not null
-The command launched</title></a>
-<a xlink:href='#processing_job.command_id'><use id='fk' x='1908' y='1031' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
-  <use id='nn' x='1742' y='1047' xlink:href='#nn'/><a xlink:href='#processing_job.command_parameters_id'><text x='1758' y='1057'>command_parameters_id</text><title>command_parameters_id bigint not null
-The parameters used in the command</title></a>
-  <use id='nn' x='1742' y='1062' xlink:href='#nn'/><a xlink:href='#processing_job.processing_job_status_id'><use id='idx' x='1742' y='1061' xlink:href='#idx'/><title>Index  ( processing_job_status_id ) </title></a>
-<a xlink:href='#processing_job.processing_job_status_id'><text x='1758' y='1072'>processing_job_status_id</text><title>processing_job_status_id bigint not null</title></a>
-<a xlink:href='#processing_job.processing_job_status_id'><use id='fk' x='1908' y='1061' xlink:href='#fk'/><title>References processing_job_status ( processing_job_status_id ) </title></a>
-  <a xlink:href='#processing_job.logging_id'><use id='idx' x='1742' y='1076' xlink:href='#idx'/><title>Index  ( logging_id ) </title></a>
-<a xlink:href='#processing_job.logging_id'><text x='1758' y='1087'>logging_id</text><title>logging_id bigint
-In case of failure&#044; point to the log entry that holds more information about the error</title></a>
-<a xlink:href='#processing_job.logging_id'><use id='fk' x='1908' y='1076' xlink:href='#fk'/><title>References logging ( logging_id ) </title></a>
-  <a xlink:href='#processing_job.heartbeat'><text x='1758' y='1102'>heartbeat</text><title>heartbeat timestamp
-The last heartbeat received by this job</title></a>
-  <a xlink:href='#processing_job.step'><text x='1758' y='1117'>step</text><title>step varchar</title></a>
-
-<!-- ============= Table 'preprocessed_sequence_454_params' ============= -->
-<rect class='table' x='1725' y='1598' width='225' height='300' rx='7' ry='7' />
-<path d='M 1725.50 1624.50 L 1725.50 1605.50 Q 1725.50 1598.50 1732.50 1598.50 L 1942.50 1598.50 Q 1949.50 1598.50 1949.50 1605.50 L 1949.50 1624.50 L1725.50 1624.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
-<a xlink:href='#preprocessed_sequence_454_params'><text x='1735' y='1612' class='tableTitle'>preprocessed_sequence_454_params</text><title>Table qiita.preprocessed_sequence_454_params
-Parameters used for processing sequence data&#046;</title></a>
-  <use id='nn' x='1727' y='1632' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.parameters_id'><use id='pk' x='1727' y='1631' xlink:href='#pk'/><title>Primary Key  ( parameters_id ) </title></a>
-<a xlink:href='#preprocessed_sequence_454_params.parameters_id'><text x='1743' y='1642'>parameters_id</text><title>parameters_id bigserial not null</title></a>
-  <use id='nn' x='1727' y='1647' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.param_set_name'><text x='1743' y='1657'>param_set_name</text><title>param_set_name varchar&#040;100&#041; not null
-The name of the parameter set</title></a>
-  <use id='nn' x='1727' y='1662' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.min_seq_len'><text x='1743' y='1672'>min_seq_len</text><title>min_seq_len integer not null default 200
-The minimum sequence length</title></a>
-  <use id='nn' x='1727' y='1677' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.max_seq_len'><text x='1743' y='1687'>max_seq_len</text><title>max_seq_len integer not null default 1000
-The maximum sequence length</title></a>
-  <use id='nn' x='1727' y='1692' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.trim_seq_length'><text x='1743' y='1702'>trim_seq_length</text><title>trim_seq_length bool not null default f
-Whether to trim the sequence length or not</title></a>
-  <use id='nn' x='1727' y='1707' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.min_qual_score'><text x='1743' y='1717'>min_qual_score</text><title>min_qual_score integer not null default 25
-The minimum phred quality score</title></a>
-  <use id='nn' x='1727' y='1722' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.max_ambig'><text x='1743' y='1732'>max_ambig</text><title>max_ambig integer not null default 6
-The maximum number of ambiguous characters</title></a>
-  <use id='nn' x='1727' y='1737' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.max_homopolymer'><text x='1743' y='1747'>max_homopolymer</text><title>max_homopolymer integer not null default 6
-The maximum homopolymer run</title></a>
-  <use id='nn' x='1727' y='1752' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.max_primer_mismatch'><text x='1743' y='1762'>max_primer_mismatch</text><title>max_primer_mismatch integer not null default 0
-Maximum number of mismatches to the primer allowed</title></a>
-  <use id='nn' x='1727' y='1767' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.barcode_type'><text x='1743' y='1777'>barcode_type</text><title>barcode_type varchar not null default &#039;golay&#095;12&#039;
-The barcode type used</title></a>
-  <use id='nn' x='1727' y='1782' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.max_barcode_errors'><text x='1743' y='1792'>max_barcode_errors</text><title>max_barcode_errors real not null default 1&#046;5
-The maximum number of allowed barcode errors</title></a>
-  <use id='nn' x='1727' y='1797' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.disable_bc_correction'><text x='1743' y='1807'>disable_bc_correction</text><title>disable_bc_correction bool not null default f
-Disable barcode correction</title></a>
-  <use id='nn' x='1727' y='1812' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.qual_score_window'><text x='1743' y='1822'>qual_score_window</text><title>qual_score_window integer not null default 0
-Enable a sliding window quality score threshold&#044; this is the size of the window</title></a>
-  <use id='nn' x='1727' y='1827' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.disable_primers'><text x='1743' y='1837'>disable_primers</text><title>disable_primers bool not null default f
-Disable primer checking</title></a>
-  <use id='nn' x='1727' y='1842' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.reverse_primers'><text x='1743' y='1852'>reverse_primers</text><title>reverse_primers varchar not null default &#039;disable&#039;
-Check for reverse primers</title></a>
-  <use id='nn' x='1727' y='1857' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.reverse_primer_mismatches'><text x='1743' y='1867'>reverse_primer_mismatches</text><title>reverse_primer_mismatches integer not null default 0
-The number of allowed mismatches in the reverse primer</title></a>
-  <use id='nn' x='1727' y='1872' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_454_params.truncate_ambig_bases_bool'><text x='1743' y='1882'>truncate_ambig_bases_bool</text><title>truncate_ambig_bases_bool bool not null default f
-Truncate at the first ambiguous base</title></a>
-
-<!-- ============= Table 'processed_params_sortmerna' ============= -->
-<rect class='table' x='1980' y='1418' width='180' height='165' rx='7' ry='7' />
-<path d='M 1980.50 1444.50 L 1980.50 1425.50 Q 1980.50 1418.50 1987.50 1418.50 L 2152.50 1418.50 Q 2159.50 1418.50 2159.50 1425.50 L 2159.50 1444.50 L1980.50 1444.50 ' style='fill:url(#tableHeaderGradient3); stroke:none;' />
-<a xlink:href='#processed_params_sortmerna'><text x='1988' y='1432' class='tableTitle'>processed_params_sortmerna</text><title>Table qiita.processed_params_sortmerna
-Parameters used for processing data using method sortmerna</title></a>
-  <use id='nn' x='1982' y='1452' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.parameters_id'><use id='pk' x='1982' y='1451' xlink:href='#pk'/><title>Primary Key  ( parameters_id ) </title></a>
-<a xlink:href='#processed_params_sortmerna.parameters_id'><text x='1998' y='1462'>parameters_id</text><title>parameters_id bigserial not null</title></a>
-  <use id='nn' x='1982' y='1467' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.reference_id'><use id='idx' x='1982' y='1466' xlink:href='#idx'/><title>Index  ( reference_id ) </title></a>
-<a xlink:href='#processed_params_sortmerna.reference_id'><text x='1998' y='1477'>reference_id</text><title>reference_id bigint not null
-What version of reference or type of reference used</title></a>
-<a xlink:href='#processed_params_sortmerna.reference_id'><use id='fk' x='2148' y='1466' xlink:href='#fk'/><title>References reference ( reference_id ) </title></a>
-  <use id='nn' x='1982' y='1482' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.sortmerna_e_value'><text x='1998' y='1492'>sortmerna_e_value</text><title>sortmerna_e_value float8 not null</title></a>
-  <use id='nn' x='1982' y='1497' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.sortmerna_max_pos'><text x='1998' y='1507'>sortmerna_max_pos</text><title>sortmerna_max_pos integer not null</title></a>
-  <use id='nn' x='1982' y='1512' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.similarity'><text x='1998' y='1522'>similarity</text><title>similarity float8 not null</title></a>
-  <use id='nn' x='1982' y='1527' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.sortmerna_coverage'><text x='1998' y='1537'>sortmerna_coverage</text><title>sortmerna_coverage float8 not null</title></a>
-  <use id='nn' x='1982' y='1542' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.threads'><text x='1998' y='1552'>threads</text><title>threads integer not null</title></a>
-  <use id='nn' x='1982' y='1557' xlink:href='#nn'/><a xlink:href='#processed_params_sortmerna.param_set_name'><text x='1998' y='1567'>param_set_name</text><title>param_set_name varchar&#040;100&#041; not null default &#039;Default&#039;
-The name of the parameter set</title></a>
-
-<!-- ============= Table 'preprocessed_sequence_illumina_params' ============= -->
-<rect class='table' x='1980' y='1598' width='240' height='210' rx='7' ry='7' />
-<path d='M 1980.50 1624.50 L 1980.50 1605.50 Q 1980.50 1598.50 1987.50 1598.50 L 2212.50 1598.50 Q 2219.50 1598.50 2219.50 1605.50 L 2219.50 1624.50 L1980.50 1624.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
-<a xlink:href='#preprocessed_sequence_illumina_params'><text x='1987' y='1612' class='tableTitle'>preprocessed_sequence_illumina_params</text><title>Table qiita.preprocessed_sequence_illumina_params
-Parameters used for processing illumina sequence data&#046;</title></a>
-  <use id='nn' x='1982' y='1632' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.parameters_id'><use id='pk' x='1982' y='1631' xlink:href='#pk'/><title>Primary Key  ( parameters_id ) </title></a>
-<a xlink:href='#preprocessed_sequence_illumina_params.parameters_id'><text x='1998' y='1642'>parameters_id</text><title>parameters_id bigserial not null</title></a>
-  <use id='nn' x='1982' y='1647' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.max_bad_run_length'><text x='1998' y='1657'>max_bad_run_length</text><title>max_bad_run_length integer not null default 3</title></a>
-  <use id='nn' x='1982' y='1662' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.min_per_read_length_fraction'><text x='1998' y='1672'>min_per_read_length_fraction</text><title>min_per_read_length_fraction real not null default 0&#046;75</title></a>
-  <use id='nn' x='1982' y='1677' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.sequence_max_n'><text x='1998' y='1687'>sequence_max_n</text><title>sequence_max_n integer not null default 0</title></a>
-  <use id='nn' x='1982' y='1692' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.rev_comp_barcode'><text x='1998' y='1702'>rev_comp_barcode</text><title>rev_comp_barcode bool not null default FALSE</title></a>
-  <use id='nn' x='1982' y='1707' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.rev_comp_mapping_barcodes'><text x='1998' y='1717'>rev_comp_mapping_barcodes</text><title>rev_comp_mapping_barcodes bool not null default FALSE</title></a>
-  <use id='nn' x='1982' y='1722' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.rev_comp'><text x='1998' y='1732'>rev_comp</text><title>rev_comp bool not null default FALSE</title></a>
-  <use id='nn' x='1982' y='1737' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.phred_quality_threshold'><text x='1998' y='1747'>phred_quality_threshold</text><title>phred_quality_threshold integer not null default 3</title></a>
-  <use id='nn' x='1982' y='1752' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.barcode_type'><text x='1998' y='1762'>barcode_type</text><title>barcode_type varchar not null default &#039;golay&#095;12&#039;</title></a>
-  <use id='nn' x='1982' y='1767' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.max_barcode_errors'><text x='1998' y='1777'>max_barcode_errors</text><title>max_barcode_errors real not null default 1&#046;5</title></a>
-  <use id='nn' x='1982' y='1782' xlink:href='#nn'/><a xlink:href='#preprocessed_sequence_illumina_params.param_set_name'><text x='1998' y='1792'>param_set_name</text><title>param_set_name varchar&#040;100&#041; not null
-The name of the parameter set</title></a>
-
-<!-- ============= Table 'command_parameter' ============= -->
-<rect class='table' x='2055' y='863' width='135' height='120' rx='7' ry='7' />
-<path d='M 2055.50 889.50 L 2055.50 870.50 Q 2055.50 863.50 2062.50 863.50 L 2182.50 863.50 Q 2189.50 863.50 2189.50 870.50 L 2189.50 889.50 L2055.50 889.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#command_parameter'><text x='2065' y='877' class='tableTitle'>command_parameter</text><title>Table qiita.command_parameter</title></a>
-  <use id='nn' x='2057' y='897' xlink:href='#nn'/><a xlink:href='#command_parameter.command_id'><use id='pk' x='2057' y='896' xlink:href='#pk'/><title>Index  ( command_id ) Primary Key  ( command_id, parameter_name ) </title></a>
-<a xlink:href='#command_parameter.command_id'><text x='2073' y='907'>command_id</text><title>command_id bigint not null</title></a>
-<a xlink:href='#command_parameter.command_id'><use id='fk' x='2178' y='896' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
-  <use id='nn' x='2057' y='912' xlink:href='#nn'/><a xlink:href='#command_parameter.parameter_name'><use id='pk' x='2057' y='911' xlink:href='#pk'/><title>Primary Key  ( command_id, parameter_name ) </title></a>
-<a xlink:href='#command_parameter.parameter_name'><text x='2073' y='922'>parameter_name</text><title>parameter_name varchar not null</title></a>
-  <use id='nn' x='2057' y='927' xlink:href='#nn'/><a xlink:href='#command_parameter.parameter_type'><text x='2073' y='937'>parameter_type</text><title>parameter_type varchar not null</title></a>
-  <use id='nn' x='2057' y='942' xlink:href='#nn'/><a xlink:href='#command_parameter.required'><text x='2073' y='952'>required</text><title>required bool not null</title></a>
-  <a xlink:href='#command_parameter.default_value'><text x='2073' y='967'>default_value</text><title>default_value varchar</title></a>
-
-<!-- ============= Table 'default_parameter_set' ============= -->
-<rect class='table' x='2025' y='998' width='165' height='105' rx='7' ry='7' />
-<path d='M 2025.50 1024.50 L 2025.50 1005.50 Q 2025.50 998.50 2032.50 998.50 L 2182.50 998.50 Q 2189.50 998.50 2189.50 1005.50 L 2189.50 1024.50 L2025.50 1024.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#default_parameter_set'><text x='2047' y='1012' class='tableTitle'>default_parameter_set</text><title>Table qiita.default_parameter_set</title></a>
-  <use id='nn' x='2027' y='1032' xlink:href='#nn'/><a xlink:href='#default_parameter_set.default_parameter_set_id'><use id='pk' x='2027' y='1031' xlink:href='#pk'/><title>Primary Key  ( default_parameter_set_id ) </title></a>
-<a xlink:href='#default_parameter_set.default_parameter_set_id'><text x='2043' y='1042'>default_parameter_set_id</text><title>default_parameter_set_id bigserial not null</title></a>
-  <use id='nn' x='2027' y='1047' xlink:href='#nn'/><a xlink:href='#default_parameter_set.command_id'><use id='unq' x='2027' y='1046' xlink:href='#unq'/><title>Index  ( command_id ) Unique Index  ( command_id, parameter_set_name ) </title></a>
-<a xlink:href='#default_parameter_set.command_id'><text x='2043' y='1057'>command_id</text><title>command_id bigint not null</title></a>
-<a xlink:href='#default_parameter_set.command_id'><use id='fk' x='2178' y='1046' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
-  <use id='nn' x='2027' y='1062' xlink:href='#nn'/><a xlink:href='#default_parameter_set.parameter_set_name'><use id='unq' x='2027' y='1061' xlink:href='#unq'/><title>Unique Index  ( command_id, parameter_set_name ) </title></a>
-<a xlink:href='#default_parameter_set.parameter_set_name'><text x='2043' y='1072'>parameter_set_name</text><title>parameter_set_name varchar not null</title></a>
-  <use id='nn' x='2027' y='1077' xlink:href='#nn'/><a xlink:href='#default_parameter_set.parameter_set'><text x='2043' y='1087'>parameter_set</text><title>parameter_set varchar not null
-This is a varchar here &#045; but is of type JSON in postgresql&#046;</title></a>
+<rect class='table' x='1785' y='1283' width='135' height='135' rx='7' ry='7' />
+<path d='M 1785.50 1309.50 L 1785.50 1290.50 Q 1785.50 1283.50 1792.50 1283.50 L 1912.50 1283.50 Q 1919.50 1283.50 1919.50 1290.50 L 1919.50 1309.50 L1785.50 1309.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
+<a xlink:href='#reference'><text x='1827' y='1297' class='tableTitle'>reference</text><title>Table qiita.reference</title></a>
+  <use id='nn' x='1787' y='1317' xlink:href='#nn'/><a xlink:href='#reference.reference_id'><use id='pk' x='1787' y='1316' xlink:href='#pk'/><title>Primary Key  ( reference_id ) </title></a>
+<a xlink:href='#reference.reference_id'><text x='1803' y='1327'>reference_id</text><title>reference_id bigserial not null</title></a>
+  <use id='nn' x='1787' y='1332' xlink:href='#nn'/><a xlink:href='#reference.reference_name'><text x='1803' y='1342'>reference_name</text><title>reference_name varchar not null</title></a>
+  <a xlink:href='#reference.reference_version'><text x='1803' y='1357'>reference_version</text><title>reference_version varchar</title></a>
+  <use id='nn' x='1787' y='1362' xlink:href='#nn'/><a xlink:href='#reference.sequence_filepath'><use id='idx' x='1787' y='1361' xlink:href='#idx'/><title>Index  ( sequence_filepath ) </title></a>
+<a xlink:href='#reference.sequence_filepath'><text x='1803' y='1372'>sequence_filepath</text><title>sequence_filepath bigint not null</title></a>
+<a xlink:href='#reference.sequence_filepath'><use id='fk' x='1908' y='1361' xlink:href='#fk'/><title>References filepath ( sequence_filepath -> filepath_id ) </title></a>
+  <a xlink:href='#reference.taxonomy_filepath'><use id='idx' x='1787' y='1376' xlink:href='#idx'/><title>Index  ( taxonomy_filepath ) </title></a>
+<a xlink:href='#reference.taxonomy_filepath'><text x='1803' y='1387'>taxonomy_filepath</text><title>taxonomy_filepath bigint</title></a>
+<a xlink:href='#reference.taxonomy_filepath'><use id='fk' x='1908' y='1376' xlink:href='#fk'/><title>References filepath ( taxonomy_filepath -> filepath_id ) </title></a>
+  <a xlink:href='#reference.tree_filepath'><use id='idx' x='1787' y='1391' xlink:href='#idx'/><title>Index  ( tree_filepath ) </title></a>
+<a xlink:href='#reference.tree_filepath'><text x='1803' y='1402'>tree_filepath</text><title>tree_filepath bigint</title></a>
+<a xlink:href='#reference.tree_filepath'><use id='fk' x='1908' y='1391' xlink:href='#fk'/><title>References filepath ( tree_filepath -> filepath_id ) </title></a>
 
 <!-- ============= Table 'software' ============= -->
-<rect class='table' x='2040' y='743' width='105' height='105' rx='7' ry='7' />
-<path d='M 2040.50 769.50 L 2040.50 750.50 Q 2040.50 743.50 2047.50 743.50 L 2137.50 743.50 Q 2144.50 743.50 2144.50 750.50 L 2144.50 769.50 L2040.50 769.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#software'><text x='2069' y='757' class='tableTitle'>software</text><title>Table qiita.software</title></a>
-  <use id='nn' x='2042' y='777' xlink:href='#nn'/><a xlink:href='#software.software_id'><use id='pk' x='2042' y='776' xlink:href='#pk'/><title>Primary Key  ( software_id ) </title></a>
-<a xlink:href='#software.software_id'><text x='2058' y='787'>software_id</text><title>software_id bigserial not null</title></a>
-<a xlink:href='#software.software_id'><use id='ref' x='2133' y='776' xlink:href='#ref'/><title>Referred by software_command ( software_id ) 
+<rect class='table' x='2100' y='743' width='105' height='105' rx='7' ry='7' />
+<path d='M 2100.50 769.50 L 2100.50 750.50 Q 2100.50 743.50 2107.50 743.50 L 2197.50 743.50 Q 2204.50 743.50 2204.50 750.50 L 2204.50 769.50 L2100.50 769.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#software'><text x='2129' y='757' class='tableTitle'>software</text><title>Table qiita.software</title></a>
+  <use id='nn' x='2102' y='777' xlink:href='#nn'/><a xlink:href='#software.software_id'><use id='pk' x='2102' y='776' xlink:href='#pk'/><title>Primary Key  ( software_id ) </title></a>
+<a xlink:href='#software.software_id'><text x='2118' y='787'>software_id</text><title>software_id bigserial not null</title></a>
+<a xlink:href='#software.software_id'><use id='ref' x='2193' y='776' xlink:href='#ref'/><title>Referred by software_command ( software_id ) 
 Referred by software_publication ( software_id ) </title></a>
-  <use id='nn' x='2042' y='792' xlink:href='#nn'/><a xlink:href='#software.name'><text x='2058' y='802'>name</text><title>name varchar not null</title></a>
-  <use id='nn' x='2042' y='807' xlink:href='#nn'/><a xlink:href='#software.version'><text x='2058' y='817'>version</text><title>version varchar not null</title></a>
-  <use id='nn' x='2042' y='822' xlink:href='#nn'/><a xlink:href='#software.description'><text x='2058' y='832'>description</text><title>description varchar not null</title></a>
+  <use id='nn' x='2102' y='792' xlink:href='#nn'/><a xlink:href='#software.name'><text x='2118' y='802'>name</text><title>name varchar not null</title></a>
+  <use id='nn' x='2102' y='807' xlink:href='#nn'/><a xlink:href='#software.version'><text x='2118' y='817'>version</text><title>version varchar not null</title></a>
+  <use id='nn' x='2102' y='822' xlink:href='#nn'/><a xlink:href='#software.description'><text x='2118' y='832'>description</text><title>description varchar not null</title></a>
 
 <!-- ============= Table 'software_command' ============= -->
-<rect class='table' x='1845' y='743' width='120' height='105' rx='7' ry='7' />
-<path d='M 1845.50 769.50 L 1845.50 750.50 Q 1845.50 743.50 1852.50 743.50 L 1957.50 743.50 Q 1964.50 743.50 1964.50 750.50 L 1964.50 769.50 L1845.50 769.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#software_command'><text x='1852' y='757' class='tableTitle'>software_command</text><title>Table qiita.software_command</title></a>
-  <use id='nn' x='1847' y='777' xlink:href='#nn'/><a xlink:href='#software_command.command_id'><use id='pk' x='1847' y='776' xlink:href='#pk'/><title>Primary Key  ( command_id ) </title></a>
-<a xlink:href='#software_command.command_id'><text x='1863' y='787'>command_id</text><title>command_id bigserial not null</title></a>
-<a xlink:href='#software_command.command_id'><use id='ref' x='1953' y='776' xlink:href='#ref'/><title>Referred by artifact ( command_id ) 
-Referred by processing_job ( command_id ) 
-Referred by command_parameter ( command_id ) 
+<rect class='table' x='1905' y='743' width='120' height='105' rx='7' ry='7' />
+<path d='M 1905.50 769.50 L 1905.50 750.50 Q 1905.50 743.50 1912.50 743.50 L 2017.50 743.50 Q 2024.50 743.50 2024.50 750.50 L 2024.50 769.50 L1905.50 769.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#software_command'><text x='1912' y='757' class='tableTitle'>software_command</text><title>Table qiita.software_command</title></a>
+  <use id='nn' x='1907' y='777' xlink:href='#nn'/><a xlink:href='#software_command.command_id'><use id='pk' x='1907' y='776' xlink:href='#pk'/><title>Primary Key  ( command_id ) </title></a>
+<a xlink:href='#software_command.command_id'><text x='1923' y='787'>command_id</text><title>command_id bigserial not null</title></a>
+<a xlink:href='#software_command.command_id'><use id='ref' x='2013' y='776' xlink:href='#ref'/><title>Referred by artifact ( command_id ) 
 Referred by command_parameter ( command_id ) 
 Referred by default_parameter_set ( command_id ) 
-Referred by default_parameter_set ( command_id ) </title></a>
-  <use id='nn' x='1847' y='792' xlink:href='#nn'/><a xlink:href='#software_command.name'><text x='1863' y='802'>name</text><title>name varchar not null</title></a>
-  <use id='nn' x='1847' y='807' xlink:href='#nn'/><a xlink:href='#software_command.software_id'><use id='idx' x='1847' y='806' xlink:href='#idx'/><title>Index  ( software_id ) </title></a>
-<a xlink:href='#software_command.software_id'><text x='1863' y='817'>software_id</text><title>software_id bigint not null</title></a>
-<a xlink:href='#software_command.software_id'><use id='fk' x='1953' y='806' xlink:href='#fk'/><title>References software ( software_id ) </title></a>
-  <use id='nn' x='1847' y='822' xlink:href='#nn'/><a xlink:href='#software_command.description'><text x='1863' y='832'>description</text><title>description varchar not null</title></a>
+Referred by processing_job ( command_id ) </title></a>
+  <use id='nn' x='1907' y='792' xlink:href='#nn'/><a xlink:href='#software_command.name'><text x='1923' y='802'>name</text><title>name varchar not null</title></a>
+  <use id='nn' x='1907' y='807' xlink:href='#nn'/><a xlink:href='#software_command.software_id'><use id='idx' x='1907' y='806' xlink:href='#idx'/><title>Index  ( software_id ) </title></a>
+<a xlink:href='#software_command.software_id'><text x='1923' y='817'>software_id</text><title>software_id bigint not null</title></a>
+<a xlink:href='#software_command.software_id'><use id='fk' x='2013' y='806' xlink:href='#fk'/><title>References software ( software_id ) </title></a>
+  <use id='nn' x='1907' y='822' xlink:href='#nn'/><a xlink:href='#software_command.description'><text x='1923' y='832'>description</text><title>description varchar not null</title></a>
 
 <!-- ============= Table 'artifact' ============= -->
 <rect class='table' x='1200' y='743' width='195' height='195' rx='7' ry='7' />
@@ -2027,6 +1845,71 @@ If the artifact is sandbox&#044; awaiting&#095;for&#095;approval&#044; private o
   <use id='nn' x='1202' y='882' xlink:href='#nn'/><a xlink:href='#artifact.can_be_submitted_to_ebi'><text x='1218' y='892'>can_be_submitted_to_ebi</text><title>can_be_submitted_to_ebi bool not null default &#039;FALSE&#039;</title></a>
   <use id='nn' x='1202' y='897' xlink:href='#nn'/><a xlink:href='#artifact.can_be_submitted_to_vamps'><text x='1218' y='907'>can_be_submitted_to_vamps</text><title>can_be_submitted_to_vamps bool not null default &#039;FALSE&#039;</title></a>
   <use id='nn' x='1202' y='912' xlink:href='#nn'/><a xlink:href='#artifact.submitted_to_vamps'><text x='1218' y='922'>submitted_to_vamps</text><title>submitted_to_vamps bool not null default &#039;FALSE&#039;</title></a>
+
+<!-- ============= Table 'processing_job_status' ============= -->
+<rect class='table' x='2025' y='1133' width='225' height='90' rx='7' ry='7' />
+<path d='M 2025.50 1159.50 L 2025.50 1140.50 Q 2025.50 1133.50 2032.50 1133.50 L 2242.50 1133.50 Q 2249.50 1133.50 2249.50 1140.50 L 2249.50 1159.50 L2025.50 1159.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#processing_job_status'><text x='2076' y='1147' class='tableTitle'>processing_job_status</text><title>Table qiita.processing_job_status</title></a>
+  <use id='nn' x='2027' y='1167' xlink:href='#nn'/><a xlink:href='#processing_job_status.processing_job_status_id'><use id='pk' x='2027' y='1166' xlink:href='#pk'/><title>Primary Key  ( processing_job_status_id ) </title></a>
+<a xlink:href='#processing_job_status.processing_job_status_id'><text x='2043' y='1177'>processing_job_status_id</text><title>processing_job_status_id bigserial not null</title></a>
+<a xlink:href='#processing_job_status.processing_job_status_id'><use id='ref' x='2238' y='1166' xlink:href='#ref'/><title>Referred by processing_job ( processing_job_status_id ) </title></a>
+  <use id='nn' x='2027' y='1182' xlink:href='#nn'/><a xlink:href='#processing_job_status.processing_job_status'><text x='2043' y='1192'>processing_job_status</text><title>processing_job_status varchar not null</title></a>
+  <use id='nn' x='2027' y='1197' xlink:href='#nn'/><a xlink:href='#processing_job_status.processing_job_status_description'><text x='2043' y='1207'>processing_job_status_description</text><title>processing_job_status_description varchar not null</title></a>
+
+<!-- ============= Table 'processing_job' ============= -->
+<rect class='table' x='1800' y='1088' width='180' height='165' rx='7' ry='7' />
+<path d='M 1800.50 1114.50 L 1800.50 1095.50 Q 1800.50 1088.50 1807.50 1088.50 L 1972.50 1088.50 Q 1979.50 1088.50 1979.50 1095.50 L 1979.50 1114.50 L1800.50 1114.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#processing_job'><text x='1848' y='1102' class='tableTitle'>processing_job</text><title>Table qiita.processing_job</title></a>
+  <use id='nn' x='1802' y='1122' xlink:href='#nn'/><a xlink:href='#processing_job.processing_job_id'><use id='pk' x='1802' y='1121' xlink:href='#pk'/><title>Primary Key  ( processing_job_id ) </title></a>
+<a xlink:href='#processing_job.processing_job_id'><text x='1818' y='1132'>processing_job_id</text><title>processing_job_id bigserial not null
+Using bigserial in DBSchema &#045; however in the postgres DB this column is of type UUID&#046;</title></a>
+  <use id='nn' x='1802' y='1137' xlink:href='#nn'/><a xlink:href='#processing_job.email'><use id='idx' x='1802' y='1136' xlink:href='#idx'/><title>Index  ( email ) </title></a>
+<a xlink:href='#processing_job.email'><text x='1818' y='1147'>email</text><title>email varchar not null
+The user that launched the job</title></a>
+<a xlink:href='#processing_job.email'><use id='fk' x='1968' y='1136' xlink:href='#fk'/><title>References qiita_user ( email ) </title></a>
+  <use id='nn' x='1802' y='1152' xlink:href='#nn'/><a xlink:href='#processing_job.command_id'><use id='idx' x='1802' y='1151' xlink:href='#idx'/><title>Index  ( command_id ) </title></a>
+<a xlink:href='#processing_job.command_id'><text x='1818' y='1162'>command_id</text><title>command_id bigint not null
+The command launched</title></a>
+<a xlink:href='#processing_job.command_id'><use id='fk' x='1968' y='1151' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
+  <use id='nn' x='1802' y='1167' xlink:href='#nn'/><a xlink:href='#processing_job.command_parameters'><text x='1818' y='1177'>command_parameters</text><title>command_parameters varchar not null
+The parameters used in the command in JSON format</title></a>
+  <use id='nn' x='1802' y='1182' xlink:href='#nn'/><a xlink:href='#processing_job.processing_job_status_id'><use id='idx' x='1802' y='1181' xlink:href='#idx'/><title>Index  ( processing_job_status_id ) </title></a>
+<a xlink:href='#processing_job.processing_job_status_id'><text x='1818' y='1192'>processing_job_status_id</text><title>processing_job_status_id bigint not null</title></a>
+<a xlink:href='#processing_job.processing_job_status_id'><use id='fk' x='1968' y='1181' xlink:href='#fk'/><title>References processing_job_status ( processing_job_status_id ) </title></a>
+  <a xlink:href='#processing_job.logging_id'><use id='idx' x='1802' y='1196' xlink:href='#idx'/><title>Index  ( logging_id ) </title></a>
+<a xlink:href='#processing_job.logging_id'><text x='1818' y='1207'>logging_id</text><title>logging_id bigint
+In case of failure&#044; point to the log entry that holds more information about the error</title></a>
+<a xlink:href='#processing_job.logging_id'><use id='fk' x='1968' y='1196' xlink:href='#fk'/><title>References logging ( logging_id ) </title></a>
+  <a xlink:href='#processing_job.heartbeat'><text x='1818' y='1222'>heartbeat</text><title>heartbeat timestamp
+The last heartbeat received by this job</title></a>
+  <a xlink:href='#processing_job.step'><text x='1818' y='1237'>step</text><title>step varchar</title></a>
+
+<!-- ============= Table 'default_parameter_set' ============= -->
+<rect class='table' x='2100' y='923' width='165' height='105' rx='7' ry='7' />
+<path d='M 2100.50 949.50 L 2100.50 930.50 Q 2100.50 923.50 2107.50 923.50 L 2257.50 923.50 Q 2264.50 923.50 2264.50 930.50 L 2264.50 949.50 L2100.50 949.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#default_parameter_set'><text x='2122' y='937' class='tableTitle'>default_parameter_set</text><title>Table qiita.default_parameter_set</title></a>
+  <use id='nn' x='2102' y='957' xlink:href='#nn'/><a xlink:href='#default_parameter_set.default_parameter_set_id'><use id='pk' x='2102' y='956' xlink:href='#pk'/><title>Primary Key  ( default_parameter_set_id ) </title></a>
+<a xlink:href='#default_parameter_set.default_parameter_set_id'><text x='2118' y='967'>default_parameter_set_id</text><title>default_parameter_set_id bigserial not null</title></a>
+  <use id='nn' x='2102' y='972' xlink:href='#nn'/><a xlink:href='#default_parameter_set.command_id'><use id='unq' x='2102' y='971' xlink:href='#unq'/><title>Index  ( command_id ) Unique Index  ( command_id, parameter_set_name ) </title></a>
+<a xlink:href='#default_parameter_set.command_id'><text x='2118' y='982'>command_id</text><title>command_id bigint not null</title></a>
+<a xlink:href='#default_parameter_set.command_id'><use id='fk' x='2253' y='971' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
+  <use id='nn' x='2102' y='987' xlink:href='#nn'/><a xlink:href='#default_parameter_set.parameter_set_name'><use id='unq' x='2102' y='986' xlink:href='#unq'/><title>Unique Index  ( command_id, parameter_set_name ) </title></a>
+<a xlink:href='#default_parameter_set.parameter_set_name'><text x='2118' y='997'>parameter_set_name</text><title>parameter_set_name varchar not null</title></a>
+  <use id='nn' x='2102' y='1002' xlink:href='#nn'/><a xlink:href='#default_parameter_set.parameter_set'><text x='2118' y='1012'>parameter_set</text><title>parameter_set varchar not null
+This is a varchar here &#045; but is of type JSON in postgresql&#046;</title></a>
+
+<!-- ============= Table 'command_parameter' ============= -->
+<rect class='table' x='1920' y='938' width='135' height='120' rx='7' ry='7' />
+<path d='M 1920.50 964.50 L 1920.50 945.50 Q 1920.50 938.50 1927.50 938.50 L 2047.50 938.50 Q 2054.50 938.50 2054.50 945.50 L 2054.50 964.50 L1920.50 964.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#command_parameter'><text x='1930' y='952' class='tableTitle'>command_parameter</text><title>Table qiita.command_parameter</title></a>
+  <use id='nn' x='1922' y='972' xlink:href='#nn'/><a xlink:href='#command_parameter.command_id'><use id='pk' x='1922' y='971' xlink:href='#pk'/><title>Index  ( command_id ) Primary Key  ( command_id, parameter_name ) </title></a>
+<a xlink:href='#command_parameter.command_id'><text x='1938' y='982'>command_id</text><title>command_id bigint not null</title></a>
+<a xlink:href='#command_parameter.command_id'><use id='fk' x='2043' y='971' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
+  <use id='nn' x='1922' y='987' xlink:href='#nn'/><a xlink:href='#command_parameter.parameter_name'><use id='pk' x='1922' y='986' xlink:href='#pk'/><title>Primary Key  ( command_id, parameter_name ) </title></a>
+<a xlink:href='#command_parameter.parameter_name'><text x='1938' y='997'>parameter_name</text><title>parameter_name varchar not null</title></a>
+  <use id='nn' x='1922' y='1002' xlink:href='#nn'/><a xlink:href='#command_parameter.parameter_type'><text x='1938' y='1012'>parameter_type</text><title>parameter_type varchar not null</title></a>
+  <use id='nn' x='1922' y='1017' xlink:href='#nn'/><a xlink:href='#command_parameter.required'><text x='1938' y='1027'>required</text><title>required bool not null</title></a>
+  <a xlink:href='#command_parameter.default_value'><text x='1938' y='1042'>default_value</text><title>default_value varchar</title></a>
 
 </g></svg>
 
@@ -5064,81 +4947,6 @@ Controlled Vocabulary </td>
 <br/><br/>
 <table class='bordered'>
 <thead>
-<tr><th colspan='3'><a name='preprocessed_spectra_params'>Table preprocessed_spectra_params</a></th></tr>
-<tr><td colspan='3'>Parameters used for processing spectra data&#046; </td></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='preprocessed_spectra_params.parameters_id'>parameters&#095;id</a></td>
-		<td> bigserial  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_spectra_params.col'>col</a></td>
-		<td> varchar   </td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>pk&#095;preprocessed&#095;spectra&#095;params primary key</td>
-		<td> ON parameters&#095;id</td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table class='bordered'>
-<thead>
-<tr><th colspan='3'><a name='processed_params_uclust'>Table processed_params_uclust</a></th></tr>
-<tr><td colspan='3'>Parameters used for processing data using method uclust </td></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='processed_params_uclust.parameters_id'>parameters&#095;id</a></td>
-		<td> bigserial  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_uclust.reference_id'>reference&#095;id</a></td>
-		<td> bigint  NOT NULL  </td>
-		<td> What version of reference or type of reference used </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_uclust.similarity'>similarity</a></td>
-		<td> float8  NOT NULL  DEFO 0.97 </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_uclust.enable_rev_strand_match'>enable&#095;rev&#095;strand&#095;match</a></td>
-		<td> bool  NOT NULL  DEFO TRUE </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_uclust.suppress_new_clusters'>suppress&#095;new&#095;clusters</a></td>
-		<td> bool  NOT NULL  DEFO TRUE </td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>pk&#095;processed&#095;params&#095;uclust primary key</td>
-		<td> ON parameters&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;processed&#095;params&#095;uclust </td>
-		<td> ON reference&#095;id</td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
-	<tr>
-		<td>fk_processed_params_uclust</td>
-		<td > ( reference&#095;id ) ref <a href='#reference'>reference</a> (reference&#095;id) </td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table class='bordered'>
-<thead>
 <tr><th colspan='3'><a name='reference'>Table reference</a></th></tr>
 </thead>
 <tbody>
@@ -5203,458 +5011,6 @@ Controlled Vocabulary </td>
 	<tr>
 		<td>fk_reference_tree_filepath</td>
 		<td > ( tree&#095;filepath ) ref <a href='#filepath'>filepath</a> (filepath&#095;id) </td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table class='bordered'>
-<thead>
-<tr><th colspan='3'><a name='processing_job_status'>Table processing_job_status</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='processing_job_status.processing_job_status_id'>processing&#095;job&#095;status&#095;id</a></td>
-		<td> bigserial  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job_status.processing_job_status'>processing&#095;job&#095;status</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job_status.processing_job_status_description'>processing&#095;job&#095;status&#095;description</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>pk&#095;processing&#095;job&#095;status primary key</td>
-		<td> ON processing&#095;job&#095;status&#095;id</td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table class='bordered'>
-<thead>
-<tr><th colspan='3'><a name='processing_job'>Table processing_job</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='processing_job.processing_job_id'>processing&#095;job&#095;id</a></td>
-		<td> bigserial  NOT NULL  </td>
-		<td> Using bigserial in DBSchema &#045; however in the postgres DB this column is of type UUID&#046; </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job.email'>email</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td> The user that launched the job </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job.command_id'>command&#095;id</a></td>
-		<td> bigint  NOT NULL  </td>
-		<td> The command launched </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job.command_parameters_id'>command&#095;parameters&#095;id</a></td>
-		<td> bigint  NOT NULL  </td>
-		<td> The parameters used in the command </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job.processing_job_status_id'>processing&#095;job&#095;status&#095;id</a></td>
-		<td> bigint  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job.logging_id'>logging&#095;id</a></td>
-		<td> bigint   </td>
-		<td> In case of failure&#044; point to the log entry that holds more information about the error </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job.heartbeat'>heartbeat</a></td>
-		<td> timestamp   </td>
-		<td> The last heartbeat received by this job </td>
-	</tr>
-	<tr>
-		<td><a name='processing_job.step'>step</a></td>
-		<td> varchar   </td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>pk&#095;processing&#095;job primary key</td>
-		<td> ON processing&#095;job&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;processing&#095;job </td>
-		<td> ON email</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;processing&#095;job </td>
-		<td> ON command&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;processing&#095;job&#095;0 </td>
-		<td> ON processing&#095;job&#095;status&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;processing&#095;job&#095;1 </td>
-		<td> ON logging&#095;id</td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
-	<tr>
-		<td>fk_processing_job_qiita_user</td>
-		<td > ( email ) ref <a href='#qiita&#095;user'>qiita&#095;user</a> (email) </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td>fk_processing_job</td>
-		<td > ( command&#095;id ) ref <a href='#software&#095;command'>software&#095;command</a> (command&#095;id) </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td>fk_processing_job_status</td>
-		<td > ( processing&#095;job&#095;status&#095;id ) ref <a href='#processing&#095;job&#095;status'>processing&#095;job&#095;status</a> (processing&#095;job&#095;status&#095;id) </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td>fk_processing_job_logging</td>
-		<td > ( logging&#095;id ) ref <a href='#logging'>logging</a> (logging&#095;id) </td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table class='bordered'>
-<thead>
-<tr><th colspan='3'><a name='preprocessed_sequence_454_params'>Table preprocessed_sequence_454_params</a></th></tr>
-<tr><td colspan='3'>Parameters used for processing sequence data&#046; </td></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='preprocessed_sequence_454_params.parameters_id'>parameters&#095;id</a></td>
-		<td> bigserial  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_454_params.param_set_name'>param&#095;set&#095;name</a></td>
-		<td> varchar&#040; 100 &#041;  NOT NULL  </td>
-		<td> The name of the parameter set </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_454_params.min_seq_len'>min&#095;seq&#095;len</a></td>
-		<td> integer  NOT NULL  DEFO 200 </td>
-		<td> The minimum sequence length </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_454_params.max_seq_len'>max&#095;seq&#095;len</a></td>
-		<td> integer  NOT NULL  DEFO 1000 </td>
-		<td> The maximum sequence length </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_454_params.trim_seq_length'>trim&#095;seq&#095;length</a></td>
-		<td> bool  NOT NULL  DEFO f </td>
-		<td> Whether to trim the sequence length or not </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_454_params.min_qual_score'>min&#095;qual&#095;score</a></td>
-		<td> integer  NOT NULL  DEFO 25 </td>
-		<td> The minimum phred quality score </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_454_params.max_ambig'>max&#095;ambig</a></td>
-		<td> integer  NOT NULL  DEFO 6 </td>
-		<td> The maximum number of ambiguous characters </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_454_params.max_homopolymer'>max&#095;homopolymer</a></td>
-		<td> integer  NOT NULL  DEFO 6 </td>
-		<td> The maximum homopolymer run </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_454_params.max_primer_mismatch'>max&#095;primer&#095;mismatch</a></td>
-		<td> integer  NOT NULL  DEFO 0 </td>
-		<td> Maximum number of mismatches to the primer allowed </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_454_params.barcode_type'>barcode&#095;type</a></td>
-		<td> varchar  NOT NULL  DEFO 'golay_12' </td>
-		<td> The barcode type used </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_454_params.max_barcode_errors'>max&#095;barcode&#095;errors</a></td>
-		<td> real  NOT NULL  DEFO 1.5 </td>
-		<td> The maximum number of allowed barcode errors </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_454_params.disable_bc_correction'>disable&#095;bc&#095;correction</a></td>
-		<td> bool  NOT NULL  DEFO f </td>
-		<td> Disable barcode correction </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_454_params.qual_score_window'>qual&#095;score&#095;window</a></td>
-		<td> integer  NOT NULL  DEFO 0 </td>
-		<td> Enable a sliding window quality score threshold&#044; this is the size of the window </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_454_params.disable_primers'>disable&#095;primers</a></td>
-		<td> bool  NOT NULL  DEFO f </td>
-		<td> Disable primer checking </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_454_params.reverse_primers'>reverse&#095;primers</a></td>
-		<td> varchar  NOT NULL  DEFO 'disable' </td>
-		<td> Check for reverse primers </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_454_params.reverse_primer_mismatches'>reverse&#095;primer&#095;mismatches</a></td>
-		<td> integer  NOT NULL  DEFO 0 </td>
-		<td> The number of allowed mismatches in the reverse primer </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_454_params.truncate_ambig_bases_bool'>truncate&#095;ambig&#095;bases&#095;bool</a></td>
-		<td> bool  NOT NULL  DEFO f </td>
-		<td> Truncate at the first ambiguous base </td>
-	</tr>
-<tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>pk&#095;preprocessed&#095;sequence&#095;454&#095;params primary key</td>
-		<td> ON parameters&#095;id</td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table class='bordered'>
-<thead>
-<tr><th colspan='3'><a name='processed_params_sortmerna'>Table processed_params_sortmerna</a></th></tr>
-<tr><td colspan='3'>Parameters used for processing data using method sortmerna </td></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='processed_params_sortmerna.parameters_id'>parameters&#095;id</a></td>
-		<td> bigserial  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_sortmerna.reference_id'>reference&#095;id</a></td>
-		<td> bigint  NOT NULL  </td>
-		<td> What version of reference or type of reference used </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_sortmerna.sortmerna_e_value'>sortmerna&#095;e&#095;value</a></td>
-		<td> float8  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_sortmerna.sortmerna_max_pos'>sortmerna&#095;max&#095;pos</a></td>
-		<td> integer  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_sortmerna.similarity'>similarity</a></td>
-		<td> float8  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_sortmerna.sortmerna_coverage'>sortmerna&#095;coverage</a></td>
-		<td> float8  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_sortmerna.threads'>threads</a></td>
-		<td> integer  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='processed_params_sortmerna.param_set_name'>param&#095;set&#095;name</a></td>
-		<td> varchar&#040; 100 &#041;  NOT NULL  DEFO 'Default' </td>
-		<td> The name of the parameter set </td>
-	</tr>
-<tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>pk&#095;processed&#095;params&#095;sortmerna primary key</td>
-		<td> ON parameters&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;processed&#095;params&#095;sortmerna </td>
-		<td> ON reference&#095;id</td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
-	<tr>
-		<td>fk_processed_params_sortmerna</td>
-		<td > ( reference&#095;id ) ref <a href='#reference'>reference</a> (reference&#095;id) </td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table class='bordered'>
-<thead>
-<tr><th colspan='3'><a name='preprocessed_sequence_illumina_params'>Table preprocessed_sequence_illumina_params</a></th></tr>
-<tr><td colspan='3'>Parameters used for processing illumina sequence data&#046; </td></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='preprocessed_sequence_illumina_params.parameters_id'>parameters&#095;id</a></td>
-		<td> bigserial  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_illumina_params.max_bad_run_length'>max&#095;bad&#095;run&#095;length</a></td>
-		<td> integer  NOT NULL  DEFO 3 </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_illumina_params.min_per_read_length_fraction'>min&#095;per&#095;read&#095;length&#095;fraction</a></td>
-		<td> real  NOT NULL  DEFO 0.75 </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_illumina_params.sequence_max_n'>sequence&#095;max&#095;n</a></td>
-		<td> integer  NOT NULL  DEFO 0 </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_illumina_params.rev_comp_barcode'>rev&#095;comp&#095;barcode</a></td>
-		<td> bool  NOT NULL  DEFO FALSE </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_illumina_params.rev_comp_mapping_barcodes'>rev&#095;comp&#095;mapping&#095;barcodes</a></td>
-		<td> bool  NOT NULL  DEFO FALSE </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_illumina_params.rev_comp'>rev&#095;comp</a></td>
-		<td> bool  NOT NULL  DEFO FALSE </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_illumina_params.phred_quality_threshold'>phred&#095;quality&#095;threshold</a></td>
-		<td> integer  NOT NULL  DEFO 3 </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_illumina_params.barcode_type'>barcode&#095;type</a></td>
-		<td> varchar  NOT NULL  DEFO 'golay_12' </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_illumina_params.max_barcode_errors'>max&#095;barcode&#095;errors</a></td>
-		<td> real  NOT NULL  DEFO 1.5 </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='preprocessed_sequence_illumina_params.param_set_name'>param&#095;set&#095;name</a></td>
-		<td> varchar&#040; 100 &#041;  NOT NULL  </td>
-		<td> The name of the parameter set </td>
-	</tr>
-<tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>pk&#095;preprocessed&#095;sequence&#095;illumina&#095;params primary key</td>
-		<td> ON parameters&#095;id</td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table class='bordered'>
-<thead>
-<tr><th colspan='3'><a name='command_parameter'>Table command_parameter</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='command_parameter.command_id'>command&#095;id</a></td>
-		<td> bigint  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='command_parameter.parameter_name'>parameter&#095;name</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='command_parameter.parameter_type'>parameter&#095;type</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='command_parameter.required'>required</a></td>
-		<td> bool  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='command_parameter.default_value'>default&#095;value</a></td>
-		<td> varchar   </td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>idx&#095;command&#095;parameter </td>
-		<td> ON command&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;command&#095;parameter&#095;0 primary key</td>
-		<td> ON command&#095;id&#044; parameter&#095;name</td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
-	<tr>
-		<td>fk_command_parameter</td>
-		<td > ( command&#095;id ) ref <a href='#software&#095;command'>software&#095;command</a> (command&#095;id) </td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table class='bordered'>
-<thead>
-<tr><th colspan='3'><a name='default_parameter_set'>Table default_parameter_set</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='default_parameter_set.default_parameter_set_id'>default&#095;parameter&#095;set&#095;id</a></td>
-		<td> bigserial  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='default_parameter_set.command_id'>command&#095;id</a></td>
-		<td> bigint  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='default_parameter_set.parameter_set_name'>parameter&#095;set&#095;name</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td><a name='default_parameter_set.parameter_set'>parameter&#095;set</a></td>
-		<td> varchar  NOT NULL  </td>
-		<td> This is a varchar here &#045; but is of type JSON in postgresql&#046; </td>
-	</tr>
-<tr><th colspan='3'><b>Indexes</b></th></tr>
-	<tr>		<td>pk&#095;default&#095;parameter&#095;set primary key</td>
-		<td> ON default&#095;parameter&#095;set&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;default&#095;parameter&#095;set </td>
-		<td> ON command&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;default&#095;parameter&#095;set&#095;0 unique</td>
-		<td> ON command&#095;id&#044; parameter&#095;set&#095;name</td>
-		<td>  </td>
-	</tr>
-<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
-	<tr>
-		<td>fk_default_parameter_set</td>
-		<td > ( command&#095;id ) ref <a href='#software&#095;command'>software&#095;command</a> (command&#095;id) </td>
 		<td>  </td>
 	</tr>
 </tbody>
@@ -5835,6 +5191,223 @@ Controlled Vocabulary </td>
 	<tr>
 		<td>fk_artifact_data_type</td>
 		<td > ( data&#095;type&#095;id ) ref <a href='#data&#095;type'>data&#095;type</a> (data&#095;type&#095;id) </td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table class='bordered'>
+<thead>
+<tr><th colspan='3'><a name='processing_job_status'>Table processing_job_status</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='processing_job_status.processing_job_status_id'>processing&#095;job&#095;status&#095;id</a></td>
+		<td> bigserial  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='processing_job_status.processing_job_status'>processing&#095;job&#095;status</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='processing_job_status.processing_job_status_description'>processing&#095;job&#095;status&#095;description</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Indexes</b></th></tr>
+	<tr>		<td>pk&#095;processing&#095;job&#095;status primary key</td>
+		<td> ON processing&#095;job&#095;status&#095;id</td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table class='bordered'>
+<thead>
+<tr><th colspan='3'><a name='processing_job'>Table processing_job</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='processing_job.processing_job_id'>processing&#095;job&#095;id</a></td>
+		<td> bigserial  NOT NULL  </td>
+		<td> Using bigserial in DBSchema &#045; however in the postgres DB this column is of type UUID&#046; </td>
+	</tr>
+	<tr>
+		<td><a name='processing_job.email'>email</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td> The user that launched the job </td>
+	</tr>
+	<tr>
+		<td><a name='processing_job.command_id'>command&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td> The command launched </td>
+	</tr>
+	<tr>
+		<td><a name='processing_job.command_parameters'>command&#095;parameters</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td> The parameters used in the command in JSON format </td>
+	</tr>
+	<tr>
+		<td><a name='processing_job.processing_job_status_id'>processing&#095;job&#095;status&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='processing_job.logging_id'>logging&#095;id</a></td>
+		<td> bigint   </td>
+		<td> In case of failure&#044; point to the log entry that holds more information about the error </td>
+	</tr>
+	<tr>
+		<td><a name='processing_job.heartbeat'>heartbeat</a></td>
+		<td> timestamp   </td>
+		<td> The last heartbeat received by this job </td>
+	</tr>
+	<tr>
+		<td><a name='processing_job.step'>step</a></td>
+		<td> varchar   </td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Indexes</b></th></tr>
+	<tr>		<td>pk&#095;processing&#095;job primary key</td>
+		<td> ON processing&#095;job&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;processing&#095;job </td>
+		<td> ON email</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;processing&#095;job </td>
+		<td> ON command&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;processing&#095;job&#095;0 </td>
+		<td> ON processing&#095;job&#095;status&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;processing&#095;job&#095;1 </td>
+		<td> ON logging&#095;id</td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
+	<tr>
+		<td>fk_processing_job_qiita_user</td>
+		<td > ( email ) ref <a href='#qiita&#095;user'>qiita&#095;user</a> (email) </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td>fk_processing_job</td>
+		<td > ( command&#095;id ) ref <a href='#software&#095;command'>software&#095;command</a> (command&#095;id) </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td>fk_processing_job_status</td>
+		<td > ( processing&#095;job&#095;status&#095;id ) ref <a href='#processing&#095;job&#095;status'>processing&#095;job&#095;status</a> (processing&#095;job&#095;status&#095;id) </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td>fk_processing_job_logging</td>
+		<td > ( logging&#095;id ) ref <a href='#logging'>logging</a> (logging&#095;id) </td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table class='bordered'>
+<thead>
+<tr><th colspan='3'><a name='default_parameter_set'>Table default_parameter_set</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='default_parameter_set.default_parameter_set_id'>default&#095;parameter&#095;set&#095;id</a></td>
+		<td> bigserial  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='default_parameter_set.command_id'>command&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='default_parameter_set.parameter_set_name'>parameter&#095;set&#095;name</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='default_parameter_set.parameter_set'>parameter&#095;set</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td> This is a varchar here &#045; but is of type JSON in postgresql&#046; </td>
+	</tr>
+<tr><th colspan='3'><b>Indexes</b></th></tr>
+	<tr>		<td>pk&#095;default&#095;parameter&#095;set primary key</td>
+		<td> ON default&#095;parameter&#095;set&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;default&#095;parameter&#095;set </td>
+		<td> ON command&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;default&#095;parameter&#095;set&#095;0 unique</td>
+		<td> ON command&#095;id&#044; parameter&#095;set&#095;name</td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
+	<tr>
+		<td>fk_default_parameter_set</td>
+		<td > ( command&#095;id ) ref <a href='#software&#095;command'>software&#095;command</a> (command&#095;id) </td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table class='bordered'>
+<thead>
+<tr><th colspan='3'><a name='command_parameter'>Table command_parameter</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='command_parameter.command_id'>command&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='command_parameter.parameter_name'>parameter&#095;name</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='command_parameter.parameter_type'>parameter&#095;type</a></td>
+		<td> varchar  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='command_parameter.required'>required</a></td>
+		<td> bool  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='command_parameter.default_value'>default&#095;value</a></td>
+		<td> varchar   </td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Indexes</b></th></tr>
+	<tr>		<td>idx&#095;command&#095;parameter </td>
+		<td> ON command&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;command&#095;parameter&#095;0 primary key</td>
+		<td> ON command&#095;id&#044; parameter&#095;name</td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
+	<tr>
+		<td>fk_command_parameter</td>
+		<td > ( command&#095;id ) ref <a href='#software&#095;command'>software&#095;command</a> (command&#095;id) </td>
 		<td>  </td>
 	</tr>
 </tbody>

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -153,6 +153,22 @@ class CommandTests(TestCase):
         self.assertEqual(qdb.software.Command(2).optional_parameters,
                          exp_params)
 
+    def test_default_parameter_sets(self):
+        obs = list(qdb.software.Command(1).default_parameter_sets)
+        exp = [qdb.software.DefaultParameters(1),
+               qdb.software.DefaultParameters(2),
+               qdb.software.DefaultParameters(3),
+               qdb.software.DefaultParameters(4),
+               qdb.software.DefaultParameters(5),
+               qdb.software.DefaultParameters(6),
+               qdb.software.DefaultParameters(7)]
+        self.assertEqual(obs, exp)
+
+        obs = list(qdb.software.Command(2).default_parameter_sets)
+        exp = [qdb.software.DefaultParameters(8),
+               qdb.software.DefaultParameters(9)]
+        self.assertEqual(obs, exp)
+
 
 @qiita_test_checker()
 class SoftwareTests(TestCase):

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -211,12 +211,6 @@ class SoftwareTests(TestCase):
 
 @qiita_test_checker()
 class DefaultParametersTests(TestCase):
-    def test_init(self):
-        obs = qdb.software.DefaultParameters(1, qdb.software.Command(1))
-        self.assertEqual(obs.id, 1)
-        self.assertEqual(obs._table, "preprocessed_sequence_illumina_params")
-        self.assertEqual(obs.command, qdb.software.Command(1))
-
     def test_exists(self):
         cmd = qdb.software.Command(1)
         obs = qdb.software.DefaultParameters.exists(
@@ -251,19 +245,10 @@ class DefaultParametersTests(TestCase):
                'phred_quality_threshold': 3, 'barcode_type': "hamming_8",
                'max_barcode_errors': 1.5}
         self.assertEqual(obs.values, exp)
-
         self.assertEqual(obs.command, cmd)
 
-    def test_iter(self):
-        cmd = qdb.software.Command(1)
-        obs = list(qdb.software.DefaultParameters.iter(cmd))
-        exp = [qdb.software.DefaultParameters(i, cmd) for i in range(1, 8)]
-        self.assertEqual(obs, exp)
-
     def test_name(self):
-        self.assertEqual(
-            qdb.software.DefaultParameters(1, qdb.software.Command(1)).name,
-            "Defaults")
+        self.assertEqual(qdb.software.DefaultParameters(1).name, "Defaults")
 
     def test_values(self):
         exp = {'min_per_read_length_fraction': 0.75,
@@ -271,22 +256,11 @@ class DefaultParametersTests(TestCase):
                'rev_comp': False, 'phred_quality_threshold': 3,
                'rev_comp_barcode': False, 'sequence_max_n': 0,
                'barcode_type': 'golay_12', 'rev_comp_mapping_barcodes': False}
-        self.assertEqual(
-            qdb.software.DefaultParameters(1, qdb.software.Command(1)).values,
-            exp)
-
-    def test_to_str(self):
-        exp = ("--barcode_type 'golay_12' --max_bad_run_length '3' "
-               "--max_barcode_errors '1.5' "
-               "--min_per_read_length_fraction '0.75' "
-               "--phred_quality_threshold '3' --sequence_max_n '0'")
-        self.assertEqual(
-            qdb.software.DefaultParameters(1, qdb.software.Command(1)).to_str(), exp)
+        self.assertEqual(qdb.software.DefaultParameters(1).values, exp)
 
     def test_command(self):
         self.assertEqual(
-            qdb.software.DefaultParameters(1, qdb.software.Command(1)).command,
-            qdb.software.Command(1))
+            qdb.software.DefaultParameters(1).command, qdb.software.Command(1))
 
 if __name__ == '__main__':
     main()

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -281,6 +281,11 @@ class DefaultParametersTests(TestCase):
 
 @qiita_test_checker()
 class ParametersTests(TestCase):
+    def test_init_error(self):
+        with self.assertRaises(
+                qdb.exceptions.QiitaDBOperationNotPermittedError):
+            qdb.software.Parameters({'a': 1}, None)
+
     def test_eq(self):
         # Test difference due to type
         a = qdb.software.Parameters.from_default_params(

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -301,7 +301,7 @@ class ParametersTests(TestCase):
             qdb.software.DefaultParameters(1), {'input_data': 1})
         self.assertTrue(a == b)
 
-    def test_load(self):
+    def test_load_json(self):
         json_str = ('{"barcode_type": "golay_12", "input_data": 1, '
                     '"max_bad_run_length": 3, "max_barcode_errors": 1.5, '
                     '"min_per_read_length_fraction": 0.75, '
@@ -309,7 +309,7 @@ class ParametersTests(TestCase):
                     '"rev_comp_barcode": false, '
                     '"rev_comp_mapping_barcodes": false, "sequence_max_n": 0}')
         cmd = qdb.software.Command(1)
-        obs = qdb.software.Parameters.load(json_str, cmd)
+        obs = qdb.software.Parameters.load(cmd, json_str=json_str)
         exp_values = {
             "barcode_type": "golay_12", "input_data": 1,
             "max_bad_run_length": 3, "max_barcode_errors": 1.5,
@@ -317,6 +317,18 @@ class ParametersTests(TestCase):
             "phred_quality_threshold": 3, "rev_comp": False,
             "rev_comp_barcode": False, "rev_comp_mapping_barcodes": False,
             "sequence_max_n": 0}
+        self.assertEqual(obs.values, exp_values)
+
+    def test_load_dictionary(self):
+        exp_values = {
+            "barcode_type": "golay_12", "input_data": 1,
+            "max_bad_run_length": 3, "max_barcode_errors": 1.5,
+            "min_per_read_length_fraction": 0.75,
+            "phred_quality_threshold": 3, "rev_comp": False,
+            "rev_comp_barcode": False, "rev_comp_mapping_barcodes": False,
+            "sequence_max_n": 0}
+        cmd = qdb.software.Command(1)
+        obs = qdb.software.Parameters.load(cmd, values_dict=exp_values)
         self.assertEqual(obs.values, exp_values)
 
     def test_load_error_missing_required(self):
@@ -328,7 +340,7 @@ class ParametersTests(TestCase):
                     '"rev_comp_mapping_barcodes": false, "sequence_max_n": 0}')
         cmd = qdb.software.Command(1)
         with self.assertRaises(qdb.exceptions.QiitaDBError):
-            qdb.software.Parameters.load(json_str, cmd)
+            qdb.software.Parameters.load(cmd, json_str=json_str)
 
     def test_load_error_missing_optional(self):
         json_str = ('{"barcode_type": "golay_12", "input_data": 1, '
@@ -339,7 +351,7 @@ class ParametersTests(TestCase):
                     '"rev_comp_mapping_barcodes": false, "sequence_max_n": 0}')
         cmd = qdb.software.Command(1)
         with self.assertRaises(qdb.exceptions.QiitaDBError):
-            qdb.software.Parameters.load(json_str, cmd)
+            qdb.software.Parameters.load(cmd, json_str=json_str)
 
     def test_load_error_extra_parameters(self):
         json_str = ('{"barcode_type": "golay_12", "input_data": 1, '
@@ -351,7 +363,7 @@ class ParametersTests(TestCase):
                     '"extra_param": 1}')
         cmd = qdb.software.Command(1)
         with self.assertRaises(qdb.exceptions.QiitaDBError):
-            qdb.software.Parameters.load(json_str, cmd)
+            qdb.software.Parameters.load(cmd, json_str=json_str)
 
     def test_from_default_parameters(self):
         obs = qdb.software.Parameters.from_default_params(

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -278,5 +278,64 @@ class DefaultParametersTests(TestCase):
         self.assertEqual(
             qdb.software.DefaultParameters(1).command, qdb.software.Command(1))
 
+
+@qiita_test_checker()
+class ParametersTests(TestCase):
+    def test_init(self):
+        obs = qdb.software.Parameters(qdb.software.DefaultParameters(1),
+                                      {'input_data': 1})
+        self.assertEqual(obs._command, qdb.software.Command(1))
+        exp = {'min_per_read_length_fraction': 0.75,
+               'max_barcode_errors': 1.5, 'max_bad_run_length': 3,
+               'rev_comp': False, 'phred_quality_threshold': 3,
+               'rev_comp_barcode': False, 'sequence_max_n': 0,
+               'barcode_type': 'golay_12', 'rev_comp_mapping_barcodes': False,
+               'input_data': 1}
+        self.assertEqual(obs._values, exp)
+
+        obs = qdb.software.Parameters(qdb.software.DefaultParameters(1),
+                                      {'input_data': 1},
+                                      opt_params={'max_bad_run_length': 5})
+        self.assertEqual(obs._command, qdb.software.Command(1))
+        exp = {'min_per_read_length_fraction': 0.75,
+               'max_barcode_errors': 1.5, 'max_bad_run_length': 5,
+               'rev_comp': False, 'phred_quality_threshold': 3,
+               'rev_comp_barcode': False, 'sequence_max_n': 0,
+               'barcode_type': 'golay_12', 'rev_comp_mapping_barcodes': False,
+               'input_data': 1}
+        self.assertEqual(obs._values, exp)
+
+    def test_init_error_missing_reqd(self):
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.software.Parameters(qdb.software.DefaultParameters(1), {})
+
+    def test_init_error_extra_reqd(self):
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.software.Parameters(qdb.software.DefaultParameters(1),
+                                    {'input_data': 1, 'another_one': 2})
+
+    def test_init_error_extra_opts(self):
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.software.Parameters(qdb.software.DefaultParameters(1),
+                                    {'input_data': 1},
+                                    opt_params={'Unknown': 'foo'})
+
+    def test_command(self):
+        obs = qdb.software.Parameters(qdb.software.DefaultParameters(1),
+                                      {'input_data': 1}).command
+        self.assertEqual(obs, qdb.software.Command(1))
+
+    def test_values(self):
+        obs = qdb.software.Parameters(qdb.software.DefaultParameters(1),
+                                      {'input_data': 1}).values
+        exp = {'min_per_read_length_fraction': 0.75,
+               'max_barcode_errors': 1.5, 'max_bad_run_length': 3,
+               'rev_comp': False, 'phred_quality_threshold': 3,
+               'rev_comp_barcode': False, 'sequence_max_n': 0,
+               'barcode_type': 'golay_12', 'rev_comp_mapping_barcodes': False,
+               'input_data': 1}
+        self.assertEqual(obs, exp)
+
+
 if __name__ == '__main__':
     main()

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -27,6 +27,15 @@ class CommandTests(TestCase):
         self.assertTrue(qdb.software.Command.exists(
             self.software, "Split libraries"))
 
+    def test_create_error_no_parameters(self):
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.software.Command.create(
+                self.software, "Test command", "Testing command", {})
+
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.software.Command.create(
+                self.software, "Test command", "Testing command", None)
+
     def test_create_error_malformed_params(self):
         self.parameters['req_param'].append('breaking_the_format')
         with self.assertRaises(qdb.exceptions.QiitaDBError):
@@ -41,7 +50,7 @@ class CommandTests(TestCase):
                 self.software, "Test command", "Testing command",
                 self.parameters)
 
-    def test_create_error_bad_defalut_choice(self):
+    def test_create_error_bad_default_choice(self):
         self.parameters['opt_choice_param'][1] = 'unsupported_choice'
         with self.assertRaises(qdb.exceptions.QiitaDBError):
             qdb.software.Command.create(

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -281,6 +281,26 @@ class DefaultParametersTests(TestCase):
 
 @qiita_test_checker()
 class ParametersTests(TestCase):
+    def test_eq(self):
+        # Test difference due to type
+        a = qdb.software.Parameters.from_default_params(
+            qdb.software.DefaultParameters(1), {'input_data': 1})
+        b = qdb.software.DefaultParameters(1)
+        self.assertFalse(a == b)
+        # Test difference due to command
+        b = qdb.software.Parameters.from_default_params(
+            qdb.software.Command(2).default_parameter_sets.next(),
+            {'input_data': 1})
+        self.assertFalse(a == b)
+        # Test difference due to values
+        b = qdb.software.Parameters.from_default_params(
+            qdb.software.DefaultParameters(1), {'input_data': 2})
+        self.assertFalse(a == b)
+        # Test equality
+        b = qdb.software.Parameters.from_default_params(
+            qdb.software.DefaultParameters(1), {'input_data': 1})
+        self.assertTrue(a == b)
+
     def test_load(self):
         json_str = ('{"barcode_type": "golay_12", "input_data": 1, '
                     '"max_bad_run_length": 3, "max_barcode_errors": 1.5, '


### PR DESCRIPTION
We were creating a table for each command that we had in the system, which doesn't make the system too flexible, and that strategy creates a lot of dynamic tables.

With the approach implemented here, we only store some information about the parameters that each command can receive, and we store in a single table the default parameter sets (so we can limit the parameters available in the system - i.e. users can't provide arbitrary parameters if we don't want to). However, this makes extremely easy to allow users to provide their own parameters, since the actual parameters used to process an artifact are stored in the artifact themselves using JSON.

Furthermore, the previous implementation did not cover the case in which we had multiple artifact as input and in which parameters they should be passed.

This also addressed the concern that @ElDeveloper had about positional arguments. Using this structure, Qiita will always see named parameters that can provide to the plugin, and the plugin will know what to do with them (i.e. if they're positional, it will create the CLI call correctly). I think this is the best trade-off that we can get between system generality (i.e. Qiita) while still being able to support any type of tool on the plugins (since they're specialized for those tools).

Another advantage of this is that we no longer need to hack various things in the parameters objects themselves due to Qiime.

The changes in this PR are already big enough that I will remove the qiita_db/parameters.py in another PR, so I can follow the same approach as with the data module: remove the module, remove the tests and remove the imports so the webserver starts.