### PR TITLE
Artifact study pages limit access

### DIFF
--- a/qiita_db/study.py
+++ b/qiita_db/study.py
@@ -1040,6 +1040,24 @@ class Study(qdb.base.QiitaObject):
 
             return self in study_set
 
+    def can_edit(self, user):
+        """Returns whether the given user can edit the study
+
+        Parameters
+        ----------
+        user : User object
+            User we are checking edit permissions for
+
+        Returns
+        -------
+        bool
+            Whether user can edit the study or not
+        """
+        # The study is editable only if the user is the owner, is in the shared
+        # list or the user is an admin
+        return (user.level in {'superuser', 'admin'} or self.owner == user or
+                user in self.shared_with)
+
     def share(self, user):
         """Share the study with another user
 

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -814,6 +814,41 @@ class ArtifactTests(TestCase):
         a.visibility = "public"
         self.assertEqual(a.visibility, "public")
 
+        # Testing that the visibility inference works as expected
+        # The current artifact network that we have in the db looks as follows:
+        #                              /- 4 (private)
+        #              /- 2 (private) -|- 5 (private)
+        # 1 (private) -|               \- 6 (private)
+        #              \- 3 (private)
+        # By changing the visibility of 4 to public, the visibility of 1 and
+        # 2 also changes to public
+        a1 = qdb.artifact.Artifact(1)
+        a2 = qdb.artifact.Artifact(2)
+        a3 = qdb.artifact.Artifact(3)
+        a4 = qdb.artifact.Artifact(4)
+        a5 = qdb.artifact.Artifact(5)
+        a6 = qdb.artifact.Artifact(6)
+
+        a4.visibility = 'public'
+
+        self.assertEqual(a1.visibility, "public")
+        self.assertEqual(a2.visibility, "public")
+        self.assertEqual(a3.visibility, "private")
+        self.assertEqual(a4.visibility, "public")
+        self.assertEqual(a5.visibility, "private")
+        self.assertEqual(a6.visibility, "private")
+
+        # However, if we change it back to private,
+        # it should remain public
+        a4.visibility = 'private'
+
+        self.assertEqual(a1.visibility, "public")
+        self.assertEqual(a2.visibility, "public")
+        self.assertEqual(a3.visibility, "private")
+        self.assertEqual(a4.visibility, "private")
+        self.assertEqual(a5.visibility, "private")
+        self.assertEqual(a6.visibility, "private")
+
     def test_ebi_run_accessions_setter(self):
         a = qdb.artifact.Artifact(3)
         self.assertEqual(a.ebi_run_accessions, dict())

--- a/qiita_db/test/test_study.py
+++ b/qiita_db/test/test_study.py
@@ -270,6 +270,13 @@ class TestStudy(TestCase):
         self.assertFalse(
             self.study.has_access(qdb.user.User("demo@microbio.me"), True))
 
+    def test_can_edit(self):
+        self.assertTrue(self.study.can_edit(qdb.user.User('test@foo.bar')))
+        self.assertTrue(self.study.can_edit(qdb.user.User('shared@foo.bar')))
+        self.assertTrue(self.study.can_edit(qdb.user.User('admin@foo.bar')))
+        self.assertFalse(
+            self.study.can_edit(qdb.user.User('demo@microbio.me')))
+
     def test_owner(self):
         self.assertEqual(self.study.owner, qdb.user.User("test@foo.bar"))
 

--- a/qiita_pet/handlers/api_proxy/artifact.py
+++ b/qiita_pet/handlers/api_proxy/artifact.py
@@ -127,7 +127,8 @@ def artifact_summary_get_request(user_id, artifact_id):
             'processing_jobs': processing_jobs,
             'visibility': visibility,
             'buttons': ' '.join(buttons),
-            'files': files}
+            'files': files,
+            'editable': artifact.study.can_edit(user)}
 
 
 def artifact_summary_post_request(user_id, artifact_id):

--- a/qiita_pet/handlers/api_proxy/prep_template.py
+++ b/qiita_pet/handlers/api_proxy/prep_template.py
@@ -551,8 +551,10 @@ def prep_template_graph_get_req(prep_id, user_id):
     node_labels = [(n.id, ' - '.join([n.name, n.artifact_type]))
                    for n in G.nodes()
                    if full_access or n.visibility == 'public']
+    node_ids = [id_ for id_, label in node_labels]
     edge_list = [(n.id, m.id) for n, m in G.edges()
-                 if n.id in node_labels and m.id in node_labels]
+                 if n.id in node_ids and m.id in node_ids]
+
     return {'status': 'success',
             'message': '',
             'edge_list': edge_list,

--- a/qiita_pet/handlers/api_proxy/prep_template.py
+++ b/qiita_pet/handlers/api_proxy/prep_template.py
@@ -17,6 +17,7 @@ from qiita_pet.handlers.api_proxy.util import check_access, check_fp
 from qiita_db.metadata_template.util import load_template_to_dataframe
 from qiita_db.util import convert_to_id, get_files_from_uploads_folders
 from qiita_db.study import Study
+from qiita_db.user import User
 from qiita_db.ontology import Ontology
 from qiita_db.metadata_template.prep_template import PrepTemplate
 
@@ -67,11 +68,13 @@ def new_prep_template_get_req(study_id):
             'ontology': ontology_info}
 
 
-def prep_template_ajax_get_req(prep_id):
+def prep_template_ajax_get_req(user_id, prep_id):
     """Returns the prep tempalte information needed for the AJAX handler
 
     Parameters
     ----------
