### PR TITLE
Linking artifacts and processing jobs

### DIFF
--- a/qiita_db/support_files/populate_test_db.sql
+++ b/qiita_db/support_files/populate_test_db.sql
@@ -331,6 +331,18 @@ INSERT INTO qiita.parent_artifact (parent_id, artifact_id)
     VALUES (1, 2), (1, 3),
            (2, 4);
 
+-- Insert the jobs that processed the previous artifacts
+INSERT INTO qiita.processing_job (processing_job_id, email, command_id, command_parameters, processing_job_status_id)
+    VALUES ('6d368e16-2242-4cf8-87b4-a5dc40bb890b', 'test@foo.bar', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":false,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1}'::json, 3),
+           ('4c7115e8-4c8e-424c-bf25-96c292ca1931', 'test@foo.bar', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":true,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1}'::json, 3),
+           ('3c9991ab-6c14-4368-a48c-841e8837a79c', 'test@foo.bar', 3, '{"reference":1,"sortmerna_e_value":1,"sortmerna_max_pos":10000,"similarity":0.97,"sortmerna_coverage":0.97,"threads":1,"input_data":2}'::json, 3);
+
+-- Relate the above jobs with the artifacts
+INSERT INTO qiita.artifact_processing_job (artifact_id, processing_job_id)
+    VALUES (1, '6d368e16-2242-4cf8-87b4-a5dc40bb890b'),
+           (1, '4c7115e8-4c8e-424c-bf25-96c292ca1931'),
+           (2, '3c9991ab-6c14-4368-a48c-841e8837a79c');
+
 -- Insert filepaths for the artifacts and reference
 INSERT INTO qiita.filepath (filepath, filepath_type_id, checksum, checksum_algorithm_id, data_directory_id)
     VALUES ('1_s_G1_L001_sequences.fastq.gz', 1, '852952723', 1, 5),
@@ -486,6 +498,12 @@ INSERT INTO qiita.processing_job
            ('bcc7ebcd-39c1-43e4-af2d-822e3589f14d', 'test@foo.bar', 2, '{"min_seq_len":100,"max_seq_len":1000,"trim_seq_length":false,"min_qual_score":25,"max_ambig":6,"max_homopolymer":6,"max_primer_mismatch":0,"barcode_type":"golay_12","max_barcode_errors":1.5,"disable_bc_correction":false,"qual_score_window":0,"disable_primers":false,"reverse_primers":"disable","reverse_primer_mismatches":0,"truncate_ambi_bases":false,"input_data":1}'::json, 2, NULL, 'Sun Nov 22 21:00:00 2015', 'demultiplexing'),
            ('b72369f9-a886-4193-8d3d-f7b504168e75', 'shared@foo.bar', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":true,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1}'::json, 3, NULL, 'Sun Nov 22 21:15:00 2015', NULL),
            ('d19f76ee-274e-4c1b-b3a2-a12d73507c55', 'shared@foo.bar', 3, '{"reference":1,"sortmerna_e_value":1,"sortmerna_max_pos":10000,"similarity":0.97,"sortmerna_coverage":0.97,"threads":1,"input_data":2}'::json, 4, 1, 'Sun Nov 22 21:30:00 2015', 'generating demux file');
+
+INSERT INTO qiita.artifact_processing_job (artifact_id, processing_job_id)
+    VALUES (1, '063e553b-327c-4818-ab4a-adfe58e49860'),
+           (1, 'bcc7ebcd-39c1-43e4-af2d-822e3589f14d'),
+           (1, 'b72369f9-a886-4193-8d3d-f7b504168e75'),
+           (2, 'd19f76ee-274e-4c1b-b3a2-a12d73507c55');
 
 -- Add a default parameter set for sortemrna
 INSERT INTO qiita.default_parameter_set (command_id, parameter_set_name, parameter_set)

--- a/qiita_db/support_files/qiita-db.dbs
+++ b/qiita_db/support_files/qiita-db.dbs
@@ -278,6 +278,26 @@
 				<fk_column name="filepath_id" pk="filepath_id" />
 			</fk>
 		</table>
+		<table name="artifact_processing_job" >
+			<column name="artifact_id" type="bigint" jt="-5" mandatory="y" />
+			<column name="processing_job_id" type="bigint" jt="-5" mandatory="y" />
+			<index name="idx_artifact_processing_job" unique="PRIMARY_KEY" >
+				<column name="artifact_id" />
+				<column name="processing_job_id" />
+			</index>
+			<index name="idx_artifact_processing_job" unique="NORMAL" >
+				<column name="artifact_id" />
+			</index>
+			<index name="idx_artifact_processing_job" unique="NORMAL" >
+				<column name="processing_job_id" />
+			</index>
+			<fk name="fk_artifact_processing_job" to_schema="qiita" to_table="artifact" >
+				<fk_column name="artifact_id" pk="artifact_id" />
+			</fk>
+			<fk name="fk_artifact_processing_job_0" to_schema="qiita" to_table="processing_job" >
+				<fk_column name="processing_job_id" pk="processing_job_id" />
+			</fk>
+		</table>
 		<table name="artifact_type" >
 			<comment>Type of artifact</comment>
 			<column name="artifact_type_id" type="bigserial" jt="-5" mandatory="y" />
@@ -1569,8 +1589,9 @@ Controlled Vocabulary]]></comment>
 		<entity schema="qiita" name="artifact" color="b2cdf7" x="1200" y="750" />
 		<entity schema="qiita" name="processing_job_status" color="b2cdf7" x="2025" y="1140" />
 		<entity schema="qiita" name="processing_job" color="b2cdf7" x="1800" y="1095" />
-		<entity schema="qiita" name="default_parameter_set" color="b2cdf7" x="2100" y="930" />
-		<entity schema="qiita" name="command_parameter" color="b2cdf7" x="1920" y="945" />
+		<entity schema="qiita" name="default_parameter_set" color="b2cdf7" x="2115" y="900" />
+		<entity schema="qiita" name="command_parameter" color="b2cdf7" x="2130" y="1020" />
+		<entity schema="qiita" name="artifact_processing_job" color="b2cdf7" x="1785" y="930" />
 		<group name="Group_analyses" color="c4e0f9" >
 			<comment>analysis tables</comment>
 			<entity schema="qiita" name="analysis" />
@@ -1665,40 +1686,27 @@ Controlled Vocabulary]]></comment>
 			<entity schema="qiita" name="processing_job_status" />
 			<entity schema="qiita" name="command_parameter" />
 			<entity schema="qiita" name="default_parameter_set" />
