### PR TITLE
Artifact lineage

### DIFF
--- a/qiita_db/artifact.py
+++ b/qiita_db/artifact.py
@@ -663,6 +663,7 @@ class Artifact(qdb.base.QiitaObject):
             The graph representing the artifact lineage stored in `edge_list`
         """
         lineage = nx.DiGraph()
+        # In case the edge list is empty, only 'self' is present in the graph
         if edge_list:
             # By creating all the artifacts here we are saving DB calls
             nodes = {a_id: Artifact(a_id)

--- a/qiita_db/artifact.py
+++ b/qiita_db/artifact.py
@@ -655,7 +655,7 @@ class Artifact(qdb.base.QiitaObject):
         Parameters
         ----------
         edge_list : list of (int, int)
-            List of (artifact_id, parent_artifact_id)
+            List of (parent_artifact_id, artifact_id)
 
         Returns
         -------
@@ -669,7 +669,7 @@ class Artifact(qdb.base.QiitaObject):
             nodes = {a_id: Artifact(a_id)
                      for a_id in set(chain.from_iterable(edge_list))}
 
-            for child, parent in edge_list:
+            for parent, child in edge_list:
                 lineage.add_edge(nodes[parent], nodes[child])
         else:
             lineage.add_node(self)
@@ -686,7 +686,8 @@ class Artifact(qdb.base.QiitaObject):
             The ancestors of the artifact
         """
         with qdb.sql_connection.TRN:
-            sql = "SELECT * FROM qiita.artifact_ancestry(%s)"
+            sql = """SELECT parent_id, artifact_id
+                     FROM qiita.artifact_ancestry(%s)"""
             qdb.sql_connection.TRN.add(sql, [self.id])
             edges = qdb.sql_connection.TRN.execute_fetchindex()
         return self._create_lineage_graph_from_edge_list(edges)
