### PR TITLE
Fixing template for prep deletion

### DIFF
--- a/qiita_pet/handlers/study_handlers/description_handlers.py
+++ b/qiita_pet/handlers/study_handlers/description_handlers.py
@@ -758,7 +758,7 @@ class StudyDescriptionHandler(BaseHandler):
             is done
         """
         prep_template_id = int(self.get_argument('prep_template_id'))
-        prep_id = PrepTemplate(prep_template_id).artifact.id
+        prep_id = prep_template_id
 
         try:
             PrepTemplate.delete(prep_template_id)


### PR DESCRIPTION
A bug in the interface when deleting a prep template that doesn't have any artifact.