### PR TITLE
fix #1626

### DIFF
--- a/qiita_db/analysis.py
+++ b/qiita_db/analysis.py
@@ -395,13 +395,9 @@ class Analysis(qdb.base.QiitaStatusObject):
 
             for biom, filepath in viewitems(bioms):
                 table = load_table(filepath)
-                # remove the samples from the sets as they
-                # are found in the table
-                proc_data_ids = set(sample['Processed_id']
-                                    for sample in table.metadata())
                 ids = set(table.ids())
-                for proc_data_id in proc_data_ids:
-                    all_samples[proc_data_id] = all_samples[proc_data_id] - ids
+                for k in all_samples:
+                    all_samples[k] = all_samples[k] - ids
 
             # what's left are unprocessed samples, so return
             return all_samples


### PR DESCRIPTION
This fixes issue #1626. 

<b>Background:</b> Biom tables generated for the analysis store from which artifact (processed file) the samples come from. Then, it will check this info and compare it with the samples in the analysis (from the DB). The idea behind this is to be able to do a summary per artifact of missing samples.
<b>Issue:</b> During the move to artifacts the biom tables weren't updated.
<b>Solution:</b> Obviously, we could update all tables to match the new artifact ids. However, this seems like the wrong way to go about this. We can simply get the sample names from the table and then compare them the ones stored in the database. This is fine as we assume unique names and if we merge 2 tables with the same sample name, they will be deleted from both of them. 

The only open question is if we still need to populate the metadata field in the generated biom ... 