### PR TITLE
Add HTML summary to the artifacts

### DIFF
--- a/qiita_db/artifact.py
+++ b/qiita_db/artifact.py
@@ -10,6 +10,7 @@ from __future__ import division
 from future.utils import viewitems
 from itertools import chain
 from datetime import datetime
+from os import remove
 
 import networkx as nx
 
@@ -797,6 +798,43 @@ class Artifact(qdb.base.QiitaObject):
             res = None
 
         return res
+
+    @html_summary_fp.setter
+    def html_summary_fp(self, value):
+        """Sets the HTML summary of the artifact
+
+        Parameters
+        ----------
+        value : str
+            Path to the new HTML summary
+        """
+        with qdb.sql_connection.TRN:
+            current = self.html_summary_fp
+            if current:
+                # Delete the current HTML summary
+                fp_id = current[0]
+                fp = current[1]
+                # From the artifact_filepath table
+                sql = """DELETE FROM qiita.artifact_filepath
+                         WHERE filepath_id = %s"""
+                qdb.sql_connection.TRN.add(sql, [fp_id])
+                # From the filepath table
+                sql = "DELETE FROM qiita.filepath WHERE filepath_id=%s"
+                qdb.sql_connection.TRN.add(sql, [fp_id])
+                # And from the filesystem only after the transaction is
+                # successfully completed (after commit)
+                qdb.sql_connection.TRN.add_post_commit_func(remove, fp)
+
+            # Add the new HTML summary
+            fp_ids = qdb.util.insert_filepaths(
+                [(value, 'html_summary')], self.id, self.artifact_type,
+                "filepath")
+            sql = """INSERT INTO qiita.artifact_filepath
+                        (artifact_id, filepath_id)
+                     VALUES (%s, %s)"""
+            # We only inserted a single filepath, so using index 0
+            qdb.sql_connection.TRN.add(sql, [self.id, fp_ids[0]])
+            qdb.sql_connection.TRN.execute()
 
     @property
     def parents(self):

--- a/qiita_db/artifact.py
+++ b/qiita_db/artifact.py
@@ -776,6 +776,29 @@ class Artifact(qdb.base.QiitaObject):
             "artifact_filepath", "artifact_id", self.id, sort='ascending')
 
     @property