+    user_id : str
+        The user id
     prep_id : int
         The prep template id
 
@@ -132,7 +135,8 @@ def prep_template_ajax_get_req(prep_id):
             'investigation_type': investigation_type,
             'ontology': ontology,
             'artifact_attached': artifact_attached,
-            'study_id': study_id}
+            'study_id': study_id,
+            'editable': Study(study_id).can_edit(User(user_id))}
 
 
 @execute_as_transaction

--- a/qiita_pet/handlers/api_proxy/sample_template.py
+++ b/qiita_pet/handlers/api_proxy/sample_template.py
@@ -18,6 +18,7 @@ from qiita_core.util import execute_as_transaction
 from qiita_db.metadata_template.util import (load_template_to_dataframe,
                                              looks_like_qiime_mapping_file)
 from qiita_db.exceptions import QiitaDBColumnError
+from qiita_db.user import User
 
 from qiita_ware.metadata_pipeline import (
     create_templates_from_qiime_mapping_file)
@@ -229,6 +230,8 @@ def sample_template_summary_get_req(samp_id, user_id):
     out = {'status': 'success',
            'message': '',
            'num_samples': df.shape[0],
+           'num_columns': df.shape[1],
+           'editable': Study(template.study_id).can_edit(User(user_id)),
            'summary': {}}
 
     # drop the samp_id column if it exists

--- a/qiita_pet/handlers/api_proxy/studies.py
+++ b/qiita_pet/handlers/api_proxy/studies.py
@@ -88,15 +88,10 @@ def study_get_req(study_id, user_id):
     samples = study.sample_template
     study_info['num_samples'] = 0 if samples is None else len(list(samples))
 
-    # The study is editable only if the user is the owner, is in the shared
-    # list or the user is an admin
-    user = User(user_id)
-    editable = (user.level == 'admin' or study.owner == user or
-                user in study.shared_with)
     return {'status': 'success',
             'message': '',
             'study_info': study_info,
-            'editable': editable}
+            'editable': study.can_edit(User(user_id))}
 
 
 def study_delete_req(study_id, user_id):

--- a/qiita_pet/handlers/api_proxy/studies.py
+++ b/qiita_pet/handlers/api_proxy/studies.py
@@ -7,6 +7,7 @@
 # -----------------------------------------------------------------------------
 from __future__ import division
 
