### PR TITLE
fixing error with portals

### DIFF
--- a/qiita_pet/handlers/portal.py
+++ b/qiita_pet/handlers/portal.py
@@ -63,7 +63,10 @@ class StudyPortalHandler(PortalEditBase):
         studies = map(int, self.get_arguments('selected'))
         action = self.get_argument('action')
 
-        portal = Portal(portal)
+        try:
+            portal = Portal(portal)
+        except:
+            raise HTTPError(400, "Not valid portal: %s" % portal)
         try:
             with warnings.catch_warnings(record=True) as warns:
                 if action == "Add":

--- a/qiita_pet/handlers/portal.py
+++ b/qiita_pet/handlers/portal.py
@@ -29,7 +29,7 @@ class PortalEditBase(BaseHandler):
     @execute_as_transaction
     def get_info(self, portal="QIITA"):
         # Add the portals and, optionally, checkbox to the information
-        studies = Portal(portal).get_studies()
+        studies = [s.id for s in Portal(portal).get_studies()]
         if not studies:
             return []
 

--- a/qiita_pet/test/test_portal.py
+++ b/qiita_pet/test/test_portal.py
@@ -13,41 +13,39 @@ class TestPortal(TestHandlerBase):
         response = self.get('/admin/portals/studies/')
         self.assertEqual(response.code, 200)
 
-    def test_post(self):
+    def test_post_add(self):
         BaseHandler.get_current_user = Mock(return_value=User("admin@foo.bar"))
         response = self.post('/admin/portals/studies/', {'portal': 'EMP',
                                                          'selected': [1],
                                                          'action': 'Add'})
         self.assertEqual(response.code, 200)
 
+    def test_post_remove(self):
+        BaseHandler.get_current_user = Mock(return_value=User("admin@foo.bar"))
         response = self.post('/admin/portals/studies/', {'portal': 'EMP',
                                                          'selected': [1],
                                                          'action': 'Remove'})
         self.assertEqual(response.code, 200)
 
-    def test_get_errors(self):
-        # not valid user
+    def test_get_not_valid_user(self):
         response = self.get('/admin/portals/studies/')
         self.assertEqual(response.code, 403)
 
-    def test_post_errors(self):
-        # not valid user
+    def test_post_not_valid_user(self):
         response = self.post('/admin/portals/studies/', {'portal': 'EMP',
                                                          'selected': [1],
                                                          'action': 'Add'})
         self.assertEqual(response.code, 403)
 
-        # making an admin the valid user so the next tests actually test
-        # what they should
+    def test_post_not_valid_portal(self):
         BaseHandler.get_current_user = Mock(return_value=User("admin@foo.bar"))
-
-        # not valid portal
         response = self.post('/admin/portals/studies/', {'portal': 'not-valid',
                                                          'selected': [1],
                                                          'action': 'Add'})
         self.assertEqual(response.code, 400)
 
-        # not a valid action
+    def test_post_not_valid_action(self):
+        BaseHandler.get_current_user = Mock(return_value=User("admin@foo.bar"))
         response = self.post('/admin/portals/studies/', {'portal': 'EMP',
                                                          'selected': [1],
                                                          'action': 'Error'})

--- a/qiita_pet/test/test_portal.py
+++ b/qiita_pet/test/test_portal.py
@@ -12,7 +12,7 @@ class TestPortal(TestHandlerBase):
         BaseHandler.get_current_user = Mock(return_value=User("admin@foo.bar"))
         response = self.get('/admin/portals/studies/')
         self.assertEqual(response.code, 200)
-        self.assertNotEqual(response.code, "")
+        self.assertNotEqual(response.body, "")
 
     def test_post_add(self):
         BaseHandler.get_current_user = Mock(return_value=User("admin@foo.bar"))
@@ -20,7 +20,7 @@ class TestPortal(TestHandlerBase):
                                                          'selected': [1],
                                                          'action': 'Add'})
         self.assertEqual(response.code, 200)
-        self.assertNotEqual(response.code, "")
+        self.assertNotEqual(response.body, "")
 
     def test_post_remove(self):
         BaseHandler.get_current_user = Mock(return_value=User("admin@foo.bar"))
@@ -28,7 +28,7 @@ class TestPortal(TestHandlerBase):
                                                          'selected': [1],
                                                          'action': 'Remove'})
         self.assertEqual(response.code, 200)
-        self.assertNotEqual(response.code, "")
+        self.assertNotEqual(response.body, "")
 
     def test_get_not_valid_user(self):
         response = self.get('/admin/portals/studies/')

--- a/qiita_pet/test/test_portal.py
+++ b/qiita_pet/test/test_portal.py
@@ -51,6 +51,20 @@ class TestPortal(TestHandlerBase):
                                                          'action': 'Error'})
         self.assertEqual(response.code, 400)
 