@@ -701,7 +702,8 @@ class Artifact(qdb.base.QiitaObject):
             The descendants of the artifact
         """
         with qdb.sql_connection.TRN:
-            sql = "SELECT * FROM qiita.artifact_descendants(%s)"
+            sql = """SELECT parent_id, artifact_id
+                     FROM qiita.artifact_descendants(%s)"""
             qdb.sql_connection.TRN.add(sql, [self.id])
             edges = qdb.sql_connection.TRN.execute_fetchindex()
         return self._create_lineage_graph_from_edge_list(edges)

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -496,6 +496,14 @@ class ArtifactTests(TestCase):
         exp_parents = [qdb.artifact.Artifact(2)]
         self.assertEqual(qdb.artifact.Artifact(4).parents, exp_parents)
 
+    def test_children(self):
+        exp = [qdb.artifact.Artifact(2), qdb.artifact.Artifact(3)]
+        self.assertEqual(qdb.artifact.Artifact(1).children, exp)
+        exp = [qdb.artifact.Artifact(4)]
+        self.assertEqual(qdb.artifact.Artifact(2).children, exp)
+        self.assertEqual(qdb.artifact.Artifact(3).children, [])
+        self.assertEqual(qdb.artifact.Artifact(4).children, [])
+
     def test_prep_templates(self):
         self.assertEqual(
             qdb.artifact.Artifact(1).prep_templates,

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -14,6 +14,7 @@ from os.path import exists, join, basename
 from functools import partial
 
 import pandas as pd
+import networkx as nx
 from biom import example_table as et
 from biom.util import biom_open
 
@@ -495,6 +496,79 @@ class ArtifactTests(TestCase):
 
         exp_parents = [qdb.artifact.Artifact(2)]
         self.assertEqual(qdb.artifact.Artifact(4).parents, exp_parents)
+
+    def test_ancestors(self):
+        obs = qdb.artifact.Artifact(1).ancestors
+        self.assertTrue(isinstance(obs, nx.DiGraph))
+        obs_nodes = obs.nodes()
+        self.assertEqual(obs_nodes, [qdb.artifact.Artifact(1)])
+        obs_edges = obs.edges()
+        self.assertEqual(obs_edges, [])
+
+        obs = qdb.artifact.Artifact(2).ancestors
+        self.assertTrue(isinstance(obs, nx.DiGraph))
+        obs_nodes = obs.nodes()
+        exp_nodes = [qdb.artifact.Artifact(1), qdb.artifact.Artifact(2)]
+        self.assertItemsEqual(obs_nodes, exp_nodes)
+        obs_edges = obs.edges()
+        exp_edges = [(qdb.artifact.Artifact(1), qdb.artifact.Artifact(2))]
+        self.assertItemsEqual(obs_edges, exp_edges)
+
+        obs = qdb.artifact.Artifact(3).ancestors
+        self.assertTrue(isinstance(obs, nx.DiGraph))
+        obs_nodes = obs.nodes()
+        exp_nodes = [qdb.artifact.Artifact(1), qdb.artifact.Artifact(3)]
+        self.assertItemsEqual(obs_nodes, exp_nodes)
+        obs_edges = obs.edges()
+        exp_edges = [(qdb.artifact.Artifact(1), qdb.artifact.Artifact(3))]
+        self.assertItemsEqual(obs_edges, exp_edges)
+
+        obs = qdb.artifact.Artifact(4).ancestors
+        self.assertTrue(isinstance(obs, nx.DiGraph))
+        obs_nodes = obs.nodes()
+        exp_nodes = [qdb.artifact.Artifact(1), qdb.artifact.Artifact(2),
+                     qdb.artifact.Artifact(4)]
+        self.assertItemsEqual(obs_nodes, exp_nodes)
+        obs_edges = obs.edges()
+        exp_edges = [(qdb.artifact.Artifact(1), qdb.artifact.Artifact(2)),
+                     (qdb.artifact.Artifact(2), qdb.artifact.Artifact(4))]
+        self.assertItemsEqual(obs_edges, exp_edges)
+
+    def test_descendants(self):
+        obs = qdb.artifact.Artifact(1).descendants
+        self.assertTrue(isinstance(obs, nx.DiGraph))
+        obs_nodes = obs.nodes()
+        exp_nodes = [qdb.artifact.Artifact(1), qdb.artifact.Artifact(2),
+                     qdb.artifact.Artifact(3), qdb.artifact.Artifact(4)]
+        self.assertItemsEqual(obs_nodes, exp_nodes)
+        obs_edges = obs.edges()
+        exp_edges = [(qdb.artifact.Artifact(1), qdb.artifact.Artifact(2)),
+                     (qdb.artifact.Artifact(1), qdb.artifact.Artifact(3)),
+                     (qdb.artifact.Artifact(2), qdb.artifact.Artifact(4))]
+        self.assertItemsEqual(obs_edges, exp_edges)
+
+        obs = qdb.artifact.Artifact(2).descendants
+        self.assertTrue(isinstance(obs, nx.DiGraph))
+        obs_nodes = obs.nodes()
+        exp_nodes = [qdb.artifact.Artifact(2), qdb.artifact.Artifact(4)]
+        self.assertItemsEqual(obs_nodes, exp_nodes)
+        obs_edges = obs.edges()
+        exp_edges = [(qdb.artifact.Artifact(2), qdb.artifact.Artifact(4))]
+        self.assertItemsEqual(obs_edges, exp_edges)
+
+        obs = qdb.artifact.Artifact(3).descendants
+        self.assertTrue(isinstance(obs, nx.DiGraph))
+        obs_nodes = obs.nodes()
+        self.assertItemsEqual(obs_nodes, [qdb.artifact.Artifact(3)])
+        obs_edges = obs.edges()
+        self.assertItemsEqual(obs_edges, [])
+
+        obs = qdb.artifact.Artifact(4).descendants
+        self.assertTrue(isinstance(obs, nx.DiGraph))
+        obs_nodes = obs.nodes()
+        self.assertItemsEqual(obs_nodes, [qdb.artifact.Artifact(4)])
+        obs_edges = obs.edges()
+        self.assertItemsEqual(obs_edges, [])
 
     def test_children(self):
         exp = [qdb.artifact.Artifact(2), qdb.artifact.Artifact(3)]

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -507,7 +507,7 @@ class ArtifactTests(TestCase):
     def test_create_lineage_graph_from_edge_list(self):
         tester = qdb.artifact.Artifact(1)
         obs = tester._create_lineage_graph_from_edge_list(
-            [(2, 1), (4, 2), (3, 1), (4, 3)])
+            [(1, 2), (2, 4), (1, 3), (3, 4)])
         self.assertTrue(isinstance(obs, nx.DiGraph))
         exp = [qdb.artifact.Artifact(1), qdb.artifact.Artifact(2),
                qdb.artifact.Artifact(3), qdb.artifact.Artifact(4)]

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -497,6 +497,27 @@ class ArtifactTests(TestCase):
         exp_parents = [qdb.artifact.Artifact(2)]
         self.assertEqual(qdb.artifact.Artifact(4).parents, exp_parents)
 
+    def test_create_lineage_graph_from_edge_list_empty(self):
+        tester = qdb.artifact.Artifact(1)
+        obs = tester._create_lineage_graph_from_edge_list([])
+        self.assertTrue(isinstance(obs, nx.DiGraph))
+        self.assertEqual(obs.nodes(), [tester])
+        self.assertEqual(obs.edges(), [])
+
+    def test_create_lineage_graph_from_edge_list(self):
+        tester = qdb.artifact.Artifact(1)
+        obs = tester._create_lineage_graph_from_edge_list(
+            [(2, 1), (4, 2), (3, 1), (4, 3)])
+        self.assertTrue(isinstance(obs, nx.DiGraph))
+        exp = [qdb.artifact.Artifact(1), qdb.artifact.Artifact(2),
+               qdb.artifact.Artifact(3), qdb.artifact.Artifact(4)]
+        self.assertItemsEqual(obs.nodes(), exp)
+        exp = [(qdb.artifact.Artifact(1), qdb.artifact.Artifact(2)),
+               (qdb.artifact.Artifact(2), qdb.artifact.Artifact(4)),
+               (qdb.artifact.Artifact(1), qdb.artifact.Artifact(3)),
+               (qdb.artifact.Artifact(3), qdb.artifact.Artifact(4))]
+        self.assertItemsEqual(obs.edges(), exp)
+
     def test_ancestors(self):
         obs = qdb.artifact.Artifact(1).ancestors
         self.assertTrue(isinstance(obs, nx.DiGraph))

--- a/qiita_db/test/test_sql.py
+++ b/qiita_db/test/test_sql.py
@@ -146,15 +146,15 @@ class TestSQL(TestCase):
         exp = []
         self.assertEqual(obs, exp)
 
-    def test_artifact_ancestry_child(self):
-        """Correctly returns the ancestry of a child node"""
+    def test_artifact_ancestry_leaf(self):
+        """Correctly returns the ancestry of a leaf artifact"""
         sql = "SELECT * FROM qiita.artifact_ancestry(%s)"
         obs = self.conn_handler.execute_fetchall(sql, [4])
         exp = [[4, 2], [2, 1]]
         self.assertItemsEqual(obs, exp)
 
-    def test_artifact_ancestry_child_multiple_parents(self):
-        """Correctly returns the ancestry of a child node with multiple parents
+    def test_artifact_ancestry_leaf_multiple_parents(self):
+        """Correctly returns the ancestry of a leaf artifact w multiple parents
         """
         sql = """INSERT INTO qiita.parent_artifact (artifact_id, parent_id)
                  VALUES (%s, %s)"""
