### PR TITLE
URGENT: split mapping file fix

### DIFF
--- a/qiita_plugins/target_gene/tgp/split_libraries/tests/test_util.py
+++ b/qiita_plugins/target_gene/tgp/split_libraries/tests/test_util.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # -----------------------------------------------------------------------------
 # Copyright (c) 2014--, The Qiita Development Team.
 #
@@ -166,20 +168,20 @@ MAPPING_FILE_SINGLE = (
 MAPPING_FILE_MULT = (
     "#SampleID\tBarcodeSequence\tLinkerPrimerSequence\trun_prefix\t"
     "Description\n"
-    "Sample1\tGTCCGCAAGTTA\tGTGCCAGCMGCCGCGGTAA\tprefix_1\tTGP test\n"
-    "Sample2\tCGTAGAGCTCTC\tGTGCCAGCMGCCGCGGTAA\tprefix_2\tTGP test\n"
+    "Sample1\tGTCCGCAAGTTA\tGTGCCAGCMGCCGCGGTAA\tprefix_1\tTGP øtest\n"
+    "Sample2\tCGTAGAGCTCTC\tGTGCCAGCMGCCGCGGTAA\tprefix_2\tTGP øtest\n"
 )
 
 EXP_MAPPING_FILE_1 = (
     "#SampleID\tBarcodeSequence\tLinkerPrimerSequence\trun_prefix\t"
     "Description\n"
-    "Sample1\tGTCCGCAAGTTA\tGTGCCAGCMGCCGCGGTAA\tprefix_1\tTGP test\n"
+    "Sample1\tGTCCGCAAGTTA\tGTGCCAGCMGCCGCGGTAA\tprefix_1\tTGP øtest\n"
 )
 
 EXP_MAPPING_FILE_2 = (
     "#SampleID\tBarcodeSequence\tLinkerPrimerSequence\trun_prefix\t"
     "Description\n"
-    "Sample2\tCGTAGAGCTCTC\tGTGCCAGCMGCCGCGGTAA\tprefix_2\tTGP test\n"
+    "Sample2\tCGTAGAGCTCTC\tGTGCCAGCMGCCGCGGTAA\tprefix_2\tTGP øtest\n"
 )
 
 if __name__ == '__main__':

--- a/qiita_plugins/target_gene/tgp/split_libraries/util.py
+++ b/qiita_plugins/target_gene/tgp/split_libraries/util.py
@@ -103,7 +103,8 @@ def split_mapping_file(mapping_file, out_dir):
         for prefix, df in mf.groupby('run_prefix'):
             out_fp = path_builder('%s_mapping_file.txt' % prefix)
             output_fps.append(out_fp)
-            df.to_csv(out_fp, index_label='#SampleID', sep='\t')
+            df.to_csv(out_fp, index_label='#SampleID', sep='\t',
+                      encoding='utf-8')
     else:
         output_fps = [mapping_file]
 


### PR DESCRIPTION
The `to_csv` call in the target gene plugin was missing the encoding keyword, which was making it to fail.

This is blocking important processing.