### PR TITLE
Base for new study page

### DIFF
--- a/qiita_db/study.py
+++ b/qiita_db/study.py
@@ -169,9 +169,11 @@ class Study(qdb.base.QiitaObject):
     @staticmethod
     def all_data_types():
         """Returns list of all the data types available in the system
+
         Returns
         -------
         list of str
+            All the data types available in the system
         """
         with qdb.sql_connection.TRN:
             sql = "SELECT DISTINCT data_type FROM qiita.data_type"

--- a/qiita_db/study.py
+++ b/qiita_db/study.py
@@ -512,8 +512,7 @@ class Study(qdb.base.QiitaObject):
             # remove non-info items from info
             for item in self._non_info:
                 info.pop(item)
-            # This is an optional column, but should not be considered part
-            # of the info
+            # removed because redundant to the id already stored in the object
             info.pop('study_id')
 
             if info['principal_investigator_id']:

--- a/qiita_db/study.py
+++ b/qiita_db/study.py
@@ -166,6 +166,18 @@ class Study(qdb.base.QiitaObject):
             return qdb.util.infer_status(
                 qdb.sql_connection.TRN.execute_fetchindex())
 
+    @staticmethod
+    def all_data_types():
+        """Returns list of all the data types available in the system
+        Returns
+        -------
+        list of str
+        """
+        with qdb.sql_connection.TRN:
+            sql = "SELECT DISTINCT data_type FROM qiita.data_type"
+            qdb.sql_connection.TRN.add(sql)
+            return qdb.sql_connection.TRN.execute_fetchflatten()
+
     @classmethod
     def get_by_status(cls, status):
         """Returns study id for all Studies with given status
@@ -503,6 +515,21 @@ class Study(qdb.base.QiitaObject):
             # This is an optional column, but should not be considered part
             # of the info
             info.pop('study_id')
+
+            if info['principal_investigator_id']:
+                info['principal_investigator'] = qdb.study.StudyPerson(
+                    info["principal_investigator_id"])
+            else:
+                info['principal_investigator'] = None
+            del info['principal_investigator_id']
+
+            if info['lab_person_id']:
+                info['lab_person'] = qdb.study.StudyPerson(
+                    info["lab_person_id"])
+            else:
+                info['lab_person'] = None
+            del info['lab_person_id']
+
             return info
 
     @info.setter

--- a/qiita_pet/handlers/api_proxy.py
+++ b/qiita_pet/handlers/api_proxy.py
@@ -9,7 +9,7 @@ from __future__ import division
 
 # This is the only file in qiita_pet that should import from outside qiita_pet
 # The idea is that this proxies the call and response dicts we expect from the
-# QIITA API once we build it. This will be removed and replaced with API calls
+# Qiita API once we build it. This will be removed and replaced with API calls
 # when the API is complete.
 from qiita_core.qiita_settings import qiita_config
 from qiita_db.study import Study
@@ -37,7 +37,7 @@ def _approve(level):
 
 
 class StudyAPIProxy(BaseHandler):
-    """Adds API proxy functions to the handler. Can be removed once the restful
+    """Adds API proxy functions to the handler. Can be removed once the RESTful
        API is in place."""
     def study_prep_proxy(self, study_id):
         """Proxies expected json from the API for existing prep templates
@@ -47,10 +47,16 @@ class StudyAPIProxy(BaseHandler):
         study_id : int
             Study id to get prep template info for
 
-        Returns:
+        Returns
+        -------
         dict of list of dict
             prep template information seperated by data type, in the form
             {data_type: [{prep 1 info dict}, ....], ...}
+
+        Raises
+        ------
+        HTTPError
+            Raises code 403 if user does not have access to the study
         """
         # Can only pass ids over API, so need to instantiate object
         study = Study(study_id)
@@ -90,7 +96,8 @@ class StudyAPIProxy(BaseHandler):
         study_id : int
             Study id to get prep template info for
 
-        Returns:
+        Returns
+        -------
         dict of list of dict
             prep template information seperated by data type, in the form
             {data_type: [{prep 1 info dict}, ....], ...}

