### PR TITLE
URGENT: Fixes Issue 1619

### DIFF
--- a/qiita_pet/handlers/study_handlers/ebi_handlers.py
+++ b/qiita_pet/handlers/study_handlers/ebi_handlers.py
@@ -43,9 +43,9 @@ class EBISubmitHandler(BaseHandler):
         if not allow_submission:
             msg_list.append(
                 "Only artifacts with a single prep template can be submitted")
-        # If allow submission is already false, we technically don't need to
-        # do the following work. However, there is currently no clean way to
-        # fix this using the current structure, so we perform the work as we
+        # If allow_submission is already false, we technically don't need to
+        # do the following work. However, there is no clean way to fix this
+        # using the current structure, so we perform the work as we
         # did not fail.
         # We currently support only one prep template for submission, so
         # grabbing the first one

--- a/qiita_pet/handlers/study_handlers/ebi_handlers.py
+++ b/qiita_pet/handlers/study_handlers/ebi_handlers.py
@@ -38,7 +38,7 @@ class EBISubmitHandler(BaseHandler):
                                      "get/EBISubmitHandler: %s!" % user.id)
 
         prep_templates = preprocessed_data.prep_templates
-        allow_submission = len(prep_templates) > 1
+        allow_submission = len(prep_templates) == 1
         msg_list = ["Submission to EBI disabled:"]
         if allow_submission:
             msg_list.append(

--- a/qiita_pet/handlers/study_handlers/ebi_handlers.py
+++ b/qiita_pet/handlers/study_handlers/ebi_handlers.py
@@ -40,7 +40,7 @@ class EBISubmitHandler(BaseHandler):
         prep_templates = preprocessed_data.prep_templates
         allow_submission = len(prep_templates) == 1
         msg_list = ["Submission to EBI disabled:"]
-        if allow_submission:
+        if not allow_submission:
             msg_list.append(
                 "Only artifacts with a single prep template can be submitted")
         # If allow submission is already false, we technically don't need to
@@ -79,7 +79,7 @@ class EBISubmitHandler(BaseHandler):
         st_missing_cols = sample_template.check_restrictions(
             [SAMPLE_TEMPLATE_COLUMNS['EBI']])
         allow_submission = (len(pt_missing_cols) == 0 and
-                            len(st_missing_cols) == 0) or allow_submission
+                            len(st_missing_cols) == 0 and allow_submission)
 
         if not allow_submission:
             if len(pt_missing_cols) > 0:

--- a/qiita_pet/handlers/study_handlers/ebi_handlers.py
+++ b/qiita_pet/handlers/study_handlers/ebi_handlers.py
@@ -12,8 +12,6 @@ from tornado.web import authenticated, HTTPError
 from qiita_ware.context import submit
 from qiita_ware.demux import stats as demux_stats
 from qiita_ware.dispatchable import submit_to_ebi
-from qiita_db.metadata_template.prep_template import PrepTemplate
-from qiita_db.metadata_template.sample_template import SampleTemplate
 from qiita_db.metadata_template.constants import (SAMPLE_TEMPLATE_COLUMNS,
                                                   PREP_TEMPLATE_COLUMNS)
 from qiita_db.study import Study
@@ -39,14 +37,26 @@ class EBISubmitHandler(BaseHandler):
                 raise HTTPError(403, "No permissions of admin, "
                                      "get/EBISubmitHandler: %s!" % user.id)
 
-        prep_template = PrepTemplate(preprocessed_data.prep_template)
-        sample_template = SampleTemplate(preprocessed_data.study)
-        study = Study(preprocessed_data.study)
+        prep_templates = preprocessed_data.prep_templates
+        allow_submission = len(prep_templates) > 1
+        msg_list = ["Submission to EBI disabled:"]
+        if allow_submission:
+            msg_list.append(
+                "Only artifacts with a single prep template can be submitted")
+        # If allow submission is already false, we technically don't need to
+        # do the following work. However, there is currently no clean way to
+        # fix this using the current structure, so we perform the work as we
+        # did not fail.
+        # We currently support only one prep template for submission, so
+        # grabbing the first one
+        prep_template = prep_templates[0]
+        study = preprocessed_data.study
+        sample_template = study.sample_template
         stats = [('Number of samples', len(prep_template)),
                  ('Number of metadata headers',
                   len(sample_template.categories()))]
 
-        demux = [path for _, path, ftype in preprocessed_data.get_filepaths()
+        demux = [path for _, path, ftype in preprocessed_data.filepaths
                  if ftype == 'preprocessed_demux']
         demux_length = len(demux)
 
@@ -69,10 +79,9 @@ class EBISubmitHandler(BaseHandler):
         st_missing_cols = sample_template.check_restrictions(
             [SAMPLE_TEMPLATE_COLUMNS['EBI']])
         allow_submission = (len(pt_missing_cols) == 0 and
-                            len(st_missing_cols) == 0)
+                            len(st_missing_cols) == 0) or allow_submission
 
         if not allow_submission:
