### PR TITLE
Propagate artifact visibility

### DIFF
--- a/qiita_pet/handlers/study_handlers/description_handlers.py
+++ b/qiita_pet/handlers/study_handlers/description_handlers.py
@@ -94,7 +94,7 @@ def _propagate_visibility(artifact):
 
     Notes
     -----
-    This is emulating the previous functionlity, in which the status of the
+    This is emulating the previous functionality, in which the status of the
     processed data was propagated to the preprocessed/raw data that was used
     to generate such processed data. In the current interface, only the status
     of the BIOM artifacts (processed data) can be changed, so this works as

--- a/qiita_pet/handlers/study_handlers/description_handlers.py
+++ b/qiita_pet/handlers/study_handlers/description_handlers.py
@@ -27,7 +27,7 @@ from qiita_db.metadata_template.sample_template import SampleTemplate
 from qiita_db.metadata_template.util import (load_template_to_dataframe,
                                              looks_like_qiime_mapping_file)
 from qiita_db.metadata_template.constants import SAMPLE_TEMPLATE_COLUMNS
-from qiita_db.util import convert_to_id, get_mountpoint
+from qiita_db.util import convert_to_id, get_mountpoint, infer_status
 from qiita_db.exceptions import (QiitaDBUnknownIDError, QiitaDBColumnError,
                                  QiitaDBExecutionError, QiitaDBDuplicateError,
                                  QiitaDBDuplicateHeaderError, QiitaDBError)
@@ -82,6 +82,28 @@ def _to_int(value):
     except ValueError:
         raise HTTPError(500, "%s cannot be converted to an integer" % value)
     return res
+
+
+def _propagate_visibility(artifact):
+    """Propagates the visibility of artifact to all its ancestors
+
+    Parameters
+    ----------
+    artifact : qiita_db.artifact.Artifact
+        The artifact to propagate the visibility for
+
+    Notes
+    -----
+    This is emulating the previous functionlity, in which the status of the
+    processed data was propagated to the preprocessed/raw data that was used
+    to generate such processed data. In the current interface, only the status
+    of the BIOM artifacts (processed data) can be changed, so this works as
+    expected.
+    """
+    for a in artifact.ancestors.nodes():
+        visibilities = [[c.visibility] for c in a.descendants.nodes()
+                        if c.artifact_type == 'BIOM']
+        a.visibility = infer_status(visibilities)
 
 
 class StudyDescriptionHandler(BaseHandler):
@@ -469,6 +491,7 @@ class StudyDescriptionHandler(BaseHandler):
         pd_id = int(self.get_argument('pd_id'))
         pd = Artifact(pd_id)
         pd.visibility = 'public'
+        _propagate_visibility(pd)
         msg = "Processed data set to public"
         msg_level = "success"
         callback((msg, msg_level, "processed_data_tab", pd_id, None))
@@ -491,6 +514,7 @@ class StudyDescriptionHandler(BaseHandler):
             pd_id = int(self.get_argument('pd_id'))
             pd = Artifact(pd_id)
             pd.visibility = 'private'
+            _propagate_visibility(pd)
             msg = "Processed data approved"
             msg_level = "success"
         else:
@@ -516,6 +540,7 @@ class StudyDescriptionHandler(BaseHandler):
         pd_id = int(self.get_argument('pd_id'))
         pd = Artifact(pd_id)
         pd.visibility = 'awaiting_approval'
+        _propagate_visibility(pd)
         msg = "Processed data sent to admin for approval"
         msg_level = "success"
         callback((msg, msg_level, "processed_data_tab", pd_id, None))
@@ -537,6 +562,7 @@ class StudyDescriptionHandler(BaseHandler):
         pd_id = int(self.get_argument('pd_id'))
         pd = Artifact(pd_id)
         pd.visibility = 'sandbox'
+        _propagate_visibility(pd)
         msg = "Processed data reverted to sandbox"
         msg_level = "success"
         callback((msg, msg_level, "processed_data_tab", pd_id, None))

--- a/qiita_pet/handlers/study_handlers/description_handlers.py
+++ b/qiita_pet/handlers/study_handlers/description_handlers.py
@@ -85,7 +85,7 @@ def _to_int(value):
 
 
 def _propagate_visibility(artifact):
-    """Propagates the visibility of artifact to all its ancestors
+    """Propagates the visibility of an artifact to all its ancestors
 
     Parameters
     ----------

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -173,6 +173,13 @@ class TestHelpers(TestHandlerBase):
         self.assertEqual(Artifact(2).visibility, 'private')
         self.assertEqual(Artifact(4).visibility, 'private')
 
+        a = Artifact(2)
+        a.visibility = 'public'
+        _propagate_visibility(a)
+        self.assertEqual(Artifact(1).visibility, 'private')
+        self.assertEqual(Artifact(2).visibility, 'private')
+        self.assertEqual(Artifact(4).visibility, 'private')
+
 
 class TestStudyEditorForm(TestHandlerBase):
     # TODO: add proper test for this once figure out how. Issue 567

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -5,12 +5,15 @@ from json import loads
 
 from qiita_pet.test.tornado_test_base import TestHandlerBase
 from qiita_core.exceptions import IncompetentQiitaDeveloperError
+from qiita_db.artifact import Artifact
 from qiita_db.study import StudyPerson, Study
 from qiita_db.util import get_count, check_count
 from qiita_db.user import User
 from qiita_pet.handlers.study_handlers.listing_handlers import (
     _get_shared_links_for_study, _build_study_info, _build_single_study_info,
     _build_single_proc_data_info)
+from qiita_pet.handlers.study_handlers.description_handlers import (
+    _propagate_visibility)
 
 
 class TestHelpers(TestHandlerBase):
@@ -155,6 +158,20 @@ class TestHelpers(TestHandlerBase):
                 '<a target="_blank" href="mailto:PI_dude@foo.bar">PIDude</a>',
             'proc_data_info': []})
         self.assertEqual(obs, self.exp)
+
+    def test_propagate_visibility(self):
+        a = Artifact(4)
+        a.visibility = 'public'
+        _propagate_visibility(a)
+        self.assertEqual(Artifact(1).visibility, 'public')
+        self.assertEqual(Artifact(2).visibility, 'public')
+        self.assertEqual(Artifact(4).visibility, 'public')
+
+        a.visibility = 'private'
+        _propagate_visibility(a)
+        self.assertEqual(Artifact(1).visibility, 'private')
+        self.assertEqual(Artifact(2).visibility, 'private')
+        self.assertEqual(Artifact(4).visibility, 'private')
 
 
 class TestStudyEditorForm(TestHandlerBase):


### PR DESCRIPTION
This emulates the prior functionality in which the visibility of a processed data was propagated to the previous objects.