--- a/qiita_pet/handlers/api_proxy.py
+++ b/qiita_pet/handlers/api_proxy.py
@@ -86,7 +86,7 @@ class StudyAPIProxy(BaseHandler):
             Data types available on the system
         """
         data_types = Study.all_data_types()
-        return data_types if data_types else []
+        return data_types
 
     def study_info_proxy(self, study_id):
         """Proxies expected json from the API for base study info
@@ -101,6 +101,11 @@ class StudyAPIProxy(BaseHandler):
         dict of list of dict
             prep template information seperated by data type, in the form
             {data_type: [{prep 1 info dict}, ....], ...}
+
+        Raises
+        ------
+        HTTPError
+            Raises code 403 if user does not have access to the study
         """
         # Can only pass ids over API, so need to instantiate object
         study = Study(study_id)
@@ -110,6 +115,8 @@ class StudyAPIProxy(BaseHandler):
         study_info['publications'] = study.publications
         study_info['study_id'] = study.id
         study_info['study_title'] = study.title
+        study_info['shared_with'] = [s.id for s in study.shared_with]
+        study_info['status'] = study.status
 
         # Clean up StudyPerson objects to string for display
         pi = study_info["principal_investigator"]

--- a/qiita_pet/handlers/api_proxy.py
+++ b/qiita_pet/handlers/api_proxy.py
@@ -9,7 +9,8 @@ from __future__ import division
 
 # This is the only file in qiita_pet that should import from outside qiita_pet
 # The idea is that this proxies the call and response dicts we expect from the
-# QIITA API once we build it.
+# QIITA API once we build it. This will be removed and replaced with API calls
+# when the API is complete.
 from qiita_core.qiita_settings import qiita_config
 from qiita_db.study import Study
 
@@ -65,7 +66,7 @@ class StudyAPIProxy(BaseHandler):
                     'status': prep.status,
                     'start_artifact': start_artifact.artifact_type,
                     'start_artifact_id': start_artifact.id,
-                    'last_artifact': 'TODO'
+                    'last_artifact': 'TODO new gui'
                 }
                 prep_info[dtype].append(info)
         return prep_info
@@ -99,7 +100,7 @@ class StudyAPIProxy(BaseHandler):
         check_access(self.current_user, study, raise_error=True)
         study_info = study.info
         # Add needed info that is not part of the initial info pull
-        study_info['publication_doi'] = [p[0] for p in study.publications]
+        study_info['publications'] = study.publications
         study_info['study_id'] = study.id
         study_info['study_title'] = study.title
 

--- a/qiita_pet/handlers/study_handlers/__init__.py
+++ b/qiita_pet/handlers/study_handlers/__init__.py
@@ -14,8 +14,10 @@ from .description_handlers import (StudyDescriptionHandler,
 from .ebi_handlers import EBISubmitHandler
 from .metadata_summary_handlers import MetadataSummaryHandler
 from .vamps_handlers import VAMPSHandler
+from .base import StudyIndexHandler, StudyBaseInfoAJAX
 
 __all__ = ['ListStudiesHandler', 'StudyApprovalList', 'ShareStudyAJAX',
            'StudyEditHandler', 'CreateStudyAJAX', 'StudyDescriptionHandler',
            'PreprocessingSummaryHandler', 'EBISubmitHandler',
-           'MetadataSummaryHandler', 'VAMPSHandler', 'SearchStudiesAJAX']
+           'MetadataSummaryHandler', 'VAMPSHandler', 'SearchStudiesAJAX',
+           'StudyIndexHandler', 'StudyBaseInfoAJAX']

--- a/qiita_pet/handlers/study_handlers/api_proxy.py
+++ b/qiita_pet/handlers/study_handlers/api_proxy.py
@@ -7,6 +7,9 @@
 # -----------------------------------------------------------------------------
 from __future__ import division
 
+# This is the only file in qiita_pet that should import from outside qiita_pet
+# The idea is that this proxies the call and response dicts we expect from the
+# QIITA API once we build it.
 from qiita_core.qiita_settings import qiita_config
 from qiita_db.study import Study
 
@@ -95,14 +98,15 @@ class StudyAPIProxy(BaseHandler):
         study = Study(study_id)
         check_access(self.current_user, study, raise_error=True)
         study_info = study.info
+        # Add needed info that is not part of the initial info pull
         study_info['publication_doi'] = [p[0] for p in study.publications]
         study_info['study_id'] = study.id
         study_info['study_title'] = study.title
 
+        # Clean up StudyPerson objects to string for display
         pi = study_info["principal_investigator"]
         study_info["principal_investigator"] = '%s (%s)' % (pi.name,
                                                             pi.affiliation)
-
         lab_person = study_info["lab_person"]
         study_info["lab_person"] = '%s (%s)' % (lab_person.name,
                                                 lab_person.affiliation)

--- a/qiita_pet/handlers/study_handlers/api_proxy.py
+++ b/qiita_pet/handlers/study_handlers/api_proxy.py
@@ -1,0 +1,112 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014--, The Qiita Development Team.
+#
+# Distributed under the terms of the BSD 3-clause License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# -----------------------------------------------------------------------------
+from __future__ import division
+
+from qiita_core.qiita_settings import qiita_config
+from qiita_db.study import Study
+
+from qiita_pet.handlers.base_handlers import BaseHandler
+from qiita_pet.handlers.util import check_access
+
+html_error_message = "<b>An error occurred %s %s</b></br>%s"
+
+
+def _approve(level):
+    """Check if the study can be approved based on user level and configuration
+
+    Parameters
+    ----------
+    level : str
+        The level of the current user
+
+    Returns
+    -------
+    bool
+        Whether the study can be approved or not
+    """
+    return True if not qiita_config.require_approval else level == 'admin'
+
+
+class StudyAPIProxy(BaseHandler):
+    """Adds API proxy functions to the handler. Can be removed once the restful
+       API is in place."""
+    def study_prep_proxy(self, study_id):
+        """Proxies expected json from the API for existing prep templates
+
+        Parameters
+        ----------
+        study_id : int
+            Study id to get prep template info for
+
+        Returns:
+        dict of list of dict
+            prep template information seperated by data type, in the form
+            {data_type: [{prep 1 info dict}, ....], ...}
+        """
+        # Can only pass ids over API, so need to instantiate object
+        study = Study(study_id)
+        check_access(self.current_user, study, raise_error=True)
+        prep_info = {}
+        for dtype in study.data_types:
+            prep_info[dtype] = []
+            for prep in study.prep_templates(dtype):
+                start_artifact = prep.artifact
+                info = {
+                    'name': 'PREP %d NAME' % prep.id,
+                    'id': prep.id,
+                    'status': prep.status,
+                    'start_artifact': start_artifact.artifact_type,
+                    'start_artifact_id': start_artifact.id,
+                    'last_artifact': 'TODO'
+                }
+                prep_info[dtype].append(info)
+        return prep_info
+
+    def study_data_types_proxy(self):
+        """Proxies expected json from the API for available data types
+
+        Returns
+        -------
+        list of str
+            Data types available on the system
+        """
+        data_types = Study.all_data_types()
+        return data_types if data_types else []
+
+    def study_info_proxy(self, study_id):
+        """Proxies expected json from the API for base study info
+
+        Parameters
+        ----------
+        study_id : int
+            Study id to get prep template info for
+
+        Returns:
+        dict of list of dict
+            prep template information seperated by data type, in the form
+            {data_type: [{prep 1 info dict}, ....], ...}
+        """
+        # Can only pass ids over API, so need to instantiate object
+        study = Study(study_id)
+        check_access(self.current_user, study, raise_error=True)
+        study_info = study.info
+        study_info['publication_doi'] = [p[0] for p in study.publications]
+        study_info['study_id'] = study.id
+        study_info['study_title'] = study.title
+
+        pi = study_info["principal_investigator"]
+        study_info["principal_investigator"] = '%s (%s)' % (pi.name,
+                                                            pi.affiliation)
+
+        lab_person = study_info["lab_person"]
+        study_info["lab_person"] = '%s (%s)' % (lab_person.name,
+                                                lab_person.affiliation)
+
+        samples = study.sample_template.keys()
+        study_info['num_samples'] = 0 if samples is None else len(set(samples))
+        return study_info

--- a/qiita_pet/handlers/study_handlers/base.py
+++ b/qiita_pet/handlers/study_handlers/base.py
@@ -9,10 +9,10 @@ from __future__ import division
 
 from tornado.web import authenticated
 
-from qiita_pet.handlers.util import to_int
+from qiita_pet.handlers.util import to_int, doi_linkifier
 # ONLY IMPORT FROM qiita_pet HERE. All other imports must be made in
 # api_proxy.py so they will be removed when we get the API in place.
-from .api_proxy import StudyAPIProxy
+from qiita_pet.handlers.api_proxy import StudyAPIProxy
 
 
 class StudyIndexHandler(StudyAPIProxy):
@@ -34,6 +34,8 @@ class StudyBaseInfoAJAX(StudyAPIProxy):
         study = to_int(self.get_argument('study_id'))
         # Proxy for what will become API request
         study_info = self.study_info_proxy(study)
+        study_doi = ' '.join(
+            [doi_linkifier(p) for p in study_info['publications']])
 
         self.render('study_ajax/base_info.html',
-                    study_info=study_info)
+                    study_info=study_info, publications=study_doi)

--- a/qiita_pet/handlers/study_handlers/base.py
+++ b/qiita_pet/handlers/study_handlers/base.py
@@ -23,9 +23,11 @@ class StudyIndexHandler(StudyAPIProxy):
         prep_info = self.study_prep_proxy(study)
         data_types = self.study_data_types_proxy()
         study_info = self.study_info_proxy(study)
+        editable = study_info['status'] == 'sandbox'
 
         self.render("study_base.html", prep_info=prep_info,
-                    data_types=data_types, study_info=study_info)
+                    data_types=data_types, study_info=study_info,
+                    editable=editable)
 
 
 class StudyBaseInfoAJAX(StudyAPIProxy):

--- a/qiita_pet/handlers/study_handlers/base.py
+++ b/qiita_pet/handlers/study_handlers/base.py
@@ -1,0 +1,39 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014--, The Qiita Development Team.
+#
+# Distributed under the terms of the BSD 3-clause License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# -----------------------------------------------------------------------------
+from __future__ import division
+
+from tornado.web import authenticated
+
+from qiita_pet.handlers.util import to_int
+# ONLY IMPORT FROM qiita_pet HERE. All other imports must be made in
+# api_proxy.py so they will be removed when we get the API in place.
+from .api_proxy import StudyAPIProxy
+
+
+class StudyIndexHandler(StudyAPIProxy):
+    @authenticated
+    def get(self, study_id):
+        study = to_int(study_id)
+        # Proxies for what will become API requests
+        prep_info = self.study_prep_proxy(study)
+        data_types = self.study_data_types_proxy()
+        study_info = self.study_info_proxy(study)
+
+        self.render("study_base.html", prep_info=prep_info,
+                    data_types=data_types, study_info=study_info)
+
+
+class StudyBaseInfoAJAX(StudyAPIProxy):
+    @authenticated
+    def get(self):
+        study = to_int(self.get_argument('study_id'))
+        # Proxy for what will become API request
+        study_info = self.study_info_proxy(study)
+
+        self.render('study_ajax/base_info.html',
+                    study_info=study_info)

--- a/qiita_pet/handlers/util.py
+++ b/qiita_pet/handlers/util.py
@@ -87,5 +87,5 @@ def to_int(value):
     try:
         res = int(value)
     except ValueError:
-        raise HTTPError(500, "%s cannot be converted to an integer" % value)
+        raise HTTPError(400, "%s cannot be converted to an integer" % value)
     return res

--- a/qiita_pet/handlers/util.py
+++ b/qiita_pet/handlers/util.py
@@ -64,3 +64,28 @@ pubmed_linkifier = partial(
 
 doi_linkifier = partial(
     linkify, "<a target=\"_blank\" href=\"http://dx.doi.org/{0}\">{0}</a>")
+
+
+def to_int(value):
+    """Transforms `value` to an integer
+
+    Parameters
+    ----------
+    value : str or int
+        The value to transform
+
+    Returns
+    -------
+    int
+        `value` as an integer
+
+    Raises
+    ------
+    HTTPError
+        If `value` cannot be transformed to an integer
+    """
+    try:
+        res = int(value)
+    except ValueError:
+        raise HTTPError(500, "%s cannot be converted to an integer" % value)
+    return res

--- a/qiita_pet/templates/study_ajax/base_info.html
+++ b/qiita_pet/templates/study_ajax/base_info.html
@@ -1,0 +1,7 @@
+<p style="font-weight:bold;">Abstract</p>
+<p>{{study_info['study_abstract']}}</p>
+Study ID:  {{study_info['study_id']}}<br />
+Publications: {% for pub in study_info['publication_doi'] %}<a href="http://dx.doi.org/{{pub}}" target="_blank">{{pub}}</a> {% end %}<br />
+PI: {{study_info['principal_investigator']}}<br />
+Lab Contact: {{study_info['lab_person']}}<br />
+Samples: {{study_info['num_samples']}}

--- a/qiita_pet/templates/study_ajax/base_info.html
+++ b/qiita_pet/templates/study_ajax/base_info.html
@@ -1,7 +1,7 @@
 <p style="font-weight:bold;">Abstract</p>
 <p>{{study_info['study_abstract']}}</p>
 Study ID:  {{study_info['study_id']}}<br />
-Publications: {% for pub in study_info['publication_doi'] %}<a href="http://dx.doi.org/{{pub}}" target="_blank">{{pub}}</a> {% end %}<br />
+Publications: {% raw publications %}<br />
 PI: {{study_info['principal_investigator']}}<br />
 Lab Contact: {{study_info['lab_person']}}<br />
 Samples: {{study_info['num_samples']}}

--- a/qiita_pet/templates/study_base.html
+++ b/qiita_pet/templates/study_base.html
@@ -1,0 +1,72 @@
+{% extends sitebase.html %}
+{% block head %}
+<script type="text/javascript">
+  function fill_base(sid) {
+  $.get( "/study/description/baseinfo/", { study_id: sid} )
+    .done(function( data ) {
+      $("#study-main").html(data);
+      $("#study-prep-graph").hide();
+      $("#study-file-breadcrumbs").hide();
+    });
+  }
+
+  $(document).ready(function() {
+    fill_base({{study_info['study_id']}});
+  });
+</script>
+{% end %}
+{% block content %}
+<div class="row">
+  <div class="col-md-3">
+  <h3>Study Information</h3>
+    <a href="#">Sample Template</a><br />
+    <a href="#">Sample Summary</a><br />
+    <a href="/study/upload/{{study_info['study_id']}}">Upload Files</a><br />
+    <a href="#">Edit Study Information</a><br />
+    <a href="#">Delete Study</a>
+
+    <h3>Data Types</h3>
+    <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+      <div class="panel panel-default">
+      {% for dt in prep_info %}
+      {% set cleaned_dt = dt.replace(' ', '_') %}
+        <div class="panel-heading" role="tab" id="heading{{cleaned_dt}}">
+          <h4 class="panel-title">
+            <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse{{cleaned_dt}}" aria-expanded="true" aria-controls="collapse{{cleaned_dt}}">{{dt}}</a>
+          </h4>
+        </div>
+        {% end %}
+        {% for prep in prep_info[dt] %}
+        <div id="collapse{{cleaned_dt}}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading{{cleaned_dt}}">
+          <div class="panel-body">
+            <a href="#" style="display:block;color:black;">
+            {{prep['name']}} - ID {{prep['id']}} - {{prep['status']}}<br/>
+            {{prep['start_artifact']}} - ID {{prep['start_artifact_id']}}<br/>
+            {{prep['last_artifact']}}
+            </a>
+          </div>
+        </div>
+        {% end %}
+      </div>
+    </div>
+  </div>
+  <div class="col-md-9">
+    <div class="row">
+      <div class="col-md-12" id="study-base-info">
+        <h2>{{study_info['study_title']}} - ID {{study_info['study_id']}}</h2>
+        <h3>{{study_info['study_alias']}}</h3>
+      </div>
+    </div>
+    {% if user_level == 'admin' %}
+    <div class="row">
+      <div class="col-md-12" id="study-admin">
+        ADMIN STUFF HERE
+      </div>
+    </div>
+    {% end %}
+    <div class="row"><div class="col-md-12" id="study-prep-graph"></div></div>
+    <div class="row"><div class="col-md-12" id="study-file-breadcrumbs"></div></div>
+    <div class="row"><div class="col-md-12" id="study-main"></div></div>
+  </div>
+</div>
+{% end %}

--- a/qiita_pet/templates/study_base.html
+++ b/qiita_pet/templates/study_base.html
@@ -2,12 +2,12 @@
 {% block head %}
 <script type="text/javascript">
   function fill_base(sid) {
-  $.get( "/study/description/baseinfo/", { study_id: sid} )
-    .done(function( data ) {
-      $("#study-main").html(data);
-      $("#study-prep-graph").hide();
-      $("#study-file-breadcrumbs").hide();
-    });
+    $.get( "/study/description/baseinfo/", { study_id: sid} )
+      .done(function( data ) {
+        $("#study-main").html(data);
+        $("#study-prep-graph").hide();
+        $("#study-file-breadcrumbs").hide();
+      });
   }
 
   $(document).ready(function() {
@@ -21,9 +21,11 @@
   <h3>Study Information</h3>
     <a href="#">Sample Template</a><br />
     <a href="#">Sample Summary</a><br />
+    {% if editable %}
     <a href="/study/upload/{{study_info['study_id']}}">Upload Files</a><br />
     <a href="#">Edit Study Information</a><br />
     <a href="#">Delete Study</a>
+    {% end %}
 
     <h3>Data Types</h3>
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
@@ -35,8 +37,8 @@
             <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse{{cleaned_dt}}" aria-expanded="true" aria-controls="collapse{{cleaned_dt}}">{{dt}}</a>
           </h4>
         </div>
-        {% end %}
-        {% for prep in prep_info[dt] %}
+      {% end %}
+      {% for prep in prep_info[dt] %}
         <div id="collapse{{cleaned_dt}}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading{{cleaned_dt}}">
           <div class="panel-body">
             <a href="#" style="display:block;color:black;">
@@ -46,7 +48,7 @@
             </a>
           </div>
         </div>
-        {% end %}
+      {% end %}
       </div>
     </div>
   </div>

--- a/qiita_pet/webserver.py
+++ b/qiita_pet/webserver.py
@@ -22,6 +22,7 @@ from qiita_pet.handlers.analysis_handlers import (
     ShowAnalysesHandler, ResultsHandler, SelectedSamplesHandler,
     AnalysisSummaryAJAX)
 from qiita_pet.handlers.study_handlers import (
+    StudyIndexHandler, StudyBaseInfoAJAX,
     StudyEditHandler, ListStudiesHandler, SearchStudiesAJAX,
     StudyDescriptionHandler, MetadataSummaryHandler, EBISubmitHandler,
     CreateStudyAJAX, ShareStudyAJAX, StudyApprovalList,
@@ -103,7 +104,10 @@ class Application(tornado.web.Application):
             (r"/study/preprocess", PreprocessHandler),
             (r"/study/process", ProcessHandler),
             (r"/study/sharing/", ShareStudyAJAX),
-            (r"/study/description/(.*)", StudyDescriptionHandler),
+            # ORDER FOR /study/description/ SUBPAGES HERE MATTERS.
+            # Same reasoning as below. /study/description/(.*) should be last.
+            (r"/study/description/baseinfo/", StudyBaseInfoAJAX),
+            (r"/study/description/(.*)", StudyIndexHandler),
             (r"/study/upload/(.*)", StudyUploadFileHandler),
             (r"/upload/", UploadFileHandler),
             (r"/check_study/", CreateStudyAJAX),

--- a/qiita_pet/webserver.py
+++ b/qiita_pet/webserver.py
@@ -24,7 +24,7 @@ from qiita_pet.handlers.analysis_handlers import (
 from qiita_pet.handlers.study_handlers import (
     StudyIndexHandler, StudyBaseInfoAJAX,
     StudyEditHandler, ListStudiesHandler, SearchStudiesAJAX,
-    StudyDescriptionHandler, MetadataSummaryHandler, EBISubmitHandler,
+    MetadataSummaryHandler, EBISubmitHandler,
     CreateStudyAJAX, ShareStudyAJAX, StudyApprovalList,
     PreprocessingSummaryHandler, VAMPSHandler)
 from qiita_pet.handlers.websocket_handlers import (


### PR DESCRIPTION
This adds in the base HTML and index handler for the study pages, and a single example of the AJAX-call-based updates done on the page. The idea is that we load the minimal information to show the first page, and then lazy load each bit of information needed as it is called for, so we save a lot of time and database calls that would be duplicated if we just reloaded the page for every link click. It also means we no longer need to load all information for all files when the page is accessed.