-            msg_list = ["Submission to EBI disabled due to missing columns:"]
             if len(pt_missing_cols) > 0:
                 msg_list.append("Columns missing in prep template: %s"
                                 % ', '.join(pt_missing_cols))

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -530,10 +530,24 @@ class TestMetadataSummaryHandler(TestHandlerBase):
                                                    'study_id': 237})
         self.assertEqual(response.code, 500)
 
+from qiita_pet.handlers.base_handlers import BaseHandler
+from mock import Mock
+
 
 class TestEBISubmitHandler(TestHandlerBase):
-    # TODO: add proper test for this once figure out how. Issue 567
-    pass
+    # TODO: add proper test for this once figure out how. Issue 567 (post)
+    def test_get(self):
+        BaseHandler.get_current_user = Mock(return_value=User("admin@foo.bar"))
+        response = self.get("/ebi_submission/2")
+        self.assertEqual(response.code, 200)
+
+    def test_get_no_admin(self):
+        response = self.get("/ebi_submission/2")
+        self.assertEqual(response.code, 403)
+
+    def test_get_no_exist(self):
+        response = self.get('/ebi_submission/100')
+        self.assertEqual(response.code, 404)
 
 
 class TestDelete(TestHandlerBase):

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -3,6 +3,9 @@
 from unittest import main
 from json import loads
 
+from mock import Mock
+
+from qiita_pet.handlers.base_handlers import BaseHandler
 from qiita_pet.test.tornado_test_base import TestHandlerBase
 from qiita_core.exceptions import IncompetentQiitaDeveloperError
 from qiita_db.artifact import Artifact
@@ -529,9 +532,6 @@ class TestMetadataSummaryHandler(TestHandlerBase):
         response = self.get('/metadata_summary/', {'sample_template': 237,
                                                    'study_id': 237})
         self.assertEqual(response.code, 500)
-
-from qiita_pet.handlers.base_handlers import BaseHandler
-from mock import Mock
 
 
 class TestEBISubmitHandler(TestHandlerBase):

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -535,7 +535,7 @@ class TestMetadataSummaryHandler(TestHandlerBase):
 
 
 class TestEBISubmitHandler(TestHandlerBase):
-    # TODO: add proper test for this once figure out how. Issue 567 (post)
+    # TODO: add tests for post function once we figure out how. Issue 567
     def test_get(self):
         BaseHandler.get_current_user = Mock(return_value=User("admin@foo.bar"))
         response = self.get("/ebi_submission/2")

--- a/qiita_pet/test/test_study_handlers.py
+++ b/qiita_pet/test/test_study_handlers.py
@@ -2,8 +2,12 @@
 
 from unittest import main
 from json import loads
+from os.path import exists
+from os import remove, close
+from tempfile import mkstemp
 
 from mock import Mock
+from h5py import File
 
 from qiita_pet.handlers.base_handlers import BaseHandler
 from qiita_pet.test.tornado_test_base import TestHandlerBase
@@ -17,6 +21,7 @@ from qiita_pet.handlers.study_handlers.listing_handlers import (
     _build_single_proc_data_info)
 from qiita_pet.handlers.study_handlers.description_handlers import (
     _propagate_visibility)
+from qiita_ware.demux import to_hdf5
 
 
 class TestHelpers(TestHandlerBase):
@@ -536,7 +541,25 @@ class TestMetadataSummaryHandler(TestHandlerBase):
 
 class TestEBISubmitHandler(TestHandlerBase):
     # TODO: add tests for post function once we figure out how. Issue 567
+    def setUp(self):
+        super(TestEBISubmitHandler, self).setUp()
+        self._clean_up_files = []
+
+    def tearDown(self):
+        for fp in self._clean_up_files:
+            if exists(fp):
+                remove(fp)
+
     def test_get(self):
+        demux_fp = [fp for _, fp, fp_type in Artifact(2).filepaths
+                    if fp_type == 'preprocessed_demux'][0]
+        fd, fna_fp = mkstemp(suffix='_seqs.fna')
+        close(fd)
+        self._clean_up_files.extend([fna_fp, demux_fp])
+        with open(fna_fp, 'w') as f:
+            f.write('>a_1 X orig_bc=X new_bc=X bc_diffs=0\nCCC')
+        with File(demux_fp, "w") as f:
+            to_hdf5(fna_fp, f)
         BaseHandler.get_current_user = Mock(return_value=User("admin@foo.bar"))
         response = self.get("/ebi_submission/2")
         self.assertEqual(response.code, 200)


### PR DESCRIPTION
This fixes issue 1619

The behavior is a bit odd in case that the artifact have more than 1 prep template (EBI submissions of these cases are not allowed) in terms that it is still providing the information of the first prep template, but this is the best that we can do as the system is right now (we shouldn't reach this page if the artifact has more than one prep template associated).

I've added a few minimal tests so at least we can check that the page is rendering correctly, so this issue doesn't appear again.