### PR TITLE
Artifact download buttons

### DIFF
--- a/qiita_db/processing_job.py
+++ b/qiita_db/processing_job.py
@@ -324,6 +324,7 @@ class ProcessingJob(qdb.base.QiitaObject):
             raise qdb.exceptions.QiitaDBOperationNotPermittedError(
                 "Can't submit job, not in 'in_construction' or "
                 "'waiting' status. Current status: %s" % status)
+        self._set_status = 'queued'
         cmd = self._generate_cmd()
         p = Process(target=_job_submitter, args=(self, cmd))
         p.start()

--- a/qiita_pet/handlers/api_proxy/artifact.py
+++ b/qiita_pet/handlers/api_proxy/artifact.py
@@ -5,7 +5,7 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
-from os.path import join
+from os.path import join, basename
 from functools import partial
 
 from future.utils import viewitems
@@ -115,6 +115,9 @@ def artifact_summary_get_request(user_id, artifact_id):
                 '<span class="glyphicon glyphicon-export"></span>'
                 ' Submit to VAMPS</a>')
 
+    files = [(f_id, "%s (%s)" % (basename(fp), f_type.replace('_', ' ')))
+             for f_id, fp, f_type in artifact.filepaths]
+
     return {'status': 'success',
             'message': '',
             'name': artifact.name,
@@ -123,7 +126,8 @@ def artifact_summary_get_request(user_id, artifact_id):
             'errored_jobs': errored_jobs,
             'processing_jobs': processing_jobs,
             'visibility': visibility,
-            'buttons': ' '.join(buttons)}
+            'buttons': ' '.join(buttons),
+            'files': files}
 
 
 def artifact_summary_post_request(user_id, artifact_id):

--- a/qiita_pet/handlers/api_proxy/tests/test_artifact.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_artifact.py
@@ -144,6 +144,9 @@ class TestArtifactAPI(TestCase):
              'running', 'demultiplexing'],
             ['b72369f9-a886-4193-8d3d-f7b504168e75', 'Split libraries FASTQ',
              'success', None]]
+        exp_files = [
+            (1L, '1_s_G1_L001_sequences.fastq.gz (raw forward seqs)'),
+            (2L, '1_s_G1_L001_sequences_barcodes.fastq.gz (raw barcodes)')]
         exp = {'status': 'success',
                'message': '',
                'name': 'Raw data 1',
@@ -157,8 +160,9 @@ class TestArtifactAPI(TestCase):
                           'Make public</button> <button onclick="'
                           'set_artifact_visibility(\'sandbox\', 1)" '
                           'class="btn btn-primary btn-sm">Revert to '
-                          'sandbox</button>'}
-        self.assertEqual(obs, exp)
+                          'sandbox</button>',
+               'files': exp_files}
+        self.assertItemsEqual(obs, exp)
 
         # Artifact with summary being generated
         job = ProcessingJob.create(
@@ -180,7 +184,8 @@ class TestArtifactAPI(TestCase):
                           'Make public</button> <button onclick="'
                           'set_artifact_visibility(\'sandbox\', 1)" '
                           'class="btn btn-primary btn-sm">Revert to '
-                          'sandbox</button>'}
+                          'sandbox</button>',
+               'files': exp_files}
         self.assertItemsEqual(obs, exp)
 
         # Artifact with summary
@@ -205,8 +210,9 @@ class TestArtifactAPI(TestCase):
                           'Make public</button> <button onclick="'
                           'set_artifact_visibility(\'sandbox\', 1)" '
                           'class="btn btn-primary btn-sm">Revert to '
-                          'sandbox</button>'}
-        self.assertEqual(obs, exp)
+                          'sandbox</button>',
+               'files': exp_files}
+        self.assertItemsEqual(obs, exp)
 
         # No access
         obs = artifact_summary_get_request('demo@microbio.me', 1)

--- a/qiita_pet/templates/study_ajax/artifact_summary.html
+++ b/qiita_pet/templates/study_ajax/artifact_summary.html
@@ -61,6 +61,14 @@
 </div>
 <div class='row'>
   <div class='col-md-12'>
+    Available files:
+    {% for f_id, f_name in files %}
+      </br><a class="btn btn-default" href="/download/{{f_id}}"><span class="glyphicon glyphicon-download-alt"></span> {{f_name}}</a>
+    {% end %}
+  </div>
+</div>
+<div class='row'>
+  <div class='col-md-12'>
     {% if processing_jobs %}
       <b>Jobs using this set of files:</b></br>
     {% end %}


### PR DESCRIPTION
This adds the buttons so users can download the artifact files.

I've also modified one line in qiita_db/processing_job.py to fix a bug that I found last night that the status of the jobs do not change when the job is submitted. Note that I can't test that line, because it will require to run some heavy commands in travis, like split libraries.