+    def html_summary_fp(self):
+        """Returns the HTML summary filepath
+
+        Returns
+        -------
+        tuple of (int, str)
+            The filepath id and the path to the HTML summary
+        """
+        fps = qdb.util.retrieve_filepaths("artifact_filepath", "artifact_id",
+                                          self.id, fp_type='html_summary')
+        if fps:
+            # If fps is not the empty list, then we have exactly one file
+            # retrieve_filepaths returns a list of lists of 3 values: the
+            # filepath id, the filepath and the filepath type. We don't want
+            # to return the filepath type here, so just grabbing the first and
+            # second element of the list
+            res = (fps[0][0], fps[0][1])
+        else:
+            res = None
+
+        return res
+
+    @property
     def parents(self):
         """Returns the parents of the artifact
 

--- a/qiita_db/handlers/artifact.py
+++ b/qiita_db/handlers/artifact.py
@@ -69,6 +69,46 @@ class ArtifactFilepathsHandler(OauthBaseHandler):
 
         self.write(response)
 
+    @authenticate_oauth
+    def patch(self, artifact_id):
+        """Patches the filepaths of the artifact
+
+        Parameter
+        ---------
+        artifact_id : str
+            The id of the artifact whole filepaths information is being updated
+
+        Returns
+        -------
+        dict
+            Format:
+            {'success': bool,
+             'error': str}
+            - success: whether the request is successful or not
+            - error: in case that success is false, it contains the error msg
+        """
+        req_op = self.get_argument('op')
+        req_path = self.get_argument('path')
+        req_value = self.get_argument('value')
+
+        if req_op == 'add':
+            req_path = [v for v in req_path.split('/') if v]
+            if len(req_path) != 1 or req_path[0] != 'html_summary':
+                success = False
+                error_msg = 'Incorrect path parameter value'
+            else:
+                artifact, success, error_msg = _get_artifact(artifact_id)
+                if success:
+                    artifact.html_summary_fp = req_value
+        else:
+            success = False
+            error_msg = ('Operation "%s" not supported. Current supported '
+                         'operations: add' % req_op)
+
+        response = {'success': success, 'error': error_msg}
+
+        self.write(response)
+
 
 class ArtifactMappingHandler(OauthBaseHandler):
     @authenticate_oauth

--- a/qiita_db/handlers/artifact.py
+++ b/qiita_db/handlers/artifact.py
@@ -76,7 +76,7 @@ class ArtifactFilepathsHandler(OauthBaseHandler):
         Parameter
         ---------
         artifact_id : str
-            The id of the artifact whole filepaths information is being updated
+            The id of the artifact whose filepaths information is being updated
 
         Returns
         -------

--- a/qiita_db/handlers/tests/test_artifact.py
+++ b/qiita_db/handlers/tests/test_artifact.py
@@ -52,6 +52,10 @@ class ArtifactFilepathsHandlerTests(OauthTestingBase):
         obs = self.get('/qiita_db/artifacts/1/filepaths/')
         self.assertEqual(obs.code, 400)
 
+    def test_patch(self):
+        # TODO: issue #1682
+        pass
+
 
 class ArtifactMappingHandlerTests(OauthTestingBase):
     def test_get_artifact_does_not_exist(self):

--- a/qiita_db/support_files/patches/40.sql
+++ b/qiita_db/support_files/patches/40.sql
@@ -9,6 +9,12 @@
 -- types if they already exist. This way, multiple plugins can share the same
 -- type of artifacts without depending in another "processing" plugin.
 
+-- Add the type HTML summary to the list of supported filepath types
+-- Note that we are not linking this filepath type with any specific artifact
+-- type. The reason is that all artifacts should have it and users are not
+-- allowed to upload this file, since it is internally generated
+INSERT INTO qiita.filepath_type (filepath_type) VALUES ('html_summary');
+
 -- Create the new table to hold the software types
 CREATE TABLE qiita.software_type (
     software_type_id     bigserial   NOT NULL,

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -189,9 +189,6 @@ class ArtifactTestsReadOnly(TestCase):
              "raw_barcodes")]
         self.assertEqual(qdb.artifact.Artifact(1).filepaths, exp_fps)
 
-    def test_html_summary(self):
-        self.assertIsNone(qdb.artifact.Artifact(1).html_summary_fp)
-
     def test_parents(self):
         self.assertEqual(qdb.artifact.Artifact(1).parents, [])
 
@@ -856,6 +853,34 @@ class ArtifactTests(TestCase):
         self.assertFalse(a.is_submitted_to_vamps)
         a.is_submitted_to_vamps = True
         self.assertTrue(a.is_submitted_to_vamps)
+
+    def test_html_summary_setter(self):
+        a = qdb.artifact.Artifact(1)
+
+        # Check that returns None when it doesn't exist
+        self.assertIsNone(a.html_summary_fp)
+
+        fd, fp = mkstemp(suffix=".html")
+        close(fd)
+        self._clean_up_files.append(fp)
+
+        db_fastq_dir = qdb.util.get_mountpoint('FASTQ')[0][1]
+        path_builder = partial(join, db_fastq_dir, str(a.id))
+
+        # Check the setter works when the artifact does not have the summary
+        a.html_summary_fp = fp
+        exp1 = path_builder(basename(fp))
+        self.assertEqual(a.html_summary_fp[1], exp1)
+
+        fd, fp = mkstemp(suffix=".html")
+        close(fd)
+        self._clean_up_files.append(fp)
+
+        # Check the setter works when the artifact already has a summary
+        a.html_summary_fp = fp
+        exp2 = path_builder(basename(fp))
+        self.assertEqual(a.html_summary_fp[1], exp2)
+        self.assertFalse(exists(exp1))
 
 if __name__ == '__main__':
     main()

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -189,6 +189,9 @@ class ArtifactTestsReadOnly(TestCase):
              "raw_barcodes")]
         self.assertEqual(qdb.artifact.Artifact(1).filepaths, exp_fps)
 
+    def test_html_summary(self):
+        self.assertIsNone(qdb.artifact.Artifact(1).html_summary_fp)
+
     def test_parents(self):
         self.assertEqual(qdb.artifact.Artifact(1).parents, [])
 

--- a/qiita_db/test/test_setup.py
+++ b/qiita_db/test/test_setup.py
@@ -39,7 +39,7 @@ class SetupTest(TestCase):
         self.assertEqual(get_count("qiita.filepath"), 19)
 
     def test_filepath_type(self):
-        self.assertEqual(get_count("qiita.filepath_type"), 19)
+        self.assertEqual(get_count("qiita.filepath_type"), 20)
 
     def test_study_prep_template(self):
         self.assertEqual(get_count("qiita.study_prep_template"), 1)

--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -251,6 +251,30 @@ class DBUtilTests(TestCase):
                 "raw_forward_seqs")]
         self.assertEqual(obs, exp)
 
+    def test_retrieve_filepaths_type(self):
+        obs = qdb.util.retrieve_filepaths(
+            'artifact_filepath', 'artifact_id', 1, sort='descending',
+            fp_type='raw_barcodes')
+        path_builder = partial(
+            join, qdb.util.get_db_files_base_dir(), "raw_data")
+        exp = [(2, path_builder("1_s_G1_L001_sequences_barcodes.fastq.gz"),
+                "raw_barcodes")]
+        self.assertEqual(obs, exp)
+
+        obs = qdb.util.retrieve_filepaths(
+            'artifact_filepath', 'artifact_id', 1, fp_type='raw_barcodes')
+        path_builder = partial(
+            join, qdb.util.get_db_files_base_dir(), "raw_data")
+        exp = [(2, path_builder("1_s_G1_L001_sequences_barcodes.fastq.gz"),
+                "raw_barcodes")]
+        self.assertEqual(obs, exp)
+
+        obs = qdb.util.retrieve_filepaths(
+            'artifact_filepath', 'artifact_id', 1, fp_type='biom')
+        path_builder = partial(
+            join, qdb.util.get_db_files_base_dir(), "raw_data")
+        self.assertEqual(obs, [])
+
     def test_retrieve_filepaths_error(self):
         with self.assertRaises(qdb.exceptions.QiitaDBError):
             qdb.util.retrieve_filepaths('artifact_filepath', 'artifact_id', 1,


### PR DESCRIPTION
This PR adds the property `html_summary_fp` to the artifact. It also adds the method "patch" to the `ArtifactFilepathsHandler` so plugins can add the HTML summary to the artifacts.