+from qiita_db.user import User
 from qiita_db.study import Study
 from qiita_db.metadata_template.prep_template import PrepTemplate
 from qiita_db.util import (supported_filepath_types,
@@ -85,10 +86,16 @@ def study_get_req(study_id, user_id):
 
     samples = study.sample_template
     study_info['num_samples'] = 0 if samples is None else len(list(samples))
+
+    # The study is editable only if the user is the owner, is in the shared
+    # list or the user is an admin
+    user = User(user_id)
+    editable = (user.level == 'admin' or study.owner == user or
+                user in study.shared_with)
     return {'status': 'success',
             'message': '',
-            'info': study_info
-            }
+            'study_info': study_info,
+            'editable': editable}
 
 
 def study_delete_req(study_id, user_id):

--- a/qiita_pet/handlers/api_proxy/studies.py
+++ b/qiita_pet/handlers/api_proxy/studies.py
@@ -6,6 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
 from __future__ import division
+from collections import defaultdict
 
 from qiita_db.user import User
 from qiita_db.study import Study
@@ -149,10 +150,12 @@ def study_prep_get_req(study_id, user_id):
         return access_error
     # Can only pass ids over API, so need to instantiate object
     study = Study(int(study_id))
-    prep_info = {}
+    prep_info = defaultdict(list)
+    editable = study.can_edit(User(user_id))
     for dtype in study.data_types:
-        prep_info[dtype] = []
         for prep in study.prep_templates(dtype):
+            if prep.status != 'public' and not editable:
+                continue
             start_artifact = prep.artifact
             info = {
                 'name': 'PREP %d NAME' % prep.id,
@@ -171,6 +174,7 @@ def study_prep_get_req(study_id, user_id):
                 info['youngest_artifact'] = None
 
             prep_info[dtype].append(info)
+
     return {'status': 'success',
             'message': '',
             'info': prep_info}

--- a/qiita_pet/handlers/api_proxy/tests/test_artifact.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_artifact.py
@@ -161,7 +161,8 @@ class TestArtifactAPI(TestCase):
                           'set_artifact_visibility(\'sandbox\', 1)" '
                           'class="btn btn-primary btn-sm">Revert to '
                           'sandbox</button>',
-               'files': exp_files}
+               'files': exp_files,
+               'editable': True}
         self.assertItemsEqual(obs, exp)
 
         # Artifact with summary being generated
@@ -185,7 +186,8 @@ class TestArtifactAPI(TestCase):
                           'set_artifact_visibility(\'sandbox\', 1)" '
                           'class="btn btn-primary btn-sm">Revert to '
                           'sandbox</button>',
-               'files': exp_files}
+               'files': exp_files,
+               'editable': True}
         self.assertItemsEqual(obs, exp)
 
         # Artifact with summary
@@ -211,7 +213,8 @@ class TestArtifactAPI(TestCase):
                           'set_artifact_visibility(\'sandbox\', 1)" '
                           'class="btn btn-primary btn-sm">Revert to '
                           'sandbox</button>',
-               'files': exp_files}
+               'files': exp_files,
+               'editable': True}
         self.assertItemsEqual(obs, exp)
 
         # No access

--- a/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
@@ -60,7 +60,7 @@ class TestPrepAPIReadOnly(TestCase):
         self.assertEqual(obs, exp)
 
     def test_prep_template_ajax_get_req(self):
-        obs = prep_template_ajax_get_req(1)
+        obs = prep_template_ajax_get_req('test@foo.bar', 1)
         exp = {'status': 'success',
                'message': '',
                'name': "Prep information 1",
@@ -80,7 +80,15 @@ class TestPrepAPIReadOnly(TestCase):
                            'Other'],
                    'User': []},
                'artifact_attached': True,