@@ -163,6 +163,36 @@ class TestSQL(TestCase):
         obs = self.conn_handler.execute_fetchall(sql, [4])
         exp = [[4, 3], [3, 1], [4, 2], [2, 1]]
         self.assertItemsEqual(obs, exp)
+
+    def test_artifact_ancestry_middle(self):
+        """Correctly returns the ancestry of an artifact in the middle of the
+        DAG"""
+        sql = "SELECT * FROM qiita.artifact_ancestry(%s)"
+        obs = self.conn_handler.execute_fetchall(sql, [2])
+        exp = [[2, 1]]
+        self.assertEqual(obs, exp)
+
+    def test_artifact_descendants_leaf(self):
+        """Correctly returns the descendants of a leaf artifact"""
+        sql = "SELECT * FROM qiita.artifact_descendants(%s)"
+        obs = self.conn_handler.execute_fetchall(sql, [4])
+        exp = []
+        self.assertEqual(obs, exp)
+
+    def test_artifact_descendants_root(self):
+        """Correctly returns the descendants of a root artifact"""
+        sql = "SELECT * FROM qiita.artifact_descendants(%s)"
+        obs = self.conn_handler.execute_fetchall(sql, [1])
+        exp = [[2, 1], [3, 1], [4, 2]]
+        self.assertItemsEqual(obs, exp)
+
+    def test_artifact_descendants_middle(self):
+        """Correctly returns the descendants of an artifact in the middle of
+        the DAG"""
+        sql = "SELECT * FROM qiita.artifact_descendants(%s)"
+        obs = self.conn_handler.execute_fetchall(sql, [2])
+        exp = [[4, 2]]
+        self.assertEqual(obs, exp)
 
 
 if __name__ == '__main__':

--- a/qiita_db/test/test_sql.py
+++ b/qiita_db/test/test_sql.py
@@ -139,6 +139,31 @@ class TestSQL(TestCase):
         exp = [[1], [new_root.id]]
         self.assertEqual(obs, exp)
 
+    def test_artifact_ancestry_root(self):
+        """Correctly returns the ancestry of a root artifact"""
+        sql = "SELECT * FROM qiita.artifact_ancestry(%s)"
+        obs = self.conn_handler.execute_fetchall(sql, [1])
+        exp = []
+        self.assertEqual(obs, exp)
+
+    def test_artifact_ancestry_child(self):
+        """Correctly returns the ancestry of a child node"""
+        sql = "SELECT * FROM qiita.artifact_ancestry(%s)"
+        obs = self.conn_handler.execute_fetchall(sql, [4])
+        exp = [[4, 2], [2, 1]]
+        self.assertItemsEqual(obs, exp)
+
+    def test_artifact_ancestry_child_multiple_parents(self):
+        """Correctly returns the ancestry of a child node with multiple parents
+        """
+        sql = """INSERT INTO qiita.parent_artifact (artifact_id, parent_id)
+                 VALUES (%s, %s)"""
+        self.conn_handler.execute(sql, [4, 3])
+        sql = "SELECT * FROM qiita.artifact_ancestry(%s)"
+        obs = self.conn_handler.execute_fetchall(sql, [4])
+        exp = [[4, 3], [3, 1], [4, 2], [2, 1]]
+        self.assertItemsEqual(obs, exp)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR adds methods to retrieve all the ancestors and descendants of a given artifact represented in a networkx directed graph in which the nodes are the artifacts themselves.

This is needed for the interface changes that @squirrelo is working on as well as for being able to propagate the status of the artifacts.