### PR TITLE
Artifact retain ppd

### DIFF
--- a/qiita_db/support_files/patches/33.sql
+++ b/qiita_db/support_files/patches/33.sql
@@ -141,11 +141,11 @@ ALTER TABLE qiita.artifact ADD CONSTRAINT fk_artifact_software_command FOREIGN K
 ALTER TABLE qiita.artifact ADD CONSTRAINT fk_artifact_data_type FOREIGN KEY ( data_type_id ) REFERENCES qiita.data_type( data_type_id )    ;
 
 -- We need to keep the old preprocessed data id for the artifact id due
--- to EBI reasons. In order to make sure that none of the raw data or processed
--- data taht we are going to transfer to the artifact table gets and id needed
--- by the preprocessed data, we are going to set the autoincrementing
+-- to EBI. In order to make sure that none of the raw data or processed
+-- data that we are going to transfer to the artifact table gets and id needed
+-- by the preprocessed data, we will set the autoincrementing
 -- artifact_id column to start at 10,000
-SELECT setval('qiita.artifact_artifact_id_seq', 10000, false);
+SELECT setval('qiita.artifact_artifact_id_seq', 2000, false);
 
 
 -- Artifact filepath table - relates an artifact with its files

--- a/qiita_db/support_files/patches/33.sql
+++ b/qiita_db/support_files/patches/33.sql
@@ -144,7 +144,7 @@ ALTER TABLE qiita.artifact ADD CONSTRAINT fk_artifact_data_type FOREIGN KEY ( da
 -- to EBI. In order to make sure that none of the raw data or processed
 -- data that we are going to transfer to the artifact table gets and id needed
 -- by the preprocessed data, we will set the autoincrementing
--- artifact_id column to start at 10,000
+-- artifact_id column to start at 2,000
 SELECT setval('qiita.artifact_artifact_id_seq', 2000, false);
 
 

--- a/qiita_db/support_files/populate_test_db.sql
+++ b/qiita_db/support_files/populate_test_db.sql
@@ -1,6 +1,9 @@
 -- Populate.sql sets the increment to begin at 10000, but all tests expect it to start at 1, so set it back to 1 for the test DB population
 SELECT setval('qiita.study_study_id_seq', 1, false);
 
+-- Patch 33.sql sets the increment to begin at 10000, but all tests expect it to start at 1, so set it back to 1 for the test DB population
+SELECT setval('qiita.artifact_artifact_id_seq', 1, false);
+
 -- Insert some users in the system. Passwords are 'password' for all users
 INSERT INTO qiita.qiita_user (email, user_level_id, password, name,
     affiliation, address, phone) VALUES

--- a/qiita_db/support_files/populate_test_db.sql
+++ b/qiita_db/support_files/populate_test_db.sql
@@ -1,7 +1,7 @@
 -- Populate.sql sets the increment to begin at 10000, but all tests expect it to start at 1, so set it back to 1 for the test DB population
 SELECT setval('qiita.study_study_id_seq', 1, false);
 
--- Patch 33.sql sets the increment to begin at 10000, but all tests expect it to start at 1, so set it back to 1 for the test DB population
+-- Patch 33.sql sets the increment to begin at 2000, but all tests expect it to start at 1, so set it back to 1 for the test DB population
 SELECT setval('qiita.artifact_artifact_id_seq', 1, false);
 
 -- Insert some users in the system. Passwords are 'password' for all users


### PR DESCRIPTION
Modifies the patch to keep the preprocessed data id as the artifact id.