-               'study_id': 1}
+               'study_id': 1,
+               'editable': True}
+        self.assertEqual(obs, exp)
+
+        obs = prep_template_ajax_get_req('admin@foo.bar', 1)
+        self.assertEqual(obs, exp)
+
+        obs = prep_template_ajax_get_req('demo@microbio.me', 1)
+        exp['editable'] = False
         self.assertEqual(obs, exp)
 
     def test_check_prep_template_exists(self):

--- a/qiita_pet/handlers/api_proxy/tests/test_sample_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_sample_template.py
@@ -205,6 +205,8 @@ class TestSampleAPI(TestCase):
                                 ('SKM4', 1), ('SKM5', 1), ('SKM6', 1),
                                 ('SKM7', 1), ('SKM8', 1), ('SKM9', 1)]},
                'num_samples': 27,
+               'num_columns': 30,
+               'editable': True,
                'status': 'success',
                'message': ''}
         self.assertEqual(obs, exp)

--- a/qiita_pet/handlers/api_proxy/tests/test_studies.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_studies.py
@@ -180,6 +180,9 @@ class TestStudyAPI(TestCase):
                             'youngest_artifact': None}]}}
         self.assertEqual(obs, exp)
 
+        obs = study_prep_get_req(1, 'admin@foo.bar')
+        self.assertEqual(obs, exp)
+
         qdb.artifact.Artifact(1).visibility = 'public'
         obs = study_prep_get_req(1, 'demo@microbio.me')
         exp = {'status': 'success',

--- a/qiita_pet/handlers/api_proxy/tests/test_studies.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_studies.py
@@ -31,7 +31,7 @@ class TestStudyAPI(TestCase):
         exp = {
             'status': 'success',
             'message': '',
-            'info': {
+            'study_info': {
                 'mixs_compliant': True,
                 'metadata_complete': True,
                 'reprocess': False,
@@ -71,7 +71,8 @@ class TestStudyAPI(TestCase):
                     'num_samples': 27,
                     'study_title': 'Identification of the Microbiomes for '
                                    'Cannabis Soils',
-                    'number_samples_collected': 27}}
+                    'number_samples_collected': 27},
+            'editable': True}
         self.assertEqual(obs, exp)
 
     def test_study_get_req_no_access(self):

--- a/qiita_pet/handlers/study_handlers/base.py
+++ b/qiita_pet/handlers/study_handlers/base.py
@@ -25,12 +25,7 @@ class StudyIndexHandler(BaseHandler):
         if study_info['status'] != 'success':
             raise HTTPError(404, study_info['message'])
 
-        study_info = study_info['info']
-
-        editable = study_info['status'] == 'sandbox'
-
-        self.render("study_base.html", study_info=study_info,
-                    editable=editable)
+        self.render("study_base.html", **study_info)
 
 
 class StudyBaseInfoAJAX(BaseHandler):
@@ -38,7 +33,7 @@ class StudyBaseInfoAJAX(BaseHandler):
     def get(self):
         study_id = self.get_argument('study_id')
         study = to_int(study_id)
-        study_info = study_get_req(study, self.current_user.id)['info']
+        study_info = study_get_req(study, self.current_user.id)['study_info']
         study_doi = ' '.join(
             [doi_linkifier(p) for p in study_info['publications']])
         email = '<a href="mailto:{email}">{name} ({affiliation})</a>'

--- a/qiita_pet/handlers/study_handlers/prep_template.py
+++ b/qiita_pet/handlers/study_handlers/prep_template.py
@@ -54,17 +54,10 @@ class PrepTemplateAJAX(BaseHandler):
         """Send formatted summary page of prep template"""
         prep_id = to_int(self.get_argument('prep_id'))
 
-        res = prep_template_ajax_get_req(prep_id)
+        res = prep_template_ajax_get_req(self.current_user.id, prep_id)
+        res['prep_id'] = prep_id
 
