### PR TITLE
Fix artifact delete

### DIFF
--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -290,6 +290,7 @@ class ArtifactTests(TestCase):
         test = qdb.artifact.Artifact.create(
             self.filepaths_root, "FASTQ", prep_template=self.prep_template)
         test.visibility = "public"
+        self._clean_up_files.extend([fp for _, fp, _ in test.filepaths])
         with self.assertRaises(qdb.exceptions.QiitaDBArtifactDeletionError):
             qdb.artifact.Artifact.delete(test.id)
 
@@ -311,6 +312,7 @@ class ArtifactTests(TestCase):
             can_be_submitted_to_vamps=True)
         obs.ebi_run_accessions = {'1.SKB1.640202': 'ERR1000001',
                                   '1.SKB2.640194': 'ERR1000002'}
+        self._clean_up_files.extend([fp for _, fp, _ in obs.filepaths])
         with self.assertRaises(qdb.exceptions.QiitaDBArtifactDeletionError):
             qdb.artifact.Artifact.delete(obs.id)
 
@@ -323,8 +325,46 @@ class ArtifactTests(TestCase):
             processing_parameters=parameters,
             can_be_submitted_to_ebi=True, can_be_submitted_to_vamps=True)
         obs.is_submitted_to_vamps = True
+        self._clean_up_files.extend([fp for _, fp, _ in obs.filepaths])
         with self.assertRaises(qdb.exceptions.QiitaDBArtifactDeletionError):
             qdb.artifact.Artifact.delete(obs.id)
+
+    def test_delete_error_queued_job(self):
+        test = qdb.artifact.Artifact.create(
+            self.filepaths_root, 'FASTQ', prep_template=self.prep_template)
+        self._clean_up_files.extend([fp for _, fp, _ in test.filepaths])
+        json_str = (
+            '{"input_data": %d, "max_barcode_errors": 1.5, '
+            '"barcode_type": "golay_12", "max_bad_run_length": 3, '
+            '"rev_comp": false, "phred_quality_threshold": 3, '
+            '"rev_comp_barcode": false, "rev_comp_mapping_barcodes": false, '
+            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0}'
+            % test.id)
+        qdb.processing_job.ProcessingJob.create(
+            qdb.user.User('test@foo.bar'),
+            qdb.software.Parameters.load(qdb.software.Command(1),
+                                         json_str=json_str))
+        with self.assertRaises(qdb.exceptions.QiitaDBArtifactDeletionError):
+            qdb.artifact.Artifact.delete(test.id)
+
+    def test_delete_error_running_job(self):
+        test = qdb.artifact.Artifact.create(
+            self.filepaths_root, 'FASTQ', prep_template=self.prep_template)
+        self._clean_up_files.extend([fp for _, fp, _ in test.filepaths])
+        json_str = (
+            '{"input_data": %d, "max_barcode_errors": 1.5, '
+            '"barcode_type": "golay_12", "max_bad_run_length": 3, '
+            '"rev_comp": false, "phred_quality_threshold": 3, '
+            '"rev_comp_barcode": false, "rev_comp_mapping_barcodes": false, '
+            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0}'
+            % test.id)
+        job = qdb.processing_job.ProcessingJob.create(
+            qdb.user.User('test@foo.bar'),
+            qdb.software.Parameters.load(qdb.software.Command(1),
+                                         json_str=json_str))
+        job.status = 'running'
+        with self.assertRaises(qdb.exceptions.QiitaDBArtifactDeletionError):
+            qdb.artifact.Artifact.delete(test.id)
 
     def test_delete(self):
         test = qdb.artifact.Artifact.create(


### PR DESCRIPTION
There is currently a bug in the system in which if there is an artifact with a processing job attached, it can't be deleted.

This PR allows to delete an artifact that has successful/failed processing jobs and raises a meaningful error if the artifact has queued/running jobs.

@antgonza @ElDeveloper @mortonjt a quick review is appreciated, since this bug is in master and in the live system.