### PR TITLE
Adding patch method to the QiitaClient

### DIFF
--- a/qiita_plugins/qiita_client/qiita_client/qiita_client.py
+++ b/qiita_plugins/qiita_client/qiita_client/qiita_client.py
@@ -261,7 +261,8 @@ class QiitaClient(object):
             The target location within the endpoint in which the operation
             should be performed
         value : str, optional
-            If `op in ['add', 'replace', 'test']`, the new value
+            If `op in ['add', 'replace', 'test']`, the new value for the given
+            path
         from_p : str, optional
             If `op in ['move', 'copy']`, the original path
         kwargs : dict

--- a/qiita_plugins/qiita_client/qiita_client/qiita_client.py
+++ b/qiita_plugins/qiita_client/qiita_client/qiita_client.py
@@ -213,7 +213,7 @@ class QiitaClient(object):
         return json_reply
 
     def get(self, url, **kwargs):
-        """Execute a get against the Qiita server
+        """Execute a get request against the Qiita server
 
         Parameters
         ----------
@@ -230,7 +230,7 @@ class QiitaClient(object):
         return self._request_retry(requests.get, url, **kwargs)
 
     def post(self, url, **kwargs):
-        """Execute a post against the Qiita server
+        """Execute a post request against the Qiita server
 
         Parameters
         ----------
@@ -245,6 +245,58 @@ class QiitaClient(object):
             The JSON response from the server
         """
         return self._request_retry(requests.post, url, **kwargs)
+
+    def patch(self, url, op, path, value=None, from_p=None, **kwargs):
+        """Executes a patch request against the Qiita server
+
+        The PATCH request is performed using the JSON PATCH specification [1]_.
+
+        Parameters
+        ----------
+        url : str
+            The url to access in the server
+        op : str, {'add', 'remove', 'replace', 'move', 'copy', 'test'}
+            The operation to perform in the PATCH request
+        path : str
+            The target location within the endpoint in which the operation
+            should be performed
+        value : str, optional
+            If `op in ['add', 'replace', 'test']`, the new value
+        from_p : str, optional
+            If `op in ['move', 'copy']`, the original path
+        kwargs : dict
+            The request kwargs
+
+        Raises
+        ------
+        ValueError
+            If `op` has one of the values ['add', 'replace', 'test'] and
+            `value` is None
+            If `op` has one of the values ['move', 'copy'] and `from_p` is None
+
+        References
+        ----------
+        .. [1] JSON PATCH spec: https://tools.ietf.org/html/rfc6902
+        """
+        if op in ['add', 'replace', 'test'] and value is None:
+            raise ValueError(
+                "Operation '%s' requires the paramater 'value'" % op)
+        if op in ['move', 'copy'] and from_p is None:
+            raise ValueError(
+                "Operation '%s' requires the parameter 'from_p'" % op)
+
+        data = {'op': op, 'path': path}
+        if value is not None:
+            data['value'] = value
+        if from_p is not None:
+            data['from'] = from_p
+
+        # Add the parameter 'data' to kwargs. Note that if it already existed
+        # it is ok to overwrite given that otherwise the call will fail and
+        # we made sure that data is correctly formatted here
+        kwargs['data'] = data
+
+        return self._request_retry(requests.patch, url, **kwargs)
 
     # The functions are shortcuts for common functionality that all plugins
     # need to implement.

--- a/qiita_plugins/qiita_client/qiita_client/tests/test_qiita_client.py
+++ b/qiita_plugins/qiita_client/qiita_client/tests/test_qiita_client.py
@@ -130,6 +130,44 @@ class QiitaClientTests(TestCase):
         self.assertIsNone(obs)
 
     @httpretty.activate
+    def test_patch(self):
+        httpretty.register_uri(
+            httpretty.PATCH,
+            "https://test_server.com/qiita_db/artifacts/1/filepaths/",
+            body='{"success": true, "error": ""}'
+        )
+        obs = self.tester.patch(
+            '/qiita_db/artifacts/1/filepaths/', 'add',
+            '/html_summary/', value='/path/to/html_summary')
+        exp = {"success": True, "error": ""}
+        self.assertEqual(obs, exp)
+
+    @httpretty.activate
+    def test_patch_error(self):
+        httpretty.register_uri(
+            httpretty.PATCH,
+            "https://test_server.com/qiita_db/artifacts/1/filepaths/",
+            status=500
+        )
+        obs = self.tester.patch(
+            '/qiita_db/artifacts/1/filepaths/', 'test',
+            '/html_summary/', value='/path/to/html_summary')
+        self.assertIsNone(obs)
+
+    def test_patch_value_error(self):
+        # Add, replace or test
+        with self.assertRaises(ValueError):
+            self.tester.patch(
+                '/qiita_db/artifacts/1/filepaths/', 'add', '/html_summary/',
+                from_p='/fastq/')
+
+        # move or copy
+        with self.assertRaises(ValueError):
+            self.tester.patch(
+                '/qiita_db/artifacts/1/filepaths/', 'move',
+                '/html_summary/', value='/path/to/html_summary')
+
+    @httpretty.activate
     def test_start_heartbeat(self):
         httpretty.register_uri(
             httpretty.POST,


### PR DESCRIPTION
This adds the PATCH method to the QiitaClient. Since QIITA is using the JSON PATCH specification for PATCH operations, this method has been specialized for such specification, encapsulating some of the burden of generating the correct request.

This is ready for review/merge since it doesn't depend in any other PR.