-        self.render('study_ajax/prep_summary.html', name=res['name'],
-                    files=res['files'], download_prep=res['download_prep'],
-                    download_qiime=res['download_qiime'],
-                    num_samples=res['num_samples'],
-                    num_columns=res['num_columns'],
-                    investigation_type=res['investigation_type'],
-                    artifact_attached=res['artifact_attached'],
-                    prep_id=prep_id, study_id=res['study_id'],
-                    ontology=res['ontology'])
+        self.render('study_ajax/prep_summary.html', **res)
 
 
 class PrepFilesHandler(BaseHandler):

--- a/qiita_pet/templates/study_ajax/artifact_summary.html
+++ b/qiita_pet/templates/study_ajax/artifact_summary.html
@@ -50,13 +50,18 @@
   <div class='col-md-12'>
     <h4>
       <i>Summary: {{name}} (ID: {{artifact_id}})</i>
-      <a class="btn btn-default btn-sm" onclick="populate_main_div('/study/process/', {artifact_id: {{artifact_id}} });"><span class="glyphicon glyphicon-play"></span> Process</a>
+      {% if editable %}
+        <a class="btn btn-default btn-sm" onclick="populate_main_div('/study/process/', {artifact_id: {{artifact_id}} });"><span class="glyphicon glyphicon-play"></span> Process</a>
+      {% end %}
     </h4>
   </div>
 </div>
 <div class='row'>
   <div class='col-md-12'>
-    Visibility: {{visibility}} {% raw buttons %}
+    Visibility: {{visibility}}
+    {% if editable %}
+      {% raw buttons %}
+    {% end %}
   </div>
 </div>
 <div class='row'>

--- a/qiita_pet/templates/study_ajax/prep_summary.html
+++ b/qiita_pet/templates/study_ajax/prep_summary.html
@@ -340,7 +340,9 @@
       {{name}} - ID {{prep_id}}
       <a class="btn btn-default" href="/download/{{download_prep}}"><span class="glyphicon glyphicon-download-alt"></span> Prep info</a>
       <a class="btn btn-default" href="/download/{{download_qiime}}"><span class="glyphicon glyphicon-download-alt"></span> Qiime map</a>
-      <a class="btn btn-danger" onclick="delete_prep_info({{prep_id}});"><span class="glyphicon glyphicon-trash"></span> Delete</a>
+      {% if editable %}
+        <a class="btn btn-danger" onclick="delete_prep_info({{prep_id}});"><span class="glyphicon glyphicon-trash"></span> Delete</a>
+      {% end %}
     </h4>
   </div>
 </div>
@@ -352,50 +354,52 @@
   </div>
 </div>
 
-<!-- Update prep template -->
-<div class="row">
-  <div class="col-md-12">
-    <b>Update information:</b>
-    <select id="file-selector">
-      <option value="">Choose file...</option>
-      {% for fp in files %}
-        <option value="{{fp}}">{{fp}}</option>
-      {% end %}
-    </select>
-    <div id="update-button-div" hidden>
-      <button class="btn btn-info btn-sm" onclick="update_prep_information();" hidden>Update</button>
+{% if editable %}
+  <!-- Update prep template -->
+  <div class="row">
+    <div class="col-md-12">
+      <b>Update information:</b>
+      <select id="file-selector">
+        <option value="">Choose file...</option>
+        {% for fp in files %}
+          <option value="{{fp}}">{{fp}}</option>
+        {% end %}
+      </select>
+      <div id="update-button-div" hidden>
+        <button class="btn btn-info btn-sm" onclick="update_prep_information();" hidden>Update</button>
+      </div>
     </div>
   </div>
-</div>
 
