### PR TITLE
Fixing raw data sharing

### DIFF
--- a/qiita_db/artifact.py
+++ b/qiita_db/artifact.py
@@ -96,7 +96,7 @@ class Artifact(qdb.base.QiitaObject):
             A new instance of Artifact
         """
         with qdb.sql_connection.TRN:
-            visibility = qdb.util.convert_to_id("sandbox", "visibility")
+            visibility_id = qdb.util.convert_to_id("sandbox", "visibility")
             atype = artifact.artifact_type
             atype_id = qdb.util.convert_to_id(atype, "artifact_type")
             dtype_id = qdb.util.convert_to_id(
@@ -107,7 +107,7 @@ class Artifact(qdb.base.QiitaObject):
                         can_be_submitted_to_vamps, submitted_to_vamps)
                      VALUES (%s, %s, %s, %s, %s, %s, %s)
                      RETURNING artifact_id"""
-            sql_args = [datetime.now(), visibility, atype_id, dtype_id,
+            sql_args = [datetime.now(), visibility_id, atype_id, dtype_id,
                         artifact.can_be_submitted_to_ebi,
                         artifact.can_be_submitted_to_vamps, False]
             qdb.sql_connection.TRN.add(sql, sql_args)

--- a/qiita_db/artifact.py
+++ b/qiita_db/artifact.py
@@ -80,6 +80,63 @@ class Artifact(qdb.base.QiitaObject):
         return cls.iter_by_visibility('public')
 
     @classmethod
+    def copy(cls, artifact, prep_template):
+        """Creates a copy of `artifact` and attaches it to `prep_template`
+
+        Parameters
+        ----------
+        artifact : qiita_db.artifact.Artifact
+            Artifact to copy from
+        prep_template : qiita_db.metadata_template.prep_template.PrepTemplate
+            The prep template to attach the new artifact to
+
+        Returns
+        -------
+        qiita_db.artifact.Artifact
+            A new instance of Artifact
+        """
+        with qdb.sql_connection.TRN:
+            visibility = qdb.util.convert_to_id("sandbox", "visibility")
+            atype = artifact.artifact_type
+            atype_id = qdb.util.convert_to_id(atype, "artifact_type")
+            dtype_id = qdb.util.convert_to_id(
+                prep_template.data_type(), "data_type")
+            sql = """INSERT INTO qiita.artifact (
+                        generated_timestamp, visibility_id, artifact_type_id,
+                        data_type_id, can_be_submitted_to_ebi,
+                        can_be_submitted_to_vamps, submitted_to_vamps)
+                     VALUES (%s, %s, %s, %s, %s, %s, %s)
+                     RETURNING artifact_id"""
+            sql_args = [datetime.now(), visibility, atype_id, dtype_id,
+                        artifact.can_be_submitted_to_ebi,
+                        artifact.can_be_submitted_to_vamps, False]
+            qdb.sql_connection.TRN.add(sql, sql_args)
+            a_id = qdb.sql_connection.TRN.execute_fetchlast()
+
+            # Associate the artifact with the prep template
+            instance = cls(a_id)
+            prep_template.artifact = instance
+
+            # Associate the artifact with the study
+            sql = """INSERT INTO qiita.study_artifact (study_id, artifact_id)
+                     VALUES (%s, %s)"""
+            sql_args = [prep_template.study_id, a_id]
+            qdb.sql_connection.TRN.add(sql, sql_args)
+
+            # Associate the artifact with its filepaths
+            filepaths = [(fp, f_type) for _, fp, f_type in artifact.filepaths]
+            fp_ids = qdb.util.insert_filepaths(
+                filepaths, a_id, atype, "filepath", copy=True)
+            sql = """INSERT INTO qiita.artifact_filepath
+                        (artifact_id, filepath_id)
+                     VALUES (%s, %s)"""
+            sql_args = [[a_id, fp_id] for fp_id in fp_ids]
+            qdb.sql_connection.TRN.add(sql, sql_args, many=True)
+            qdb.sql_connection.TRN.execute()
+
+        return instance
+
+    @classmethod
     def create(cls, filepaths, artifact_type, prep_template=None,
                parents=None, processing_parameters=None,
                can_be_submitted_to_ebi=False, can_be_submitted_to_vamps=False):

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -109,7 +109,7 @@ class ArtifactTests(TestCase):
 
     def test_copy(self):
         src = qdb.artifact.Artifact(1)
-        # Craete the files to the first artifact
+        # Create the files to the first artifact
         for _, fp, _ in src.filepaths:
             with open(fp, 'w') as f:
                 f.write("\n")

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -107,6 +107,42 @@ class ArtifactTests(TestCase):
         exp = [a1, a4]
         self.assertEqual(obs, exp)
 
+    def test_copy(self):
+        src = qdb.artifact.Artifact(1)
+        # Craete the files to the first artifact
+        for _, fp, _ in src.filepaths:
+            with open(fp, 'w') as f:
+                f.write("\n")
+            self._clean_up_files.append(fp)
+        fp_count = qdb.util.get_count('qiita.filepath')
+        before = datetime.now()
+        obs = qdb.artifact.Artifact.copy(src, self.prep_template)
+
+        self.assertTrue(before < obs.timestamp < datetime.now())
+        self.assertIsNone(obs.processing_parameters)
+        self.assertEqual(obs.visibility, 'sandbox')
+        self.assertEqual(obs.artifact_type, src.artifact_type)
+        self.assertEqual(obs.data_type, self.prep_template.data_type())
+        self.assertEqual(obs.can_be_submitted_to_ebi,
+                         src.can_be_submitted_to_ebi)
+        self.assertEqual(obs.can_be_submitted_to_vamps,
+                         src.can_be_submitted_to_vamps)
+
+        db_dir = qdb.util.get_mountpoint(src.artifact_type)[0][1]
+        path_builder = partial(join, db_dir, str(obs.id))
+        exp_fps = []
+        for fp_id, fp, fp_type in src.filepaths:
+            fp_count += 1
+            new_fp = path_builder(basename(fp))
+            exp_fps.append((fp_count, new_fp, fp_type))
+            self._clean_up_files.append(new_fp)
+
+        self.assertEqual(obs.filepaths, exp_fps)
+        self.assertEqual(obs.parents, [])
+        self.assertEqual(obs.prep_templates, [self.prep_template])
+
+        self.assertEqual(obs.study, qdb.study.Study(1))
+
     def test_create_error_no_filepaths(self):
         with self.assertRaises(qdb.exceptions.QiitaDBArtifactCreationError):
             qdb.artifact.Artifact.create(

--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -164,6 +164,34 @@ class DBUtilTests(TestCase):
         exp_fp = join(qdb.util.get_db_files_base_dir(), "raw_data",
                       "1_%s" % basename(fp))
         self.assertTrue(exists(exp_fp))
+        self.assertFalse(exists(fp))
+        self.files_to_remove.append(exp_fp)
+
+        # Check that the filepaths have been added to the DB
+        obs = self.conn_handler.execute_fetchall(
+            "SELECT * FROM qiita.filepath WHERE filepath_id=%d" % exp_new_id)
+        exp_fp = "1_%s" % basename(fp)
+        exp = [[exp_new_id, exp_fp, 1, '852952723', 1, 5]]
+        self.assertEqual(obs, exp)
+
+    def test_insert_filepaths_copy(self):
+        fd, fp = mkstemp()
+        close(fd)
+        with open(fp, "w") as f:
+            f.write("\n")
+        self.files_to_remove.append(fp)
+
+        exp_new_id = 1 + self.conn_handler.execute_fetchone(
+            "SELECT count(1) FROM qiita.filepath")[0]
+        obs = qdb.util.insert_filepaths([(fp, 1)], 1, "raw_data", "filepath",
+                                        copy=True)
+        self.assertEqual(obs, [exp_new_id])
+
+        # Check that the files have been copied correctly
+        exp_fp = join(qdb.util.get_db_files_base_dir(), "raw_data",
+                      "1_%s" % basename(fp))
+        self.assertTrue(exists(exp_fp))
+        self.assertTrue(exists(fp))
         self.files_to_remove.append(exp_fp)
 
         # Check that the filepaths have been added to the DB

--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -181,6 +181,8 @@ class DBUtilTests(TestCase):
             f.write("\n")
         self.files_to_remove.append(fp)
 
+        # The id's in the database are bigserials, i.e. they get
+        # autoincremented for each element introduced.
         exp_new_id = 1 + self.conn_handler.execute_fetchone(
             "SELECT count(1) FROM qiita.filepath")[0]
         obs = qdb.util.insert_filepaths([(fp, 1)], 1, "raw_data", "filepath",

--- a/qiita_pet/handlers/compute.py
+++ b/qiita_pet/handlers/compute.py
@@ -73,7 +73,6 @@ class CreateRawData(BaseHandler):
         study_id = pt.study_id
 
         artifact_id = self.get_argument('artifact_id', default=None)
-        print artifact_id
 
         if artifact_id is not None:
             job_id = self.create_from_artifact(pt, artifact_id)

--- a/qiita_pet/handlers/compute.py
+++ b/qiita_pet/handlers/compute.py
@@ -6,7 +6,7 @@ from moi import r_client
 from .base_handlers import BaseHandler
 
 from qiita_ware.context import submit
-from qiita_ware.dispatchable import create_raw_data
+from qiita_ware.dispatchable import create_raw_data, copy_raw_data
 from qiita_core.util import execute_as_transaction
 from qiita_db.util import get_mountpoint
 from qiita_db.metadata_template.prep_template import PrepTemplate
@@ -27,10 +27,7 @@ class ComputeCompleteHandler(BaseHandler):
 
 
 class CreateRawData(BaseHandler):
-    @authenticated
-    @execute_as_transaction
-    def post(self):
-        pt_id = self.get_argument('prep_template_id')
+    def create_from_scratch(self, prep_template, study_id):
         raw_data_filetype = self.get_argument('filetype')
         barcodes_str = self.get_argument('barcodes')
         forward_reads_str = self.get_argument('forward')
@@ -38,9 +35,6 @@ class CreateRawData(BaseHandler):
         fasta_str = self.get_argument('fasta')
         qual_str = self.get_argument('qual')
         reverse_reads_str = self.get_argument('reverse')
-
-        pt = PrepTemplate(pt_id)
-        study_id = pt.study_id
 
         def _split(x):
             return x.split(',') if x else []
@@ -64,8 +58,27 @@ class CreateRawData(BaseHandler):
                     if exists(ft):
                         filepaths.append((ft, filetype))
 
-        job_id = submit(self.current_user.id, create_raw_data,
-                        raw_data_filetype, pt, filepaths)
+        return submit(self.current_user.id, create_raw_data, raw_data_filetype,
+                      prep_template, filepaths)
+
+    def create_from_artifact(self, prep_template, artifact_id):
+        return submit(self.current_user.id, copy_raw_data,
+                      prep_template, artifact_id)
+
+    @authenticated
+    @execute_as_transaction
+    def post(self):
+        pt_id = self.get_argument('prep_template_id')
+        pt = PrepTemplate(pt_id)
+        study_id = pt.study_id
+
+        artifact_id = self.get_argument('artifact_id', default=None)
+        print artifact_id
+
+        if artifact_id is not None:
+            job_id = self.create_from_artifact(pt, artifact_id)
+        else:
+            job_id = self.create_from_scratch(pt, study_id)
 
         self.render('compute_wait.html',
                     job_id=job_id, title='Adding raw data',

--- a/qiita_pet/handlers/study_handlers/description_handlers.py
+++ b/qiita_pet/handlers/study_handlers/description_handlers.py
@@ -287,39 +287,6 @@ class StudyDescriptionHandler(BaseHandler):
         callback((msg, msg_level, None, None, None))
 
     @execute_as_transaction
-    def add_raw_data(self, study, user, callback):
-        """Adds an existing raw data to the study
-
-        Parameters
-        ----------
-        study : Study
-            The current study object
-        user : User
-            The current user object
-        callback : function
-            The callback function to call with the results once the processing
-            is done
-        """
-        msg = "Raw data successfully added"
-        msg_level = "success"
-
-        # Get the arguments to add the raw data
-        pt_id = self.get_argument('prep_template_id')
-        raw_data_id = self.get_argument('raw_data_id')
-
-        prep_template = PrepTemplate(pt_id)
-        artifact = Artifact(raw_data_id)
-
-        try:
-            prep_template.artifact = artifact
-        except QiitaDBError as e:
-            msg = html_error_message % ("adding the raw data",
-                                        str(raw_data_id), str(e))
-            msg = convert_text_html(msg)
-
-        callback((msg, msg_level, 'prep_template_tab', pt_id, None))
-
-    @execute_as_transaction
     def add_prep_template(self, study, user, callback):
         """Adds a prep template to the system
 
@@ -856,7 +823,6 @@ class StudyDescriptionHandler(BaseHandler):
             lambda: self.unspecified_action,
             process_sample_template=self.process_sample_template,
             update_sample_template=self.update_sample_template,
-            add_raw_data=self.add_raw_data,
             add_prep_template=self.add_prep_template,
             update_prep_template=self.update_prep_template,
             make_public=self.make_public,

--- a/qiita_pet/templates/study_description.html
+++ b/qiita_pet/templates/study_description.html
@@ -207,20 +207,16 @@ function add_raw_data(prep_id) {
     bootstrapAlert("You need to select a raw data used in a previous study");
   } else {
     var form = $("<form>")
-      .attr("action", window.location.href)
+      .attr("action", "/study/create_raw_data")
       .attr("method", "post")
       .append($("<input>")
         .attr("type", "hidden")
-        .attr("name", "raw_data_id")
+        .attr("name", "artifact_id")
         .attr("value", raw_data_id))
       .append($("<input>")
         .attr("type", "hidden")
         .attr("name", "prep_template_id")
-        .attr("value", prep_id))
-      .append($("<input>")
-        .attr("type", "hidden")
-        .attr("name", "action")
-        .attr("value", "add_raw_data"));
+        .attr("value", prep_id));
     $("body").append(form);
     form.submit();
   }

--- a/qiita_ware/dispatchable.py
+++ b/qiita_ware/dispatchable.py
@@ -35,3 +35,8 @@ def create_raw_data(filetype, prep_template, filepaths):
     Needs to be dispachable because it moves large files
     """
     Artifact.create(filepaths, filetype, prep_template=prep_template)
+
+
+def copy_raw_data(prep_template, artifact_id):
+    """Creates a new raw data by copying from artifact_id"""
+    Artifact.copy(Artifact(artifact_id), prep_template)


### PR DESCRIPTION
This PR allows to "share" the raw data objects across multiple studies correctly.

The main issue is that artifacts are designed to not be shared across studies. Instead, the artifact is copied.

This is currently copying the files. I think this is fine for now, but at some point we need to modify the interface and some parts of the code so we can share files across artifacts. It will be complicated to do this right now w/o major changes to the interface, which I don't think is worth given the on-going refactoring.