+			<entity schema="qiita" name="artifact_processing_job" />
 		</group>
 		<group name="Group_publication" color="ffccff" >
 			<entity schema="qiita" name="publication" />
 			<entity schema="qiita" name="software_publication" />
 			<entity schema="qiita" name="study_publication" />
 		</group>
-		<script name="Sql" id="SQL7779022" >
-			<string><![CDATA[CREATE TABLE qiita.command_parameter ( 
-	command_id           bigint  NOT NULL,
-	parameter_name       varchar  NOT NULL,
-	parameter_type       varchar  NOT NULL,
-	required             bool  NOT NULL,
-	deafult_value        varchar  ,
-	CONSTRAINT idx_command_parameter_0 PRIMARY KEY ( command_id, parameter_name )
+		<script name="Sql_001" id="SQL7268209" >
+			<string><![CDATA[CREATE TABLE qiita.artifact_processing_job ( 
+	artifact_id          bigint  NOT NULL,
+	processing_job_id    bigint  NOT NULL,
+	CONSTRAINT idx_artifact_processing_job PRIMARY KEY ( artifact_id, processing_job_id )
  ) ;
 
-CREATE INDEX idx_command_parameter ON qiita.command_parameter ( command_id ) ;
+CREATE INDEX idx_artifact_processing_job ON qiita.artifact_processing_job ( artifact_id ) ;
 
-CREATE TABLE qiita.default_parameter_set ( 
-	default_parameter_set_id bigserial  NOT NULL,
-	command_id           bigint  NOT NULL,
-	parameter_set_name   varchar  NOT NULL,
-	parameter_set        varchar  NOT NULL,
-	CONSTRAINT pk_default_parameter_set PRIMARY KEY ( default_parameter_set_id ),
-	CONSTRAINT idx_default_parameter_set_0 UNIQUE ( command_id, parameter_set_name ) 
- ) ;
+CREATE INDEX idx_artifact_processing_job ON qiita.artifact_processing_job ( processing_job_id ) ;
 
-CREATE INDEX idx_default_parameter_set ON qiita.default_parameter_set ( command_id ) ;
+ALTER TABLE qiita.artifact_processing_job ADD CONSTRAINT fk_artifact_processing_job FOREIGN KEY ( artifact_id ) REFERENCES qiita.artifact( artifact_id )    ;
 
-COMMENT ON COLUMN qiita.default_parameter_set.parameter_set IS 'This is a varchar here - but is of type JSON in postgresql.';
-
-ALTER TABLE qiita.command_parameter ADD CONSTRAINT fk_command_parameter FOREIGN KEY ( command_id ) REFERENCES qiita.software_command( command_id )    ;
-
-ALTER TABLE qiita.default_parameter_set ADD CONSTRAINT fk_default_parameter_set FOREIGN KEY ( command_id ) REFERENCES qiita.software_command( command_id )    ;
+ALTER TABLE qiita.artifact_processing_job ADD CONSTRAINT fk_artifact_processing_job_0 FOREIGN KEY ( processing_job_id ) REFERENCES qiita.processing_job( processing_job_id )    ;
 
 ]]></string>
 		</script>

--- a/qiita_db/support_files/qiita-db.html
+++ b/qiita_db/support_files/qiita-db.html
@@ -313,9 +313,9 @@ table {
 <rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='1045' y='133' width='760' height='2' />
 
 <!-- ============= Group 'Group_processing' ============= -->
-<rect class='grp' style='fill:#c4e0f9;stroke:#c5d4e0' x='1769' y='715' width='512' height='725' />
+<rect class='grp' style='fill:#c4e0f9;stroke:#c5d4e0' x='1769' y='715' width='527' height='725' />
 <text x='1780' y='730'>Group_processing</text>
-<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='1780' y='733' width='490' height='2' />
+<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='1780' y='733' width='505' height='2' />
 
 <!-- ============= Group 'Group_publication' ============= -->
 <rect class='grp' style='fill:#ffccff;stroke:#e0c5e0' x='2324' y='670' width='317' height='215' />
@@ -782,11 +782,11 @@ table {
 	processing_job references qiita_user ( email )</title>
 </path>
 <text x='1759' y='1090' transform='rotate(0 1759,1090)' title='Foreign Key fk_processing_job_qiita_user
-	processing_job references qiita_user ( email )' style='fill:#a1a0a0;'>email</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1875 1080 L 1875,832 Q 1875,825 1882,825 L 1890,825' >
+	processing_job references qiita_user ( email )' style='fill:#a1a0a0;'>email</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1950 1080 L 1950,855' >
 	<title>Foreign Key fk_processing_job
 	processing_job references software_command ( command_id )</title>
 </path>
-<text x='1877' y='1075' transform='rotate(270 1877,1075)' title='Foreign Key fk_processing_job
+<text x='1952' y='1075' transform='rotate(270 1952,1075)' title='Foreign Key fk_processing_job
 	processing_job references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1980 1140 L 2010,1140' >
 	<title>Foreign Key fk_processing_job_status
 	processing_job references processing_job_status ( processing_job_status_id )</title>
@@ -797,17 +797,27 @@ table {
 	processing_job references logging ( logging_id )</title>
 </path>
 <text x='1730' y='1225' transform='rotate(0 1730,1225)' title='Foreign Key fk_processing_job_logging
-	processing_job references logging ( logging_id )' style='fill:#a1a0a0;'>logging_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2085 930 L 2077,930 Q 2070,930 2070,922 L 2070,847 Q 2070,840 2062,840 L 2025,840' >
+	processing_job references logging ( logging_id )' style='fill:#a1a0a0;'>logging_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2100 900 L 2002,900 Q 1995,900 1995,892 L 1995,855' >
 	<title>Foreign Key fk_default_parameter_set
 	default_parameter_set references software_command ( command_id )</title>
 </path>
-<text x='2018' y='925' transform='rotate(0 2018,925)' title='Foreign Key fk_default_parameter_set
-	default_parameter_set references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1935 930 L 1935,855' >
+<text x='2033' y='895' transform='rotate(0 2033,895)' title='Foreign Key fk_default_parameter_set
+	default_parameter_set references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 2115 1020 L 2017,1020 Q 2010,1020 2010,1012 L 2010,855' >
 	<title>Foreign Key fk_command_parameter
 	command_parameter references software_command ( command_id )</title>
 </path>
-<text x='1937' y='925' transform='rotate(270 1937,925)' title='Foreign Key fk_command_parameter
-	command_parameter references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><!-- ============= Table 'controlled_vocab_values' ============= -->
+<text x='2048' y='1015' transform='rotate(0 2048,1015)' title='Foreign Key fk_command_parameter
+	command_parameter references software_command ( command_id )' style='fill:#a1a0a0;'>command_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1770 930 L 1507,930 Q 1500,930 1500,922 L 1500,922 Q 1500,915 1492,915 L 1395,915' >
+	<title>Foreign Key fk_artifact_processing_job
+	artifact_processing_job references artifact ( artifact_id )</title>
+</path>
+<text x='1718' y='925' transform='rotate(0 1718,925)' title='Foreign Key fk_artifact_processing_job
+	artifact_processing_job references artifact ( artifact_id )' style='fill:#a1a0a0;'>artifact_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1815 1005 L 1815,1080' >
+	<title>Foreign Key fk_artifact_processing_job_0
+	artifact_processing_job references processing_job ( processing_job_id )</title>
+</path>
+<text x='1828' y='1005' transform='rotate(90 1828,1005)' title='Foreign Key fk_artifact_processing_job_0
+	artifact_processing_job references processing_job ( processing_job_id )' style='fill:#a1a0a0;'>processing_job_id</text><!-- ============= Table 'controlled_vocab_values' ============= -->
 <rect class='table' x='45' y='1688' width='150' height='120' rx='7' ry='7' />
 <path d='M 45.50 1714.50 L 45.50 1695.50 Q 45.50 1688.50 52.50 1688.50 L 187.50 1688.50 Q 194.50 1688.50 194.50 1695.50 L 194.50 1714.50 L45.50 1714.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
 <a xlink:href='#controlled_vocab_values'><text x='53' y='1702' class='tableTitle'>controlled_vocab_values</text><title>Table qiita.controlled_vocab_values</title></a>
@@ -1825,7 +1835,8 @@ Referred by ebi_run_accession ( artifact_id )
 Referred by parent_artifact ( artifact_id ) 
 Referred by parent_artifact ( parent_id -> artifact_id ) 
 Referred by prep_template ( artifact_id ) 
-Referred by study_artifact ( artifact_id ) </title></a>
+Referred by study_artifact ( artifact_id ) 
+Referred by artifact_processing_job ( artifact_id ) </title></a>
   <use id='nn' x='1202' y='792' xlink:href='#nn'/><a xlink:href='#artifact.generated_timestamp'><text x='1218' y='802'>generated_timestamp</text><title>generated_timestamp timestamp not null</title></a>
   <a xlink:href='#artifact.command_id'><use id='idx' x='1202' y='806' xlink:href='#idx'/><title>Index  ( command_id ) </title></a>
 <a xlink:href='#artifact.command_id'><text x='1218' y='817'>command_id</text><title>command_id bigint</title></a>
@@ -1863,6 +1874,7 @@ If the artifact is sandbox&#044; awaiting&#095;for&#095;approval&#044; private o
   <use id='nn' x='1802' y='1122' xlink:href='#nn'/><a xlink:href='#processing_job.processing_job_id'><use id='pk' x='1802' y='1121' xlink:href='#pk'/><title>Primary Key  ( processing_job_id ) </title></a>
 <a xlink:href='#processing_job.processing_job_id'><text x='1818' y='1132'>processing_job_id</text><title>processing_job_id bigserial not null
 Using bigserial in DBSchema &#045; however in the postgres DB this column is of type UUID&#046;</title></a>
+<a xlink:href='#processing_job.processing_job_id'><use id='ref' x='1968' y='1121' xlink:href='#ref'/><title>Referred by artifact_processing_job ( processing_job_id ) </title></a>
   <use id='nn' x='1802' y='1137' xlink:href='#nn'/><a xlink:href='#processing_job.email'><use id='idx' x='1802' y='1136' xlink:href='#idx'/><title>Index  ( email ) </title></a>
 <a xlink:href='#processing_job.email'><text x='1818' y='1147'>email</text><title>email varchar not null
 The user that launched the job</title></a>
@@ -1885,31 +1897,42 @@ The last heartbeat received by this job</title></a>
   <a xlink:href='#processing_job.step'><text x='1818' y='1237'>step</text><title>step varchar</title></a>
 
 <!-- ============= Table 'default_parameter_set' ============= -->
-<rect class='table' x='2100' y='923' width='165' height='105' rx='7' ry='7' />
-<path d='M 2100.50 949.50 L 2100.50 930.50 Q 2100.50 923.50 2107.50 923.50 L 2257.50 923.50 Q 2264.50 923.50 2264.50 930.50 L 2264.50 949.50 L2100.50 949.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#default_parameter_set'><text x='2122' y='937' class='tableTitle'>default_parameter_set</text><title>Table qiita.default_parameter_set</title></a>
-  <use id='nn' x='2102' y='957' xlink:href='#nn'/><a xlink:href='#default_parameter_set.default_parameter_set_id'><use id='pk' x='2102' y='956' xlink:href='#pk'/><title>Primary Key  ( default_parameter_set_id ) </title></a>
-<a xlink:href='#default_parameter_set.default_parameter_set_id'><text x='2118' y='967'>default_parameter_set_id</text><title>default_parameter_set_id bigserial not null</title></a>
-  <use id='nn' x='2102' y='972' xlink:href='#nn'/><a xlink:href='#default_parameter_set.command_id'><use id='unq' x='2102' y='971' xlink:href='#unq'/><title>Index  ( command_id ) Unique Index  ( command_id, parameter_set_name ) </title></a>
-<a xlink:href='#default_parameter_set.command_id'><text x='2118' y='982'>command_id</text><title>command_id bigint not null</title></a>
-<a xlink:href='#default_parameter_set.command_id'><use id='fk' x='2253' y='971' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
-  <use id='nn' x='2102' y='987' xlink:href='#nn'/><a xlink:href='#default_parameter_set.parameter_set_name'><use id='unq' x='2102' y='986' xlink:href='#unq'/><title>Unique Index  ( command_id, parameter_set_name ) </title></a>
-<a xlink:href='#default_parameter_set.parameter_set_name'><text x='2118' y='997'>parameter_set_name</text><title>parameter_set_name varchar not null</title></a>
-  <use id='nn' x='2102' y='1002' xlink:href='#nn'/><a xlink:href='#default_parameter_set.parameter_set'><text x='2118' y='1012'>parameter_set</text><title>parameter_set varchar not null
+<rect class='table' x='2115' y='893' width='165' height='105' rx='7' ry='7' />
+<path d='M 2115.50 919.50 L 2115.50 900.50 Q 2115.50 893.50 2122.50 893.50 L 2272.50 893.50 Q 2279.50 893.50 2279.50 900.50 L 2279.50 919.50 L2115.50 919.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#default_parameter_set'><text x='2137' y='907' class='tableTitle'>default_parameter_set</text><title>Table qiita.default_parameter_set</title></a>
+  <use id='nn' x='2117' y='927' xlink:href='#nn'/><a xlink:href='#default_parameter_set.default_parameter_set_id'><use id='pk' x='2117' y='926' xlink:href='#pk'/><title>Primary Key  ( default_parameter_set_id ) </title></a>
+<a xlink:href='#default_parameter_set.default_parameter_set_id'><text x='2133' y='937'>default_parameter_set_id</text><title>default_parameter_set_id bigserial not null</title></a>
+  <use id='nn' x='2117' y='942' xlink:href='#nn'/><a xlink:href='#default_parameter_set.command_id'><use id='unq' x='2117' y='941' xlink:href='#unq'/><title>Index  ( command_id ) Unique Index  ( command_id, parameter_set_name ) </title></a>
+<a xlink:href='#default_parameter_set.command_id'><text x='2133' y='952'>command_id</text><title>command_id bigint not null</title></a>
+<a xlink:href='#default_parameter_set.command_id'><use id='fk' x='2268' y='941' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
+  <use id='nn' x='2117' y='957' xlink:href='#nn'/><a xlink:href='#default_parameter_set.parameter_set_name'><use id='unq' x='2117' y='956' xlink:href='#unq'/><title>Unique Index  ( command_id, parameter_set_name ) </title></a>
+<a xlink:href='#default_parameter_set.parameter_set_name'><text x='2133' y='967'>parameter_set_name</text><title>parameter_set_name varchar not null</title></a>
+  <use id='nn' x='2117' y='972' xlink:href='#nn'/><a xlink:href='#default_parameter_set.parameter_set'><text x='2133' y='982'>parameter_set</text><title>parameter_set varchar not null
 This is a varchar here &#045; but is of type JSON in postgresql&#046;</title></a>
 
 <!-- ============= Table 'command_parameter' ============= -->
-<rect class='table' x='1920' y='938' width='135' height='120' rx='7' ry='7' />
-<path d='M 1920.50 964.50 L 1920.50 945.50 Q 1920.50 938.50 1927.50 938.50 L 2047.50 938.50 Q 2054.50 938.50 2054.50 945.50 L 2054.50 964.50 L1920.50 964.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#command_parameter'><text x='1930' y='952' class='tableTitle'>command_parameter</text><title>Table qiita.command_parameter</title></a>
-  <use id='nn' x='1922' y='972' xlink:href='#nn'/><a xlink:href='#command_parameter.command_id'><use id='pk' x='1922' y='971' xlink:href='#pk'/><title>Index  ( command_id ) Primary Key  ( command_id, parameter_name ) </title></a>
-<a xlink:href='#command_parameter.command_id'><text x='1938' y='982'>command_id</text><title>command_id bigint not null</title></a>
-<a xlink:href='#command_parameter.command_id'><use id='fk' x='2043' y='971' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
-  <use id='nn' x='1922' y='987' xlink:href='#nn'/><a xlink:href='#command_parameter.parameter_name'><use id='pk' x='1922' y='986' xlink:href='#pk'/><title>Primary Key  ( command_id, parameter_name ) </title></a>
-<a xlink:href='#command_parameter.parameter_name'><text x='1938' y='997'>parameter_name</text><title>parameter_name varchar not null</title></a>
-  <use id='nn' x='1922' y='1002' xlink:href='#nn'/><a xlink:href='#command_parameter.parameter_type'><text x='1938' y='1012'>parameter_type</text><title>parameter_type varchar not null</title></a>
-  <use id='nn' x='1922' y='1017' xlink:href='#nn'/><a xlink:href='#command_parameter.required'><text x='1938' y='1027'>required</text><title>required bool not null</title></a>
-  <a xlink:href='#command_parameter.default_value'><text x='1938' y='1042'>default_value</text><title>default_value varchar</title></a>
+<rect class='table' x='2130' y='1013' width='135' height='120' rx='7' ry='7' />
+<path d='M 2130.50 1039.50 L 2130.50 1020.50 Q 2130.50 1013.50 2137.50 1013.50 L 2257.50 1013.50 Q 2264.50 1013.50 2264.50 1020.50 L 2264.50 1039.50 L2130.50 1039.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#command_parameter'><text x='2140' y='1027' class='tableTitle'>command_parameter</text><title>Table qiita.command_parameter</title></a>
+  <use id='nn' x='2132' y='1047' xlink:href='#nn'/><a xlink:href='#command_parameter.command_id'><use id='pk' x='2132' y='1046' xlink:href='#pk'/><title>Index  ( command_id ) Primary Key  ( command_id, parameter_name ) </title></a>
+<a xlink:href='#command_parameter.command_id'><text x='2148' y='1057'>command_id</text><title>command_id bigint not null</title></a>
+<a xlink:href='#command_parameter.command_id'><use id='fk' x='2253' y='1046' xlink:href='#fk'/><title>References software_command ( command_id ) </title></a>
+  <use id='nn' x='2132' y='1062' xlink:href='#nn'/><a xlink:href='#command_parameter.parameter_name'><use id='pk' x='2132' y='1061' xlink:href='#pk'/><title>Primary Key  ( command_id, parameter_name ) </title></a>
+<a xlink:href='#command_parameter.parameter_name'><text x='2148' y='1072'>parameter_name</text><title>parameter_name varchar not null</title></a>
+  <use id='nn' x='2132' y='1077' xlink:href='#nn'/><a xlink:href='#command_parameter.parameter_type'><text x='2148' y='1087'>parameter_type</text><title>parameter_type varchar not null</title></a>
+  <use id='nn' x='2132' y='1092' xlink:href='#nn'/><a xlink:href='#command_parameter.required'><text x='2148' y='1102'>required</text><title>required bool not null</title></a>
+  <a xlink:href='#command_parameter.default_value'><text x='2148' y='1117'>default_value</text><title>default_value varchar</title></a>
+
+<!-- ============= Table 'artifact_processing_job' ============= -->
+<rect class='table' x='1785' y='923' width='150' height='75' rx='7' ry='7' />
+<path d='M 1785.50 949.50 L 1785.50 930.50 Q 1785.50 923.50 1792.50 923.50 L 1927.50 923.50 Q 1934.50 923.50 1934.50 930.50 L 1934.50 949.50 L1785.50 949.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#artifact_processing_job'><text x='1796' y='937' class='tableTitle'>artifact_processing_job</text><title>Table qiita.artifact_processing_job</title></a>
+  <use id='nn' x='1787' y='957' xlink:href='#nn'/><a xlink:href='#artifact_processing_job.artifact_id'><use id='pk' x='1787' y='956' xlink:href='#pk'/><title>Primary Key  ( artifact_id, processing_job_id ) Index  ( artifact_id ) </title></a>
+<a xlink:href='#artifact_processing_job.artifact_id'><text x='1803' y='967'>artifact_id</text><title>artifact_id bigint not null</title></a>
+<a xlink:href='#artifact_processing_job.artifact_id'><use id='fk' x='1923' y='956' xlink:href='#fk'/><title>References artifact ( artifact_id ) </title></a>
+  <use id='nn' x='1787' y='972' xlink:href='#nn'/><a xlink:href='#artifact_processing_job.processing_job_id'><use id='pk' x='1787' y='971' xlink:href='#pk'/><title>Primary Key  ( artifact_id, processing_job_id ) Index  ( processing_job_id ) </title></a>
+<a xlink:href='#artifact_processing_job.processing_job_id'><text x='1803' y='982'>processing_job_id</text><title>processing_job_id bigint not null</title></a>
+<a xlink:href='#artifact_processing_job.processing_job_id'><use id='fk' x='1923' y='971' xlink:href='#fk'/><title>References processing_job ( processing_job_id ) </title></a>
 
 </g></svg>
 
@@ -5408,6 +5431,49 @@ Controlled Vocabulary </td>
 	<tr>
 		<td>fk_command_parameter</td>
 		<td > ( command&#095;id ) ref <a href='#software&#095;command'>software&#095;command</a> (command&#095;id) </td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table class='bordered'>
+<thead>
+<tr><th colspan='3'><a name='artifact_processing_job'>Table artifact_processing_job</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='artifact_processing_job.artifact_id'>artifact&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td><a name='artifact_processing_job.processing_job_id'>processing&#095;job&#095;id</a></td>
+		<td> bigint  NOT NULL  </td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Indexes</b></th></tr>
+	<tr>		<td>idx&#095;artifact&#095;processing&#095;job primary key</td>
+		<td> ON artifact&#095;id&#044; processing&#095;job&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;artifact&#095;processing&#095;job </td>
+		<td> ON artifact&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;artifact&#095;processing&#095;job </td>
+		<td> ON processing&#095;job&#095;id</td>
+		<td>  </td>
+	</tr>
+<tr><th colspan='3'><b>Foreign Keys</b></th></tr>
+	<tr>
+		<td>fk_artifact_processing_job</td>
+		<td > ( artifact&#095;id ) ref <a href='#artifact'>artifact</a> (artifact&#095;id) </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td>fk_artifact_processing_job_0</td>
+		<td > ( processing&#095;job&#095;id ) ref <a href='#processing&#095;job'>processing&#095;job</a> (processing&#095;job&#095;id) </td>
 		<td>  </td>
 	</tr>
 </tbody>

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -497,5 +497,87 @@ class ArtifactTests(TestCase):
     def test_study(self):
         self.assertEqual(qdb.artifact.Artifact(1).study, qdb.study.Study(1))
 
+    def test_jobs(self):
+        obs = qdb.artifact.Artifact(1).jobs()
+        exp = [
+            qdb.processing_job.ProcessingJob(
+                '6d368e16-2242-4cf8-87b4-a5dc40bb890b'),
+            qdb.processing_job.ProcessingJob(
+                '4c7115e8-4c8e-424c-bf25-96c292ca1931'),
+            qdb.processing_job.ProcessingJob(
+                '063e553b-327c-4818-ab4a-adfe58e49860'),
+            qdb.processing_job.ProcessingJob(
+                'bcc7ebcd-39c1-43e4-af2d-822e3589f14d'),
+            qdb.processing_job.ProcessingJob(
+                'b72369f9-a886-4193-8d3d-f7b504168e75')
+            ]
+        self.assertEqual(obs, exp)
+
+    def test_jobs_cmd(self):
+        cmd = qdb.software.Command(1)
+        obs = qdb.artifact.Artifact(1).jobs(cmd=cmd)
+        exp = [
+            qdb.processing_job.ProcessingJob(
+                '6d368e16-2242-4cf8-87b4-a5dc40bb890b'),
+            qdb.processing_job.ProcessingJob(
+                '4c7115e8-4c8e-424c-bf25-96c292ca1931'),
+            qdb.processing_job.ProcessingJob(
+                '063e553b-327c-4818-ab4a-adfe58e49860'),
+            qdb.processing_job.ProcessingJob(
+                'b72369f9-a886-4193-8d3d-f7b504168e75')
+            ]
+        self.assertEqual(obs, exp)
+
+        cmd = qdb.software.Command(2)
+        obs = qdb.artifact.Artifact(1).jobs(cmd=cmd)
+        exp = [qdb.processing_job.ProcessingJob(
+            'bcc7ebcd-39c1-43e4-af2d-822e3589f14d')]
+        self.assertEqual(obs, exp)
+
+    def test_jobs_status(self):
+        obs = qdb.artifact.Artifact(1).jobs(status='success')
+        exp = [
+            qdb.processing_job.ProcessingJob(
+                '6d368e16-2242-4cf8-87b4-a5dc40bb890b'),
+            qdb.processing_job.ProcessingJob(
+                '4c7115e8-4c8e-424c-bf25-96c292ca1931'),
+            qdb.processing_job.ProcessingJob(
+                'b72369f9-a886-4193-8d3d-f7b504168e75')
+            ]
+        self.assertEqual(obs, exp)
+
+        obs = qdb.artifact.Artifact(1).jobs(status='running')
+        exp = [qdb.processing_job.ProcessingJob(
+            'bcc7ebcd-39c1-43e4-af2d-822e3589f14d')]
+        self.assertEqual(obs, exp)
+
+        obs = qdb.artifact.Artifact(1).jobs(status='queued')
+        exp = [qdb.processing_job.ProcessingJob(
+            '063e553b-327c-4818-ab4a-adfe58e49860')]
+        self.assertEqual(obs, exp)
+
+    def test_jobs_cmd_and_status(self):
+        cmd = qdb.software.Command(1)
+        obs = qdb.artifact.Artifact(1).jobs(cmd=cmd, status='success')
+        exp = [
+            qdb.processing_job.ProcessingJob(
+                '6d368e16-2242-4cf8-87b4-a5dc40bb890b'),
+            qdb.processing_job.ProcessingJob(
+                '4c7115e8-4c8e-424c-bf25-96c292ca1931'),
+            qdb.processing_job.ProcessingJob(
+                'b72369f9-a886-4193-8d3d-f7b504168e75')
+            ]
+        self.assertEqual(obs, exp)
+
+        obs = qdb.artifact.Artifact(1).jobs(cmd=cmd, status='queued')
+        exp = [qdb.processing_job.ProcessingJob(
+            '063e553b-327c-4818-ab4a-adfe58e49860')]
+        self.assertEqual(obs, exp)
+
+        cmd = qdb.software.Command(2)
+        obs = qdb.artifact.Artifact(1).jobs(cmd=cmd, status='queued')
+        exp = []
+        self.assertEqual(obs, exp)
+
 if __name__ == '__main__':
     main()

--- a/qiita_db/test/test_processing_job.py
+++ b/qiita_db/test/test_processing_job.py
@@ -58,6 +58,7 @@ class ProcessingJobTest(TestCase):
         self.assertEqual(obs.log, None)
         self.assertEqual(obs.heartbeat, None)
         self.assertEqual(obs.step, None)
+        self.assertTrue(obs in qdb.artifact.Artifact(1).jobs())
 
     def test_user(self):
         exp_user = qdb.user.User('test@foo.bar')


### PR DESCRIPTION
This PR adds links the artifacts with those processing jobs that are using the artifact as input.

Since we removed the 'processing_status' attribute from the artifacts, you can know check if it being processed by doing:
```python
is_processing = len(artifact.jobs(status='running')) > 0
```
Although it may seem complex, the main advantage is that `artifact.jobs(status='running')` actually returns the jobs, so you can ask in which step are they or which parameters are being used.