-<!-- Investigation type info -->
-<div class="row">
-  <!-- Ena ontology selector -->
-  <div class="col-md-4">
-    <b>Select Investigation Type:</b>
-    <select id="ena-ontology" name="ena-ontology" value="ena-ontology">
-      <option value=""></option>
-      {% for o in ontology['ENA'] %}
-        <option value="{{o}}">{{o}}</option>
-      {% end %}
-    </select>
+  <!-- Investigation type info -->
+  <div class="row">
+    <!-- Ena ontology selector -->
+    <div class="col-md-4">
+      <b>Select Investigation Type:</b>
+      <select id="ena-ontology" name="ena-ontology" value="ena-ontology">
+        <option value=""></option>
+        {% for o in ontology['ENA'] %}
+          <option value="{{o}}">{{o}}</option>
+        {% end %}
+      </select>
+    </div>
+    <!-- user-defined selector -->
+    <div class="col-md-4" id="user-ena-info" hidden> User defined investigation type:
+      <select id="user-ontology" name="user-ontology" value="user-ontology">
+        <option value=""></option>
+        {% for o in ontology['User'] %}
+          <option value="{{o}}">{{o}}</option>
+        {% end %}
+        <option value="New Type">New Type</option>
+      </select>
+    </div>
+    <!-- new user-defined input -->
+    <div class="col-md-4" id="new-ena-info" hidden> New user defined term:
+      <input type="textbox" id="new-ontology" name="new-ontology">
+      <button class="btn btn-info btn-sm" onclick="add_new_investigation_type_term_and_update();">Add</button>
+    </div>
   </div>
-  <!-- user-defined selector -->
-  <div class="col-md-4" id="user-ena-info" hidden> User defined investigation type:
-    <select id="user-ontology" name="user-ontology" value="user-ontology">
-      <option value=""></option>
-      {% for o in ontology['User'] %}
-        <option value="{{o}}">{{o}}</option>
-      {% end %}
-      <option value="New Type">New Type</option>
-    </select>
-  </div>
-  <!-- new user-defined input -->
-  <div class="col-md-4" id="new-ena-info" hidden> New user defined term:
-    <input type="textbox" id="new-ontology" name="new-ontology">
-    <button class="btn btn-info btn-sm" onclick="add_new_investigation_type_term_and_update();">Add</button>
-  </div>
-</div>
+{% end %}
 
 <!-- Files graph or add artifact -->
 <div class="row">

--- a/qiita_pet/templates/study_ajax/sample_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_summary.html
@@ -1,71 +1,8 @@
 {% from future.utils import viewitems %}
