### PR TITLE
Reduce tests running time for qiita_db

### DIFF
--- a/qiita_db/handlers/tests/test_processing_job.py
+++ b/qiita_db/handlers/tests/test_processing_job.py
@@ -159,6 +159,7 @@ class CompleteHandlerTests(OauthTestingBase):
         super(CompleteHandlerTests, self).setUp()
 
     def tearDown(self):
+        super(CompleteHandlerTests, self).tearDown()
         for fp in self._clean_up_files:
             if exists(fp):
                 remove(fp)

--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -563,7 +563,8 @@ class MetadataTemplate(qdb.base.QiitaObject):
 
             if missing:
                 warning_msg.append(
-                    "%s: %s" % (restriction.error_msg, ', '.join(missing)))
+                    "%s: %s" % (restriction.error_msg,
+                                ', '.join(sorted(missing))))
 
         if warning_msg:
             warnings.warn(
@@ -712,7 +713,7 @@ class MetadataTemplate(qdb.base.QiitaObject):
             if new_cols:
                 warnings.warn(
                     "The following columns have been added to the existing"
-                    " template: %s" % ", ".join(new_cols),
+                    " template: %s" % ", ".join(sorted(new_cols)),
                     qdb.exceptions.QiitaDBWarning)
                 # If we are adding new columns, add them first (simplifies
                 # code). Sorting the new columns to enforce an order

--- a/qiita_db/metadata_template/prep_template.py
+++ b/qiita_db/metadata_template/prep_template.py
@@ -538,7 +538,8 @@ class PrepTemplate(MetadataTemplate):
                     "Some columns required to generate a QIIME-compliant "
                     "mapping file are not present in the template. A "
                     "placeholder value (XXQIITAXX) has been used to populate "
-                    "these columns. Missing columns: %s" % ', '.join(missing),
+                    "these columns. Missing columns: %s"
+                    % ', '.join(sorted(missing)),
                     qdb.exceptions.QiitaDBWarning)
 
             # Gets the orginal mapping columns and readjust the order to comply

--- a/qiita_db/test/test_analysis.py
+++ b/qiita_db/test/test_analysis.py
@@ -3,7 +3,6 @@ from os import remove
 from os.path import exists, join
 from datetime import datetime
 from shutil import move
-import warnings
 
 from future.utils import viewitems
 from biom import load_table
@@ -321,8 +320,9 @@ class TestAnalysis(TestCase):
              'SKB7.640196': {'barcode': 'AAAAAAAAAAAG'}},
             orient='index')
 
-        warnings.simplefilter('ignore', qdb.exceptions.QiitaDBWarning)
-        pt = qdb.metadata_template.prep_template.PrepTemplate.create(
+        pt = npt.assert_warns(
+            qdb.exceptions.QiitaDBWarning,
+            qdb.metadata_template.prep_template.PrepTemplate.create,
             metadata, study, "16S")
 
         mp = qdb.util.get_mountpoint("processed_data")[0][1]

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -7,6 +7,7 @@
 # -----------------------------------------------------------------------------
 
 from unittest import TestCase, main
+from copy import deepcopy
 
 import networkx as nx
 
@@ -14,8 +15,7 @@ from qiita_core.util import qiita_test_checker
 import qiita_db as qdb
 
 
-@qiita_test_checker()
-class CommandTests(TestCase):
+class CommandTestsReadOnly(TestCase):
     def setUp(self):
         self.software = qdb.software.Software(1)
         self.parameters = {
@@ -28,56 +28,6 @@ class CommandTests(TestCase):
             self.software, "donotexists"))
         self.assertTrue(qdb.software.Command.exists(
             self.software, "Split libraries"))