+    def test_get_AJAX(self):
+        BaseHandler.get_current_user = Mock(return_value=User("admin@foo.bar"))
+        page = '/admin/portals/studiesAJAX/'
+        response = self.get(page, {'sEcho': '1001', 'view-portal': 'QIITA'})
+        self.assertEqual(response.code, 200)
+
+        exp = "Identification of the Microbiomes for Cannabis Soils"
+        self.assertIn(exp, response.body)
+
+    def test_get_AJAX_not_valid_user(self):
+        page = '/admin/portals/studiesAJAX/'
+        response = self.get(page, {'sEcho': '1001', 'view-portal': 'QIITA'})
+        self.assertEqual(response.code, 403)
+
 
 if __name__ == "__main__":
     main()

--- a/qiita_pet/test/test_portal.py
+++ b/qiita_pet/test/test_portal.py
@@ -1,0 +1,58 @@
+from unittest import main
+from qiita_pet.test.tornado_test_base import TestHandlerBase
+
+from mock import Mock
+
+from qiita_db.user import User
+from qiita_pet.handlers.base_handlers import BaseHandler
+
+
+class TestPortal(TestHandlerBase):
+    def test_get(self):
+        BaseHandler.get_current_user = Mock(return_value=User("admin@foo.bar"))
+        response = self.get('/admin/portals/studies/')
+        self.assertEqual(response.code, 200)
+
+    def test_post(self):
+        BaseHandler.get_current_user = Mock(return_value=User("admin@foo.bar"))
+        response = self.post('/admin/portals/studies/', {'portal': 'EMP',
+                                                         'selected': [1],
+                                                         'action': 'Add'})
+        self.assertEqual(response.code, 200)
+
+        response = self.post('/admin/portals/studies/', {'portal': 'EMP',
+                                                         'selected': [1],
+                                                         'action': 'Remove'})
+        self.assertEqual(response.code, 200)
+
+    def test_get_errors(self):
+        # not valid user
+        response = self.get('/admin/portals/studies/')
+        self.assertEqual(response.code, 403)
+
+    def test_post_errors(self):
+        # not valid user
+        response = self.post('/admin/portals/studies/', {'portal': 'EMP',
+                                                         'selected': [1],
+                                                         'action': 'Add'})
+        self.assertEqual(response.code, 403)
+
+        # making an admin the valid user so the next tests actually test
+        # what they should
+        BaseHandler.get_current_user = Mock(return_value=User("admin@foo.bar"))
+
+        # not valid portal
+        response = self.post('/admin/portals/studies/', {'portal': 'not-valid',
+                                                         'selected': [1],
+                                                         'action': 'Add'})
+        self.assertEqual(response.code, 400)
+
+        # not a valid action
+        response = self.post('/admin/portals/studies/', {'portal': 'EMP',
+                                                         'selected': [1],
+                                                         'action': 'Error'})
+        self.assertEqual(response.code, 400)
+
+
+if __name__ == "__main__":
+    main()

--- a/qiita_pet/test/test_portal.py
+++ b/qiita_pet/test/test_portal.py
@@ -12,6 +12,7 @@ class TestPortal(TestHandlerBase):
         BaseHandler.get_current_user = Mock(return_value=User("admin@foo.bar"))
         response = self.get('/admin/portals/studies/')
         self.assertEqual(response.code, 200)
+        self.assertNotEqual(response.code, "")
 
     def test_post_add(self):
         BaseHandler.get_current_user = Mock(return_value=User("admin@foo.bar"))
@@ -19,6 +20,7 @@ class TestPortal(TestHandlerBase):
                                                          'selected': [1],
                                                          'action': 'Add'})
         self.assertEqual(response.code, 200)
+        self.assertNotEqual(response.code, "")
 
     def test_post_remove(self):
         BaseHandler.get_current_user = Mock(return_value=User("admin@foo.bar"))

--- a/qiita_pet/test/test_portal.py
+++ b/qiita_pet/test/test_portal.py
@@ -28,6 +28,7 @@ class TestPortal(TestHandlerBase):
                                                          'selected': [1],
                                                          'action': 'Remove'})
         self.assertEqual(response.code, 200)
+        self.assertNotEqual(response.code, "")
 
     def test_get_not_valid_user(self):
         response = self.get('/admin/portals/studies/')


### PR DESCRIPTION
An error was identified when looking at the portals list. The error is simple to solve but no idea how to test it as the error was due to the changes we made (now returning objects vs. ids). BTW I think we had a discussion about the get_info method before and agreed that it was fine to just work with ids. 