-<div>
-    {% raw dl_path %}
-</div>
-
-<div>
-<h3>Update Sample Information</h3>
-    <p><select id="filepath" value="filepath">
-    {% for f in files %}
-      <option value="{{f}}">{{f}}</option>
-    {% end %}
-    </select>
-    <button class="btn btn-info btn-sm" onclick="sample_action('create')">Create or reset</button>
-    {% if stats %}
-    <button class="btn btn-info btn-sm" onclick="sample_action('update')">Update</button>
-    <button class="btn btn-danger btn-sm" onclick="sample_action('delete')">Delete</button>
-    {% end %}
-    </p>
-    <p> <select id="data_types" value="data_types">
-      <option value=""></option>
-    {% for d in data_types %}
-      <option value="{{d}}">{{d}}</option>
-    {% end %}
-    </select> If uploading a qiime mapping file, select data type</p>
-</div>
-
-<div>
-    <h3>Sample information summary</h3>
-    <p>There are <strong>{{num_samples}}</strong> samples in this study.</p>
-</div>
-
-<div class="panel panel-default" id="summary">
-    <div class="panel-heading">
-        A summary of the sample information is below.
-    </div>
-
-    <table class="table">
-    {% for category, summary in viewitems(stats) %}
-        {% if len(summary) == 1 %}
-            <tr>
-                <td colspan="2">
-                    <b>{{category}}</b>: <tt>{{summary[0][0]}}</tt> is repeated in all rows.
-                </td>
-            </tr>
-        {% elif len(set([row[1] for row in summary])) == 1 %}
-            <tr>
-                <td colspan="2">
-                    <b>{{category}}</b>: All the values in this category are different.
-                </td>
-            </tr>
-        {% else %}
-            <tr>
-                <th colspan="2" align="center">{{category}}</th>
-            </tr>
-            {% for row in summary %}
-            <tr>
-                <td>{{row[0]}}</td>
-                <td>{{row[1]}}</td>
-            </tr>
-            {% end %}
-        {% end %}
-    {% end %}
-    </table>
-</div>
 
 <script type="text/javascript">
   function sample_action(act) {
-    $.post('/study/description/sample_template/', { study_id: {{study_id}}, action: act, filepath: $("#filepath").val(), data_type: $("#data_types").val() })
+    $.post('/study/description/sample_template/', { study_id: {{study_id}}, action: act, filepath: $("#file-selector").val(), data_type: $("#data_types").val() })
       .done(function ( data ) {
         if(data.status == "error") {
           bootstrapAlert("<p>Error updating sample template</p>" + data.message, "danger", 4000);
@@ -79,3 +16,92 @@
       })
   }
 </script>
+
+
+<!-- Title and download button -->
+<div class="row">
+  <div class="col-md-12">
+    <h4>
+      Sample Information
+      {% if download_id %}
+        <a class="btn btn-default" href="/download/{{download_id}}"><span class="glyphicon glyphicon-download-alt"></span> Sample info</a>
+        {% if editable %}
+          <a class="btn btn-danger" onclick="sample_action('delete');"><span class="glyphicon glyphicon-trash"></span> Delete</a>
+        {% end %}
+      {% end %}
+    </h4>
+  </div>
+</div>
+
+<!-- # samples and # columns -->
+<div class="row">
+  <div class="col-md-12">
+    {% if download_id %}
+      There are <b>{{num_samples}}</b> samples and <b>{{num_columns}}</b> columns in this study.
+    {% end %}
+  </div>
+</div>
+
+<!-- Update sample template -->
+{% if editable %}
+  <div class="row">
+    <div class="col-md-12">
+      <b>Update information</b>
+      <select id="file-selector">
+        <option value="">Choose file...</option>
+        {% for fp in files %}
+          <option value="{{fp}}">{{fp}}</option>
+        {% end %}
+      </select>
+      {% if stats %}
+        <button class="btn btn-info btn-sm" onclick="sample_action('update')">Update</button>
+      {% else %}
+        <button class="btn btn-info btn-sm" onclick="sample_action('create')">Create</button>
+        If uploading a qiime mapping file, select data type:
+        <select id="data_types" value="data_types">
+          <option value="">Choose a data type...</option>
+          {% for d in data_types %}
+            <option value="{{d}}">{{d}}</option>
+          {% end %}
+        </select>
+      {% end %}
+      </br>
+    </div>
+  </div>
+{% end %}
+
+{% if stats %}
+  <div class="panel panel-default" id="summary">
+    <div class="panel-heading">
+      Sample information summary
+    </div>
+
+    <table class="table">
+      {% for category, summary in viewitems(stats) %}
+        {% if len(summary) == 1 %}
+          <tr>
+            <td colspan="2">
+              <b>{{category}}</b>: <tt>{{summary[0][0]}}</tt> is repeated in all rows.
+            </td>
+          </tr>
+        {% elif len(set([row[1] for row in summary])) == 1 %}
+          <tr>
+            <td colspan="2">
+              <b>{{category}}</b>: All the values in this category are different.
+            </td>
+          </tr>
+        {% else %}
+          <tr>
+            <th colspan="2" align="center">{{category}}</th>
+          </tr>
+          {% for row in summary %}
+            <tr>
+              <td>{{row[0]}}</td>
+              <td>{{row[1]}}</td>
+            </tr>
+          {% end %}
+        {% end %}
+      {% end %}
+    </table>
+  </div>
+{% end %}


### PR DESCRIPTION
As the interface was before, it was giving access to the entire study once 1 artifact was public.

This limits that to only provide public access to those artifacts that are public. It also limits the interface to allow to modify the study sections only to admins, the owner and the users that the study is shared with.

Finally, if an artifact changes the visibility, all the artifacts that were used to generate that one also change visibility.