-
-    def test_create_error_no_parameters(self):
-        with self.assertRaises(qdb.exceptions.QiitaDBError):
-            qdb.software.Command.create(
-                self.software, "Test command", "Testing command", {})
-
-        with self.assertRaises(qdb.exceptions.QiitaDBError):
-            qdb.software.Command.create(
-                self.software, "Test command", "Testing command", None)
-
-    def test_create_error_malformed_params(self):
-        self.parameters['req_param'].append('breaking_the_format')
-        with self.assertRaises(qdb.exceptions.QiitaDBError):
-            qdb.software.Command.create(
-                self.software, "Test command", "Testing command",
-                self.parameters)
-
-    def test_create_error_unsupported_parameter_type(self):
-        self.parameters['opt_int_param'][0] = 'unsupported_type'
-        with self.assertRaises(qdb.exceptions.QiitaDBError):
-            qdb.software.Command.create(
-                self.software, "Test command", "Testing command",
-                self.parameters)
-
-    def test_create_error_bad_default_choice(self):
-        self.parameters['opt_choice_param'][1] = 'unsupported_choice'
-        with self.assertRaises(qdb.exceptions.QiitaDBError):
-            qdb.software.Command.create(
-                self.software, "Test command", "Testing command",
-                self.parameters)
-
-    def test_create_error_duplicate(self):
-        with self.assertRaises(qdb.exceptions.QiitaDBDuplicateError):
-            qdb.software.Command.create(
-                self.software, "Split libraries",
-                "This is a command for testing", self.parameters)
-
-    def test_create(self):
-        obs = qdb.software.Command.create(
-            self.software, "Test Command", "This is a command for testing",
-            self.parameters)
-        self.assertEqual(obs.name, "Test Command")
-        self.assertEqual(obs.description, "This is a command for testing")
-        self.assertEqual(obs.parameters, self.parameters)
-        exp_required = {'req_param': 'string'}
-        self.assertEqual(obs.required_parameters, exp_required)
-        exp_optional = {
-            'opt_int_param': ['integer', '4'],
-            'opt_choice_param': ['choice:["opt1", "opt2"]', 'opt1']}
-        self.assertEqual(obs.optional_parameters, exp_optional)
 
     def test_software(self):
         self.assertEqual(qdb.software.Command(1).software,
@@ -188,35 +138,70 @@ class CommandTests(TestCase):
 
 
 @qiita_test_checker()
-class SoftwareTests(TestCase):
+class CommandTests(TestCase):
+    def setUp(self):
+        self.software = qdb.software.Software(1)
+        self.parameters = {
+            'req_param': ['string', None],
+            'opt_int_param': ['integer', '4'],
+            'opt_choice_param': ['choice:["opt1", "opt2"]', 'opt1']}
+
+    def test_create_error(self):
+        #  no parameters
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.software.Command.create(
+                self.software, "Test command", "Testing command", {})
+
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.software.Command.create(
+                self.software, "Test command", "Testing command", None)
+
+        # malformed params
+        parameters = deepcopy(self.parameters)
+        parameters['req_param'].append('breaking_the_format')
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.software.Command.create(
+                self.software, "Test command", "Testing command",
+                parameters)
+
+        # unsupported parameter type
+        parameters = deepcopy(self.parameters)
+        parameters['opt_int_param'][0] = 'unsupported_type'
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.software.Command.create(
+                self.software, "Test command", "Testing command",
+                parameters)
+
+        # bad default choice
+        parameters = deepcopy(self.parameters)
+        parameters['opt_choice_param'][1] = 'unsupported_choice'
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.software.Command.create(
+                self.software, "Test command", "Testing command",
+                parameters)
+
+        # duplicate
+        with self.assertRaises(qdb.exceptions.QiitaDBDuplicateError):
+            qdb.software.Command.create(
+                self.software, "Split libraries",
+                "This is a command for testing", self.parameters)
+
     def test_create(self):
-        obs = qdb.software.Software.create(
-            "New Software", "0.1.0",
-            "This is adding a new software for testing", "env_name",
-            "start_plugin")
-        self.assertEqual(obs.name, "New Software")
-        self.assertEqual(obs.version, "0.1.0")
-        self.assertEqual(obs.description,
-                         "This is adding a new software for testing")
-        self.assertEqual(obs.commands, [])
-        self.assertEqual(obs.publications, [])
-        self.assertEqual(obs.environment_script, 'env_name')
-        self.assertEqual(obs.start_script, 'start_plugin')
+        obs = qdb.software.Command.create(
+            self.software, "Test Command", "This is a command for testing",
+            self.parameters)
+        self.assertEqual(obs.name, "Test Command")
+        self.assertEqual(obs.description, "This is a command for testing")
+        self.assertEqual(obs.parameters, self.parameters)
+        exp_required = {'req_param': 'string'}
+        self.assertEqual(obs.required_parameters, exp_required)
+        exp_optional = {
+            'opt_int_param': ['integer', '4'],
+            'opt_choice_param': ['choice:["opt1", "opt2"]', 'opt1']}
+        self.assertEqual(obs.optional_parameters, exp_optional)
 
-    def test_create_with_publications(self):
-        exp_publications = [['10.1000/nmeth.f.101', '12345678']]
-        obs = qdb.software.Software.create(
-            "Published Software", "1.0.0", "Another testing software",
-            "env_name", "start_plugin",
-            publications=exp_publications)
-        self.assertEqual(obs.name, "Published Software")
-        self.assertEqual(obs.version, "1.0.0")
-        self.assertEqual(obs.description, "Another testing software")
-        self.assertEqual(obs.commands, [])
-        self.assertEqual(obs.publications, exp_publications)
-        self.assertEqual(obs.environment_script, 'env_name')
-        self.assertEqual(obs.start_script, 'start_plugin')
 
+class SoftwareTestsReadOnly(TestCase):
     def test_name(self):
         self.assertEqual(qdb.software.Software(1).name, "QIIME")
 
@@ -238,6 +223,52 @@ class SoftwareTests(TestCase):
         self.assertEqual(qdb.software.Software(1).publications,
                          [['10.1038/nmeth.f.303', '20383131']])
 
+    def test_environment_script(self):
+        tester = qdb.software.Software(1)
+        self.assertEqual(tester.environment_script, 'source activate qiita')
+
+    def test_start_script(self):
+        tester = qdb.software.Software(1)
+        self.assertEqual(tester.start_script, 'start_target_gene')
+
+    def test_default_workflows(self):
+        obs = list(qdb.software.Software(1).default_workflows)
+        exp = [qdb.software.DefaultWorkflow(1),
+               qdb.software.DefaultWorkflow(2),
+               qdb.software.DefaultWorkflow(3)]
+        self.assertEqual(obs, exp)
+
+
+@qiita_test_checker()
+class SoftwareTests(TestCase):
+    def test_create(self):
+        obs = qdb.software.Software.create(
+            "New Software", "0.1.0",
+            "This is adding a new software for testing", "env_name",
+            "start_plugin")
+        self.assertEqual(obs.name, "New Software")
+        self.assertEqual(obs.version, "0.1.0")
+        self.assertEqual(obs.description,
+                         "This is adding a new software for testing")
+        self.assertEqual(obs.commands, [])
+        self.assertEqual(obs.publications, [])
+        self.assertEqual(obs.environment_script, 'env_name')
+        self.assertEqual(obs.start_script, 'start_plugin')
+
+    # create with publications
+        exp_publications = [['10.1000/nmeth.f.101', '12345678']]
+        obs = qdb.software.Software.create(
+            "Published Software", "1.0.0", "Another testing software",
+            "env_name", "start_plugin",
+            publications=exp_publications)
+        self.assertEqual(obs.name, "Published Software")
+        self.assertEqual(obs.version, "1.0.0")
+        self.assertEqual(obs.description, "Another testing software")
+        self.assertEqual(obs.commands, [])
+        self.assertEqual(obs.publications, exp_publications)
+        self.assertEqual(obs.environment_script, 'env_name')
+        self.assertEqual(obs.start_script, 'start_plugin')
+
     def test_add_publications(self):
         tester = qdb.software.Software(1)
         self.assertEqual(tester.publications,
@@ -247,24 +278,8 @@ class SoftwareTests(TestCase):
                ['10.1000/nmeth.f.101', '12345678']]
         self.assertItemsEqual(tester.publications, exp)
 
-    def test_environment_script(self):
-        tester = qdb.software.Software(1)
-        self.assertEqual(tester.environment_script, 'source activate qiita')
 
-    def test_start_script(self):
-        tester = qdb.software.Software(1)
-        self.assertEqual(tester.start_script, 'start_target_gene')
-
-    def test_default_software(self):
-        obs = list(qdb.software.Software(1).default_workflows)
-        exp = [qdb.software.DefaultWorkflow(1),
-               qdb.software.DefaultWorkflow(2),
-               qdb.software.DefaultWorkflow(3)]
-        self.assertEqual(obs, exp)
-
-
-@qiita_test_checker()
-class DefaultParametersTests(TestCase):
+class DefaultParametersTestsReadOnly(TestCase):
     def test_exists(self):
         cmd = qdb.software.Command(1)
         obs = qdb.software.DefaultParameters.exists(
@@ -283,6 +298,24 @@ class DefaultParametersTests(TestCase):
             max_barcode_errors=1.5)
         self.assertFalse(obs)
 
+    def test_name(self):
+        self.assertEqual(qdb.software.DefaultParameters(1).name, "Defaults")
+
+    def test_values(self):
+        exp = {'min_per_read_length_fraction': 0.75,
+               'max_barcode_errors': 1.5, 'max_bad_run_length': 3,
+               'rev_comp': False, 'phred_quality_threshold': 3,
+               'rev_comp_barcode': False, 'sequence_max_n': 0,
+               'barcode_type': 'golay_12', 'rev_comp_mapping_barcodes': False}
+        self.assertEqual(qdb.software.DefaultParameters(1).values, exp)
+
+    def test_command(self):
+        self.assertEqual(
+            qdb.software.DefaultParameters(1).command, qdb.software.Command(1))
+
+
+@qiita_test_checker()
+class DefaultParametersTests(TestCase):
     def test_create(self):
         cmd = qdb.software.Command(1)
         obs = qdb.software.DefaultParameters.create(
@@ -301,23 +334,7 @@ class DefaultParametersTests(TestCase):
         self.assertEqual(obs.values, exp)
         self.assertEqual(obs.command, cmd)
 
-    def test_name(self):
-        self.assertEqual(qdb.software.DefaultParameters(1).name, "Defaults")
 
-    def test_values(self):
-        exp = {'min_per_read_length_fraction': 0.75,
-               'max_barcode_errors': 1.5, 'max_bad_run_length': 3,
-               'rev_comp': False, 'phred_quality_threshold': 3,
-               'rev_comp_barcode': False, 'sequence_max_n': 0,
-               'barcode_type': 'golay_12', 'rev_comp_mapping_barcodes': False}
-        self.assertEqual(qdb.software.DefaultParameters(1).values, exp)
-
-    def test_command(self):
-        self.assertEqual(
-            qdb.software.DefaultParameters(1).command, qdb.software.Command(1))
-
-
-@qiita_test_checker()
 class ParametersTests(TestCase):
     def test_init_error(self):
         with self.assertRaises(
@@ -477,7 +494,6 @@ class ParametersTests(TestCase):
         self.assertEqual(obs, exp)
 
 
-@qiita_test_checker()
 class DefaultWorkflowNodeTests(TestCase):
     def test_command(self):
         obs = qdb.software.DefaultWorkflowNode(1)
@@ -494,7 +510,6 @@ class DefaultWorkflowNodeTests(TestCase):
         self.assertEqual(obs.parameters, qdb.software.DefaultParameters(10))
 
 
-@qiita_test_checker()
 class DefaultWorkflowEdgeTests(TestCase):
     def test_connections(self):
         tester = qdb.software.DefaultWorkflowEdge(1)
@@ -502,7 +517,6 @@ class DefaultWorkflowEdgeTests(TestCase):
         self.assertEqual(obs, [['demultiplexed', 'input_data']])
 
 
-@qiita_test_checker()
 class DefaultWorkflowTests(TestCase):
     def test_name(self):
         self.assertEqual(qdb.software.DefaultWorkflow(1).name,

--- a/qiita_pet/handlers/api_proxy/prep_template.py
+++ b/qiita_pet/handlers/api_proxy/prep_template.py
@@ -207,7 +207,7 @@ def prep_template_post_req(study_id, user_id, prep_template, data_type,
             # join all the warning messages into one. Note that this info
             # will be ignored if an exception is raised
             if warns:
-                msg = '; '.join([str(w.message) for w in warns])
+                msg = '\n'.join(set(str(w.message) for w in warns))
                 status = 'warning'
     except Exception as e:
         # Some error occurred while processing the prep template

--- a/qiita_pet/handlers/api_proxy/tests/test_artifact.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_artifact.py
@@ -25,51 +25,9 @@ from qiita_pet.handlers.api_proxy.artifact import (
     artifact_delete_req, artifact_types_get_req, artifact_post_req)
 
 
-@qiita_test_checker()
-class TestArtifactAPI(TestCase):
-    database = True
-
-    def setUp(self):
-        uploads_path = get_mountpoint('uploads')[0][1]
-        # Create prep test file to point at
-        self.update_fp = join(uploads_path, '1', 'update.txt')
-        with open(self.update_fp, 'w') as f:
-            f.write("""sample_name\tnew_col\n1.SKD6.640190\tnew_value\n""")
-
-    def tearDown(self):
-        Artifact(1).visibility = 'private'
-        if exists(self.update_fp):
-            remove(self.update_fp)
-
-        # Replace file if removed as part of function testing
-        uploads_path = get_mountpoint('uploads')[0][1]
-        fp = join(uploads_path, '1', 'uploaded_file.txt')
-        if not exists(fp):
-            with open(fp, 'w') as f:
-                f.write('')
-
+class TestArtifactAPIReadOnly(TestCase):
     def test_artifact_get_req_no_access(self):
         obs = artifact_get_req('demo@microbio.me', 1)
-        exp = {'status': 'error',
-               'message': 'User does not have access to study'}
-        self.assertEqual(obs, exp)
-
-    def test_artifact_delete_req(self):
-        obs = artifact_delete_req(3, 'test@foo.bar')
-        exp = {'status': 'success', 'message': ''}
-        self.assertEqual(obs, exp)
-
-        with self.assertRaises(QiitaDBUnknownIDError):
-            Artifact(3)
-
-    def test_artifact_delete_req_error(self):
-        obs = artifact_delete_req(1, 'test@foo.bar')
-        exp = {'status': 'error',
-               'message': 'Cannot delete artifact 1: it has children: 2, 3'}
-        self.assertEqual(obs, exp)
-
-    def test_artifact_delete_req_no_access(self):
-        obs = artifact_delete_req(3, 'demo@microbio.me')
         exp = {'status': 'error',
                'message': 'User does not have access to study'}
         self.assertEqual(obs, exp)
@@ -95,6 +53,94 @@ class TestArtifactAPI(TestCase):
                     '1_s_G1_L001_sequences_barcodes.fastq.gz'),
                     'raw_barcodes')]
                }
+        self.assertEqual(obs, exp)
+
+    def test_artifact_graph_get_req_ancestors(self):
+        obs = artifact_graph_get_req(1, 'ancestors', 'test@foo.bar')
+        exp = {'status': 'success',
+               'message': '',
+               'edge_list': [],
+               'node_labels': [(1, 'Raw data 1 - FASTQ')]}
+        self.assertEqual(obs, exp)
+
+    def test_artifact_graph_get_req_descendants(self):
+        obs = artifact_graph_get_req(1, 'descendants', 'test@foo.bar')
+        exp = {'status': 'success',
+               'message': '',
+               'node_labels': [(1, 'Raw data 1 - FASTQ'),
+                               (3, 'Demultiplexed 2 - Demultiplexed'),
+                               (2, 'Demultiplexed 1 - Demultiplexed'),
+                               (4, 'BIOM - BIOM'),
+                               (5, 'BIOM - BIOM')],
+               'edge_list': [(1, 3), (1, 2), (2, 5), (2, 4)]}
+        self.assertItemsEqual(obs, exp)
+
+    def test_artifact_graph_get_req_no_access(self):
+        obs = artifact_graph_get_req(1, 'ancestors', 'demo@microbio.me')
+        exp = {'status': 'error',
+               'message': 'User does not have access to study'}
+        self.assertEqual(obs, exp)
+
+    def test_artifact_graph_get_req_bad_direction(self):
+        obs = artifact_graph_get_req(1, 'WRONG', 'test@foo.bar')
+        exp = {'status': 'error', 'message': 'Unknown directon WRONG'}
+        self.assertEqual(obs, exp)
+
+    def test_artifact_types_get_req(self):
+        obs = artifact_types_get_req()
+        exp = {'message': '',
+               'status': 'success',
+               'types': [['BIOM', 'BIOM table'],
+                         ['Demultiplexed', 'Demultiplexed and QC sequeneces'],
+                         ['FASTA', None],
+                         ['FASTA_Sanger', None],
+                         ['FASTQ', None],
+                         ['SFF', None],
+                         ['per_sample_FASTQ', None]]}
+
+        self.assertEqual(obs['message'], exp['message'])
+        self.assertEqual(obs['status'], exp['status'])
+        self.assertItemsEqual(obs['types'], exp['types'])
+
+
+@qiita_test_checker()
+class TestArtifactAPI(TestCase):
+    def setUp(self):
+        uploads_path = get_mountpoint('uploads')[0][1]
+        # Create prep test file to point at
+        self.update_fp = join(uploads_path, '1', 'update.txt')
+        with open(self.update_fp, 'w') as f:
+            f.write("""sample_name\tnew_col\n1.SKD6.640190\tnew_value\n""")
+
+    def tearDown(self):
+        if exists(self.update_fp):
+            remove(self.update_fp)
+
+        # Replace file if removed as part of function testing
+        uploads_path = get_mountpoint('uploads')[0][1]
+        fp = join(uploads_path, '1', 'uploaded_file.txt')
+        if not exists(fp):
+            with open(fp, 'w') as f:
+                f.write('')
+
+    def test_artifact_delete_req(self):
+        obs = artifact_delete_req(3, 'test@foo.bar')
+        exp = {'status': 'success', 'message': ''}
+        self.assertEqual(obs, exp)
+
+        with self.assertRaises(QiitaDBUnknownIDError):
+            Artifact(3)
+
+    def test_artifact_delete_req_error(self):
+        obs = artifact_delete_req(1, 'test@foo.bar')
+        exp = {'status': 'error',
+               'message': 'Cannot delete artifact 1: it has children: 2, 3'}
+        self.assertEqual(obs, exp)
+
+    def test_artifact_delete_req_no_access(self):
+        obs = artifact_delete_req(3, 'demo@microbio.me')
+        exp = {'status': 'error',
+               'message': 'User does not have access to study'}
         self.assertEqual(obs, exp)
 
     def test_artifact_post_req(self):
@@ -159,54 +205,6 @@ class TestArtifactAPI(TestCase):
         exp = {'status': 'error',
                'message': 'Unknown visiblity value: BADSTAT'}
         self.assertEqual(obs, exp)
-
-    def test_artifact_graph_get_req_ancestors(self):
-        obs = artifact_graph_get_req(1, 'ancestors', 'test@foo.bar')
-        exp = {'status': 'success',
-               'message': '',
-               'edge_list': [],
-               'node_labels': [(1, 'Raw data 1 - FASTQ')]}
-        self.assertEqual(obs, exp)
-
-    def test_artifact_graph_get_req_descendants(self):
-        obs = artifact_graph_get_req(1, 'descendants', 'test@foo.bar')
-        exp = {'status': 'success',
-               'message': '',
-               'node_labels': [(1, 'Raw data 1 - FASTQ'),
-                               (3, 'Demultiplexed 2 - Demultiplexed'),
-                               (2, 'Demultiplexed 1 - Demultiplexed'),
-                               (4, 'BIOM - BIOM'),
-                               (5, 'BIOM - BIOM')],
-               'edge_list': [(1, 3), (1, 2), (2, 5), (2, 4)]}
-        self.assertItemsEqual(obs, exp)
-
-    def test_artifact_graph_get_req_no_access(self):
-        obs = artifact_graph_get_req(1, 'ancestors', 'demo@microbio.me')
-        exp = {'status': 'error',
-               'message': 'User does not have access to study'}
-        self.assertEqual(obs, exp)
-
-    def test_artifact_types_get_req(self):
-        obs = artifact_types_get_req()
-        exp = {'message': '',
-               'status': 'success',
-               'types': [['BIOM', 'BIOM table'],
-                         ['Demultiplexed', 'Demultiplexed and QC sequeneces'],
-                         ['FASTA', None],
-                         ['FASTA_Sanger', None],
-                         ['FASTQ', None],
-                         ['SFF', None],
-                         ['per_sample_FASTQ', None]]}
-
-        self.assertEqual(obs['message'], exp['message'])
-        self.assertEqual(obs['status'], exp['status'])
-        self.assertItemsEqual(obs['types'], exp['types'])
-
-    def test_artifact_graph_get_req_bad_direction(self):
-        obs = artifact_graph_get_req(1, 'WRONG', 'test@foo.bar')
-        exp = {'status': 'error', 'message': 'Unknown directon WRONG'}
-        self.assertEqual(obs, exp)
-
 
 if __name__ == "__main__":
     main()

--- a/qiita_pet/handlers/api_proxy/tests/test_artifact.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_artifact.py
@@ -13,7 +13,6 @@ from datetime import datetime
 import pandas as pd
 import numpy.testing as npt
 
-from qiita_core.qiita_settings import qiita_config
 from qiita_core.util import qiita_test_checker
 from qiita_db.artifact import Artifact
 from qiita_db.metadata_template.prep_template import PrepTemplate
@@ -47,9 +46,9 @@ class TestArtifactAPIReadOnly(TestCase):
                'is_submitted_vamps': False,
                'parents': [],
                'filepaths': [
-                   (1, join(qiita_config.base_data_dir, 'raw_data',
+                   (1, join(get_mountpoint('raw_data')[0][1],
                     '1_s_G1_L001_sequences.fastq.gz'), 'raw_forward_seqs'),
-                   (2,  join(qiita_config.base_data_dir, 'raw_data',
+                   (2,  join(get_mountpoint('raw_data')[0][1],
                     '1_s_G1_L001_sequences_barcodes.fastq.gz'),
                     'raw_barcodes')]
                }

--- a/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
@@ -14,12 +14,11 @@ from random import choice
 import pandas as pd
 import numpy.testing as npt
 
-from qiita_core.qiita_settings import qiita_config
 from qiita_core.util import qiita_test_checker
 from qiita_db.metadata_template.prep_template import PrepTemplate
 from qiita_db.ontology import Ontology
 from qiita_db.study import Study
-from qiita_db.util import get_count
+from qiita_db.util import get_count, get_mountpoint
 from qiita_db.exceptions import QiitaDBWarning
 from qiita_pet.handlers.api_proxy.prep_template import (
     prep_template_summary_get_req, prep_template_post_req,
@@ -119,10 +118,10 @@ class TestPrepAPIReadOnly(TestCase):
         exp = {'status': 'success',
                'message': '',
                'filepaths': [
-                   (15, join(qiita_config.base_data_dir,
-                             'templates/1_prep_1_19700101-000000.txt')),
-                   (16, join(qiita_config.base_data_dir,
-                             'templates/1_prep_1_qiime_19700101-000000.txt'))]}
+                   (15, join(get_mountpoint('templates')[0][1],
+                             '1_prep_1_19700101-000000.txt')),
+                   (16, join(get_mountpoint('templates')[0][1],
+                             '1_prep_1_qiime_19700101-000000.txt'))]}
         self.assertItemsEqual(obs, exp)
 
     def test_prep_template_filepaths_get_req_no_access(self):
@@ -224,7 +223,7 @@ class TestPrepAPIReadOnly(TestCase):
 class TestPrepAPI(TestCase):
     def setUp(self):
         # Create test file to point update tests at
-        self.update_fp = join(qiita_config.base_data_dir, 'uploads', '1',
+        self.update_fp = join(get_mountpoint("uploads")[0][1], '1',
                               'update.txt')
         with open(self.update_fp, 'w') as f:
             f.write("""sample_name\tnew_col\n1.SKD6.640190\tnew_value\n""")
@@ -232,8 +231,7 @@ class TestPrepAPI(TestCase):
     def tear_down(self):
         remove(self.update_fp)
 
-        fp = join(qiita_config.base_data_dir, 'uploads', '1',
-                  'uploaded_file.txt')
+        fp = join(get_mountpoint("uploads")[0][1], '1', 'uploaded_file.txt')
         if not exists(fp):
             with open(fp, 'w') as f:
                 f.write('')

--- a/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
@@ -275,23 +275,22 @@ class TestPrepAPI(TestCase):
                                      '16S')
         exp = {'status': 'warning',
                'message': 'Sample names were already prefixed with the study '
-                          'id.; Some functionality will be disabled due to '
+                          'id.\nSome functionality will be disabled due to '
                           'missing columns:\n\tDemultiplexing with multiple '
                           'input files disabled. If your raw data includes '
                           'multiple raw input files, you will not be able to '
-                          'preprocess your raw data: primer, run_prefix, '
-                          'barcode;\n\tDemultiplexing disabled. You will not '
-                          'be able to preprocess your raw data: primer, '
-                          'barcode;\n\tEBI submission disabled: center_name, '
-                          'instrument_model, platform, '
-                          'library_construction_protocol, '
-                          'experiment_design_description, primer.\nSee the '
-                          'Templates tutorial for a description of these '
-                          'fields.; Some columns required to generate a '
+                          'preprocess your raw data: barcode, primer, '
+                          'run_prefix;\n\tDemultiplexing disabled. You will '
+                          'not be able to preprocess your raw data: barcode, '
+                          'primer;\n\tEBI submission disabled: center_name, '
+                          'experiment_design_description, instrument_model, '
+                          'library_construction_protocol, platform, primer.'
+                          '\nSee the Templates tutorial for a description of '
+                          'these fields.\nSome columns required to generate a '
                           'QIIME-compliant mapping file are not present in the'
                           ' template. A placeholder value (XXQIITAXX) has been'
                           ' used to populate these columns. Missing columns: '
-                          'LinkerPrimerSequence, BarcodeSequence',
+                          'BarcodeSequence, LinkerPrimerSequence',
                'file': 'update.txt',
                'id': new_id}
         self.assertItemsEqual(obs['message'].split('\n'),

--- a/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
@@ -29,42 +29,7 @@ from qiita_pet.handlers.api_proxy.prep_template import (
     _check_prep_template_exists)
 
 
-@qiita_test_checker()
-class TestPrepAPI(TestCase):
-    def setUp(self):
-        # Create test file to point update tests at
-        self.update_fp = join(qiita_config.base_data_dir, 'uploads', '1',
-                              'update.txt')
-        with open(self.update_fp, 'w') as f:
-            f.write("""sample_name\tnew_col\n1.SKD6.640190\tnew_value\n""")
-
-    def tear_down(self):
-        remove(self.update_fp)
-
-        fp = join(qiita_config.base_data_dir, 'uploads', '1',
-                  'uploaded_file.txt')
-        if not exists(fp):
-            with open(fp, 'w') as f:
-                f.write('')
-
-    def test_process_investigation_type(self):
-        obs = _process_investigation_type('Metagenomics', '', '')
-        self.assertEqual(obs, 'Metagenomics')
-
-    def test_process_investigation_type_user_term(self):
-        _process_investigation_type('Other', 'New Type', 'userterm')
-        obs = _process_investigation_type('Other', 'userterm', '')
-        self.assertEqual(obs, 'userterm')
-
-    def test_process_investigation_type_new_term(self):
-        randstr = ''.join([choice(ascii_letters) for x in range(30)])
-        obs = _process_investigation_type('Other', 'New Type', randstr)
-        self.assertEqual(obs, randstr)
-
-        # Make sure New Type added
-        ontology = Ontology(999999999)
-        self.assertIn(randstr, ontology.user_defined_terms)
-
+class TestPrepAPIReadOnly(TestCase):
     def test_check_prep_template_exists(self):
         obs = _check_prep_template_exists(1)
         self.assertEqual(obs, {'status': 'success', 'message': ''})
@@ -83,21 +48,6 @@ class TestPrepAPI(TestCase):
                        'Synthetic Genomics', 'Transcriptome Analysis',
                        'Whole Genome Sequencing', 'Other'],
                'User': [],
-               'status': 'success',
-               'message': ''}
-        self.assertEqual(obs, exp)
-
-    def test_ena_ontology_get_req_user_terms(self):
-        _process_investigation_type('Other', 'New Type', 'userterm')
-
-        obs = ena_ontology_get_req()
-        exp = {'ENA': ['Cancer Genomics', 'Epigenetics', 'Exome Sequencing',
-                       'Forensic or Paleo-genomics', 'Gene Regulation Study',
-                       'Metagenomics', 'Pooled Clone Sequencing',
-                       'Population Genomics', 'RNASeq', 'Resequencing',
-                       'Synthetic Genomics', 'Transcriptome Analysis',
-                       'Whole Genome Sequencing', 'Other'],
-               'User': ['userterm'],
                'status': 'success',
                'message': ''}
         self.assertEqual(obs, exp)
@@ -163,148 +113,6 @@ class TestPrepAPI(TestCase):
         obs = prep_template_get_req(3100, 'test@foo.bar')
         self.assertEqual(obs, {'status': 'error',
                                'message': 'Prep template 3100 does not exist'})
-
-    def test_prep_template_post_req(self):
-        new_id = get_count('qiita.prep_template') + 1
-        obs = prep_template_post_req(1, 'test@foo.bar', 'update.txt',
-                                     '16S')
-        exp = {'status': 'warning',
-               'message': 'Sample names were already prefixed with the study '
-                          'id.; Some functionality will be disabled due to '
-                          'missing columns:\n\tDemultiplexing with multiple '
-                          'input files disabled. If your raw data includes '
-                          'multiple raw input files, you will not be able to '
-                          'preprocess your raw data: primer, run_prefix, '
-                          'barcode;\n\tDemultiplexing disabled. You will not '
-                          'be able to preprocess your raw data: primer, '
-                          'barcode;\n\tEBI submission disabled: center_name, '
-                          'instrument_model, platform, '
-                          'library_construction_protocol, '
-                          'experiment_design_description, primer.\nSee the '
-                          'Templates tutorial for a description of these '
-                          'fields.; Some columns required to generate a '
-                          'QIIME-compliant mapping file are not present in the'
-                          ' template. A placeholder value (XXQIITAXX) has been'
-                          ' used to populate these columns. Missing columns: '
-                          'LinkerPrimerSequence, BarcodeSequence',
-               'file': 'update.txt',
-               'id': new_id}
-        self.assertEqual(obs['status'], exp['status'])
-        self.assertItemsEqual(obs['message'].split('\n'),
-                              exp['message'].split('\n'))
-        self.assertEqual(obs['file'], exp['file'])
-        self.assertEqual(obs['id'], exp['id'])
-
-        # Make sure new prep template added
-        prep = PrepTemplate(new_id)
-        self.assertEqual(prep.data_type(), '16S')
-        self.assertEqual([x for x in prep.keys()], ['1.SKD6.640190'])
-        self.assertEqual([x._to_dict() for x in prep.values()],
-                         [{'new_col': 'new_value'}])
-
-    def test_prep_template_post_req_no_access(self):
-        obs = prep_template_post_req(1, 'demo@microbio.me', 'filepath', '16S')
-        exp = {'status': 'error',
-               'message': 'User does not have access to study'}
-        self.assertEqual(obs, exp)
-
-    def test_prep_template_post_req_bad_filepath(self):
-        obs = prep_template_post_req(1, 'test@foo.bar', 'badfilepath', '16S')
-        exp = {'status': 'error',
-               'message': 'file does not exist',
-               'file': 'badfilepath'}
-        self.assertEqual(obs, exp)
-
-    def test_prep_template_post_req_no_exists(self):
-        obs = prep_template_post_req(3100, 'test@foo.bar', 'update.txt',
-                                     '16S')
-        self.assertEqual(obs, {'status': 'error',
-                               'message': 'Study does not exist'})
-
-    def test_prep_template_put_req(self):
-        obs = prep_template_put_req(1, 'test@foo.bar',
-                                    'uploaded_file.txt')
-        exp = {'status': 'error',
-               'message': 'Empty file passed!',
-               'file': 'uploaded_file.txt'}
-        self.assertEqual(obs, exp)
-
-    def test_prep_template_put_req_warning(self):
-        obs = prep_template_put_req(1, 'test@foo.bar', 'update.txt')
-        exp = {'status': 'warning',
-               'message': 'Sample names were already prefixed with the study '
-                          'id.\nThe following columns have been added to the '
-                          'existing template: new_col\nThere are no '
-                          'differences between the data stored in the DB and '
-                          'the new data provided',
-               'file': 'update.txt'}
-        self.assertEqual(obs['status'], exp['status'])
-        self.assertItemsEqual(obs['message'].split('\n'),
-                              exp['message'].split('\n'))
-        self.assertEqual(obs['file'], exp['file'])
-
-    def test_prep_put_req_inv_type(self):
-        randstr = ''.join([choice(ascii_letters) for x in range(30)])
-        obs = prep_template_put_req(1, 'test@foo.bar',
-                                    investigation_type='Other',
-                                    user_defined_investigation_type='New Type',
-                                    new_investigation_type=randstr)
-        exp = {'status': 'success',
-               'message': '',
-               'file': None}
-        self.assertEqual(obs, exp)
-
-        # Make sure New Type added
-        ontology = Ontology(999999999)
-        self.assertIn(randstr, ontology.user_defined_terms)
-
-    def test_prep_template_put_req_no_access(self):
-        obs = prep_template_put_req(1, 'demo@microbio.me', 'filepath')
-        exp = {'status': 'error',
-               'message': 'User does not have access to study'}
-        self.assertEqual(obs, exp)
-
-    def test_prep_template_put_req_bad_filepath(self):
-        obs = prep_template_put_req(1, 'test@foo.bar', 'badfilepath')
-        exp = {'status': 'error',
-               'message': 'file does not exist',
-               'file': 'badfilepath'}
-        self.assertEqual(obs, exp)
-
-    def test_prep_template_put_req_no_exists(self):
-        obs = prep_template_put_req(3100, 'test@foo.bar')
-        self.assertEqual(obs, {'status': 'error',
-                               'message': 'Prep template 3100 does not exist'})
-
-    def test_prep_template_delete_req(self):
-        template = pd.read_csv(self.update_fp, sep='\t', index_col=0)
-        new_id = get_count('qiita.prep_template') + 1
-        npt.assert_warns(QiitaDBWarning, PrepTemplate.create,
-                         template, Study(1), '16S')
-        obs = prep_template_delete_req(new_id, 'test@foo.bar')
-        exp = {'status': 'success',
-               'message': ''}
-        self.assertEqual(obs, exp)
-
-    def test_prep_template_delete_req_attached_artifact(self):
-        obs = prep_template_delete_req(1, 'test@foo.bar')
-        exp = {'status': 'error',
-               'message': "Couldn't remove prep template: Cannot remove prep "
-                          "template 1 because it has an artifact associated "
-                          "with it"}
-        self.assertEqual(obs, exp)
-
-    def test_prep_template_delete_req_no_access(self):
-        obs = prep_template_delete_req(1, 'demo@microbio.me')
-        exp = {'status': 'error',
-               'message': 'User does not have access to study'}
-        self.assertEqual(obs, exp)
-
-    def test_prep_template_delete_req_no_prep(self):
-        obs = prep_template_delete_req(3100, 'test@foo.bar')
-        exp = {'status': 'error',
-               'message': 'Prep template 3100 does not exist'}
-        self.assertEqual(obs, exp)
 
     def test_prep_template_filepaths_get_req(self):
         obs = prep_template_filepaths_get_req(1, 'test@foo.bar')
@@ -410,6 +218,200 @@ class TestPrepAPI(TestCase):
         obs = prep_template_summary_get_req(3100, 'test@foo.bar')
         self.assertEqual(obs, {'status': 'error',
                                'message': 'Prep template 3100 does not exist'})
+
+
+@qiita_test_checker()
+class TestPrepAPI(TestCase):
+    def setUp(self):
+        # Create test file to point update tests at
+        self.update_fp = join(qiita_config.base_data_dir, 'uploads', '1',
+                              'update.txt')
+        with open(self.update_fp, 'w') as f:
+            f.write("""sample_name\tnew_col\n1.SKD6.640190\tnew_value\n""")
+
+    def tear_down(self):
+        remove(self.update_fp)
+
+        fp = join(qiita_config.base_data_dir, 'uploads', '1',
+                  'uploaded_file.txt')
+        if not exists(fp):
+            with open(fp, 'w') as f:
+                f.write('')
+
+    def test_process_investigation_type(self):
+        obs = _process_investigation_type('Metagenomics', '', '')
+        self.assertEqual(obs, 'Metagenomics')
+
+    def test_process_investigation_type_user_term(self):
+        _process_investigation_type('Other', 'New Type', 'userterm')
+        obs = _process_investigation_type('Other', 'userterm', '')
+        self.assertEqual(obs, 'userterm')
+
+    def test_process_investigation_type_new_term(self):
+        randstr = ''.join([choice(ascii_letters) for x in range(30)])
+        obs = _process_investigation_type('Other', 'New Type', randstr)
+        self.assertEqual(obs, randstr)
+
+        # Make sure New Type added
+        ontology = Ontology(999999999)
+        self.assertIn(randstr, ontology.user_defined_terms)
+
+    def test_ena_ontology_get_req_user_terms(self):
+        _process_investigation_type('Other', 'New Type', 'userterm')
+
+        obs = ena_ontology_get_req()
+        exp = {'ENA': ['Cancer Genomics', 'Epigenetics', 'Exome Sequencing',
+                       'Forensic or Paleo-genomics', 'Gene Regulation Study',
+                       'Metagenomics', 'Pooled Clone Sequencing',
+                       'Population Genomics', 'RNASeq', 'Resequencing',
+                       'Synthetic Genomics', 'Transcriptome Analysis',
+                       'Whole Genome Sequencing', 'Other'],
+               'User': ['userterm'],
+               'status': 'success',
+               'message': ''}
+        self.assertEqual(obs, exp)
+
+    def test_prep_template_post_req(self):
+        new_id = get_count('qiita.prep_template') + 1
+        obs = prep_template_post_req(1, 'test@foo.bar', 'update.txt',
+                                     '16S')
+        exp = {'status': 'warning',
+               'message': 'Sample names were already prefixed with the study '
+                          'id.; Some functionality will be disabled due to '
+                          'missing columns:\n\tDemultiplexing with multiple '
+                          'input files disabled. If your raw data includes '
+                          'multiple raw input files, you will not be able to '
+                          'preprocess your raw data: primer, run_prefix, '
+                          'barcode;\n\tDemultiplexing disabled. You will not '
+                          'be able to preprocess your raw data: primer, '
+                          'barcode;\n\tEBI submission disabled: center_name, '
+                          'instrument_model, platform, '
+                          'library_construction_protocol, '
+                          'experiment_design_description, primer.\nSee the '
+                          'Templates tutorial for a description of these '
+                          'fields.; Some columns required to generate a '
+                          'QIIME-compliant mapping file are not present in the'
+                          ' template. A placeholder value (XXQIITAXX) has been'
+                          ' used to populate these columns. Missing columns: '
+                          'LinkerPrimerSequence, BarcodeSequence',
+               'file': 'update.txt',
+               'id': new_id}
+        self.assertItemsEqual(obs['message'].split('\n'),
+                              exp['message'].split('\n'))
+        self.assertEqual(obs['status'], exp['status'])
+        self.assertEqual(obs['file'], exp['file'])
+        self.assertEqual(obs['id'], exp['id'])
+
+        # Make sure new prep template added
+        prep = PrepTemplate(new_id)
+        self.assertEqual(prep.data_type(), '16S')
+        self.assertEqual([x for x in prep.keys()], ['1.SKD6.640190'])
+        self.assertEqual([x._to_dict() for x in prep.values()],
+                         [{'new_col': 'new_value'}])
+
+    def test_prep_template_post_req_no_access(self):
+        obs = prep_template_post_req(1, 'demo@microbio.me', 'filepath', '16S')
+        exp = {'status': 'error',
+               'message': 'User does not have access to study'}
+        self.assertEqual(obs, exp)
+
+    def test_prep_template_post_req_bad_filepath(self):
+        obs = prep_template_post_req(1, 'test@foo.bar', 'badfilepath', '16S')
+        exp = {'status': 'error',
+               'message': 'file does not exist',
+               'file': 'badfilepath'}
+        self.assertEqual(obs, exp)
+
+    def test_prep_template_post_req_no_exists(self):
+        obs = prep_template_post_req(3100, 'test@foo.bar', 'update.txt',
+                                     '16S')
+        self.assertEqual(obs, {'status': 'error',
+                               'message': 'Study does not exist'})
+
+    def test_prep_template_put_req(self):
+        obs = prep_template_put_req(1, 'test@foo.bar',
+                                    'uploaded_file.txt')
+        exp = {'status': 'error',
+               'message': 'Empty file passed!',
+               'file': 'uploaded_file.txt'}
+        self.assertEqual(obs, exp)
+
+    def test_prep_template_put_req_warning(self):
+        obs = prep_template_put_req(1, 'test@foo.bar', 'update.txt')
+        exp = {'status': 'warning',
+               'message': 'Sample names were already prefixed with the study '
+                          'id.\nThe following columns have been added to the '
+                          'existing template: new_col\nThere are no '
+                          'differences between the data stored in the DB and '
+                          'the new data provided',
+               'file': 'update.txt'}
+        self.assertItemsEqual(obs['message'].split('\n'),
+                              exp['message'].split('\n'))
+        self.assertEqual(obs['status'], exp['status'])
+        self.assertEqual(obs['file'], exp['file'])
+
+    def test_prep_put_req_inv_type(self):
+        randstr = ''.join([choice(ascii_letters) for x in range(30)])
+        obs = prep_template_put_req(1, 'test@foo.bar',
+                                    investigation_type='Other',
+                                    user_defined_investigation_type='New Type',
+                                    new_investigation_type=randstr)
+        exp = {'status': 'success',
+               'message': '',
+               'file': None}
+        self.assertEqual(obs, exp)
+
+        # Make sure New Type added
+        ontology = Ontology(999999999)
+        self.assertIn(randstr, ontology.user_defined_terms)
+
+    def test_prep_template_put_req_no_access(self):
+        obs = prep_template_put_req(1, 'demo@microbio.me', 'filepath')
+        exp = {'status': 'error',
+               'message': 'User does not have access to study'}
+        self.assertEqual(obs, exp)
+
+    def test_prep_template_put_req_bad_filepath(self):
+        obs = prep_template_put_req(1, 'test@foo.bar', 'badfilepath')
+        exp = {'status': 'error',
+               'message': 'file does not exist',
+               'file': 'badfilepath'}
+        self.assertEqual(obs, exp)
+
+    def test_prep_template_put_req_no_exists(self):
+        obs = prep_template_put_req(3100, 'test@foo.bar')
+        self.assertEqual(obs, {'status': 'error',
+                               'message': 'Prep template 3100 does not exist'})
+
+    def test_prep_template_delete_req(self):
+        template = pd.read_csv(self.update_fp, sep='\t', index_col=0)
+        new_id = get_count('qiita.prep_template') + 1
+        npt.assert_warns(QiitaDBWarning, PrepTemplate.create,
+                         template, Study(1), '16S')
+        obs = prep_template_delete_req(new_id, 'test@foo.bar')
+        exp = {'status': 'success',
+               'message': ''}
+        self.assertEqual(obs, exp)
+
+    def test_prep_template_delete_req_attached_artifact(self):
+        obs = prep_template_delete_req(1, 'test@foo.bar')
+        exp = {'status': 'error',
+               'message': "Couldn't remove prep template: Cannot remove prep "
+                          "template 1 because it has an artifact associated "
+                          "with it"}
+        self.assertEqual(obs, exp)
+
+    def test_prep_template_delete_req_no_access(self):
+        obs = prep_template_delete_req(1, 'demo@microbio.me')
+        exp = {'status': 'error',
+               'message': 'User does not have access to study'}
+        self.assertEqual(obs, exp)
+
+    def test_prep_template_delete_req_no_prep(self):
+        obs = prep_template_delete_req(3100, 'test@foo.bar')
+        exp = {'status': 'error',
+               'message': 'Prep template 3100 does not exist'}
+        self.assertEqual(obs, exp)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Built on top of: https://github.com/biocore/qiita/pull/1647 so review/merge that one first.

Here I split the tests of processing job, software and artifact between read/write and read/only, as well as grouping tests that are testing the same thing. This reduces the amount of times the database needs to be reset. Times:
- Artifact:  From 1m59.500s to 0m32.497s
- Processing job: From 1m34.795s to 0m30.331s
- Software: From 1m34.751s to 0m7.590s