### PR TITLE
Solving multiple small issues

### DIFF
--- a/qiita_db/support_files/patches/35.sql
+++ b/qiita_db/support_files/patches/35.sql
@@ -1,4 +1,4 @@
 -- Dec 5, 2015
 -- Adds names to the artifacts
 
-ALTER TABLE qiita.artifact ADD name varchar(35)  NOT NULL DEFAULT 'dflt_name';
+ALTER TABLE qiita.artifact ADD name varchar(35)  NOT NULL DEFAULT 'noname';

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -596,7 +596,7 @@ class ArtifactTests(TestCase):
             self.filepaths_processed, "Demultiplexed",
             parents=[qdb.artifact.Artifact(1)],
             processing_parameters=exp_params)
-        self.assertEqual(obs.name, 'dflt_name')
+        self.assertEqual(obs.name, 'noname')
         self.assertTrue(before < obs.timestamp < datetime.now())
         self.assertEqual(obs.processing_parameters, exp_params)
         self.assertEqual(obs.visibility, 'sandbox')
@@ -627,7 +627,7 @@ class ArtifactTests(TestCase):
         obs = qdb.artifact.Artifact.create(
             self.filepaths_biom, "BIOM", parents=[qdb.artifact.Artifact(2)],
             processing_parameters=exp_params)
-        self.assertEqual(obs.name, 'dflt_name')
+        self.assertEqual(obs.name, 'noname')
         self.assertTrue(before < obs.timestamp < datetime.now())
         self.assertEqual(obs.processing_parameters, exp_params)
         self.assertEqual(obs.visibility, 'sandbox')

--- a/qiita_pet/handlers/api_proxy/prep_template.py
+++ b/qiita_pet/handlers/api_proxy/prep_template.py
@@ -136,7 +136,8 @@ def prep_template_ajax_get_req(user_id, prep_id):
             'ontology': ontology,
             'artifact_attached': artifact_attached,
             'study_id': study_id,
-            'editable': Study(study_id).can_edit(User(user_id))}
+            'editable': Study(study_id).can_edit(User(user_id)),
+            'data_type': pt.data_type()}
 
 
 @execute_as_transaction

--- a/qiita_pet/handlers/api_proxy/processing.py
+++ b/qiita_pet/handlers/api_proxy/processing.py
@@ -37,7 +37,8 @@ def process_artifact_handler_get_req(artifact_id):
     return {'status': 'success',
             'message': '',
             'name': artifact.name,
-            'type': artifact.artifact_type}
+            'type': artifact.artifact_type,
+            'study_id': artifact.study.id}
 
 
 def list_commands_handler_get_req(artifact_types):

--- a/qiita_pet/handlers/api_proxy/sample_template.py
+++ b/qiita_pet/handlers/api_proxy/sample_template.py
@@ -297,7 +297,7 @@ def sample_template_post_req(study_id, user_id, data_type,
         with warnings.catch_warnings(record=True) as warns:
             if is_mapping_file:
                 create_templates_from_qiime_mapping_file(fp_rsp, study,
-                                                         int(data_type))
+                                                         data_type)
             else:
                 SampleTemplate.create(load_template_to_dataframe(fp_rsp),
                                       study)

--- a/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
@@ -82,7 +82,8 @@ class TestPrepAPIReadOnly(TestCase):
                    'User': []},
                'artifact_attached': True,
                'study_id': 1,
-               'editable': True}
+               'editable': True,
+               'data_type': '18S'}
         self.assertEqual(obs, exp)
 
         obs = prep_template_ajax_get_req('admin@foo.bar', 1)

--- a/qiita_pet/handlers/api_proxy/tests/test_processing.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_processing.py
@@ -25,14 +25,16 @@ class TestProcessingAPIReadOnly(TestCase):
         exp = {'status': 'success',
                'message': '',
                'name': 'Raw data 1',
-               'type': 'FASTQ'}
+               'type': 'FASTQ',
+               'study_id': 1}
         self.assertEqual(obs, exp)
 
         obs = process_artifact_handler_get_req(2)
         exp = {'status': 'success',
                'message': '',
                'name': 'Demultiplexed 1',
-               'type': 'Demultiplexed'}
+               'type': 'Demultiplexed',
+               'study_id': 1}
         self.assertEqual(obs, exp)
 
     def test_list_commands_handler_get_req(self):

--- a/qiita_pet/handlers/study_handlers/base.py
+++ b/qiita_pet/handlers/study_handlers/base.py
@@ -33,7 +33,8 @@ class StudyBaseInfoAJAX(BaseHandler):
     def get(self):
         study_id = self.get_argument('study_id')
         study = to_int(study_id)
-        study_info = study_get_req(study, self.current_user.id)['study_info']
+        res = study_get_req(study, self.current_user.id)
+        study_info = res['study_info']
         study_doi = ' '.join(
             [doi_linkifier(p) for p in study_info['publications']])
         email = '<a href="mailto:{email}">{name} ({affiliation})</a>'
@@ -45,7 +46,7 @@ class StudyBaseInfoAJAX(BaseHandler):
 
         self.render('study_ajax/base_info.html',
                     study_info=study_info, publications=study_doi, pi=pi,
-                    contact=contact)
+                    contact=contact, editable=res['editable'])
 
 
 class StudyDeleteAjax(BaseHandler):

--- a/qiita_pet/handlers/study_handlers/edit_handlers.py
+++ b/qiita_pet/handlers/study_handlers/edit_handlers.py
@@ -88,7 +88,8 @@ class StudyEditorForm(Form):
                 'study_description'].decode('utf-8')
             self.principal_investigator.data = study_info[
                 'principal_investigator'].id
-            self.lab_person.data = study_info['lab_person'].id
+            self.lab_person.data = (study_info['lab_person'].id
+                                    if study_info['lab_person'] else None)
 
 
 class StudyEditorExtendedForm(StudyEditorForm):

--- a/qiita_pet/handlers/study_handlers/sample_template.py
+++ b/qiita_pet/handlers/study_handlers/sample_template.py
@@ -85,7 +85,7 @@ class SampleTemplateAJAX(BaseHandler):
         summary = stats['summary'] if 'summary' in stats else {}
         num_samples = stats['num_samples'] if 'num_samples' in stats else 0
         num_columns = stats['num_columns'] if 'num_columns' in stats else 0
-        editable = stats['editable'] if 'editable' in stats else False
+        editable = stats['editable'] if 'editable' in stats else True
         self.render('study_ajax/sample_summary.html', stats=summary,
                     num_samples=num_samples, num_columns=num_columns,
                     download_id=download_id, files=files, study_id=study_id,

--- a/qiita_pet/templates/study_ajax/base_info.html
+++ b/qiita_pet/templates/study_ajax/base_info.html
@@ -4,4 +4,8 @@ Study ID:  {{study_info['study_id']}}<br />
 Publications: {% raw publications %}<br />
 PI: {% raw pi %}<br />
 Lab Contact: {% raw contact %}<br />
-Samples: {{study_info['num_samples']}}
+Samples: {{study_info['num_samples']}}<br />
+{% if editable %}
+  <a class="btn btn-default" href="/study/edit/{{study_info['study_id']}}"><span class="glyphicon glyphicon-edit"></span> Edit</a>
+  <a class="btn btn-danger" href="#" data-toggle="modal" data-target="#delete-study"><span class="glyphicon glyphicon-trash"></span> Delete</a>
+{% end %}

--- a/qiita_pet/templates/study_ajax/data_type_menu.html
+++ b/qiita_pet/templates/study_ajax/data_type_menu.html
@@ -1,25 +1,29 @@
-<h3>Data Types</h3>
-<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
-  <div class="panel panel-default">
-    {% for dt in prep_info %}
-    {% set cleaned_dt = dt.replace(' ', '_') %}
-      <div class="panel-heading" role="tab" id="heading{{cleaned_dt}}">
-        <h4 class="panel-title">
-          <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse{{cleaned_dt}}" aria-expanded="true" aria-controls="collapse{{cleaned_dt}}">{{dt}}</a>
-        </h4>
-      </div>
-      <div id="collapse{{cleaned_dt}}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading{{cleaned_dt}}">
-        <div class="panel-body">
-          {% for prep in prep_info[dt] %}
-            <a href="#" style="display:block;color:black;" onclick="populate_main_div('/study/description/prep_template/', { prep_id: {{prep['id']}}, study_id: {{study_id}} });">
-              <span id="prep-header-{{prep['id']}}">{{prep['name']}} - ID {{prep['id']}} - {{prep['status']}}</span><br/>
-              {{prep['start_artifact']}} - ID {{prep['start_artifact_id']}}<br/>
-              {{prep['youngest_artifact']}}
-            </a>
-            <hr>
-          {% end %}
+{% if prep_info %}
+  <h3>Data Types</h3>
+  <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+    <div class="panel panel-default">
+      {% for dt in prep_info %}
+      {% set cleaned_dt = dt.replace(' ', '_') %}
+        <div class="panel-heading" role="tab" id="heading{{cleaned_dt}}">
+          <h4 class="panel-title">
+            <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse{{cleaned_dt}}" aria-expanded="true" aria-controls="collapse{{cleaned_dt}}">{{dt}}</a>
+          </h4>
         </div>
-      </div>
-    {% end %}
+        <div id="collapse{{cleaned_dt}}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading{{cleaned_dt}}">
+          <div class="panel-body">
+            {% for prep in prep_info[dt] %}
+              <a href="#" style="display:block;color:black;" onclick="populate_main_div('/study/description/prep_template/', { prep_id: {{prep['id']}}, study_id: {{study_id}} });">
+                <span id="prep-header-{{prep['id']}}">{{prep['name']}} - ID {{prep['id']}} - {{prep['status']}}</span><br/>
+                {{prep['start_artifact']}} - ID {{prep['start_artifact_id']}}<br/>
+                {{prep['youngest_artifact']}}
+              </a>
+              <hr>
+            {% end %}
+          </div>
+        </div>
+      {% end %}
+    </div>
   </div>
-</div>
+{% else %}
+<h4>No preparation information has been added yet</h4>
+{% end %}

--- a/qiita_pet/templates/study_ajax/prep_summary.html
+++ b/qiita_pet/templates/study_ajax/prep_summary.html
@@ -337,7 +337,7 @@
 <div class="row">
   <div class="col-md-12">
     <h4>
-      {{name}} - ID {{prep_id}}
+      {{name}} - ID {{prep_id}} ({{data_type}})
       <a class="btn btn-default" href="/download/{{download_prep}}"><span class="glyphicon glyphicon-download-alt"></span> Prep info</a>
       <a class="btn btn-default" href="/download/{{download_qiime}}"><span class="glyphicon glyphicon-download-alt"></span> Qiime map</a>
       {% if editable %}

--- a/qiita_pet/templates/study_ajax/processing_artifact.html
+++ b/qiita_pet/templates/study_ajax/processing_artifact.html
@@ -52,6 +52,7 @@
       .done(function(data) {
         if (data.status == 'success') {
           bootstrapAlert("Workflow " + w_id + " submitted", "success");
+          populate_main_div('/study/description/baseinfo/', { study_id: {{study_id}} });
         }
         else {
           bootstrapAlert(data.message, "danger");

--- a/qiita_pet/templates/study_ajax/sample_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_summary.html
@@ -46,7 +46,7 @@
 {% if editable %}
   <div class="row">
     <div class="col-md-12">
-      <b>Update information</b>
+      <b>Upload information</b>
       <select id="file-selector">
         <option value="">Choose file...</option>
         {% for fp in files %}
@@ -56,7 +56,7 @@
       {% if stats %}
         <button class="btn btn-info btn-sm" onclick="sample_action('update')">Update</button>
       {% else %}
-        <button class="btn btn-info btn-sm" onclick="sample_action('create')">Create</button>
+        <button class="btn btn-info btn-sm" onclick="sample_action('create')">Create</button><br/>
         If uploading a qiime mapping file, select data type:
         <select id="data_types" value="data_types">
           <option value="">Choose a data type...</option>

--- a/qiita_pet/templates/study_ajax/sample_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_summary.html
@@ -15,6 +15,18 @@
          fill_sample({{study_id}})
       })
   }
+
+  $(document).ready(function() {
+    $('#file-btn').prop('disabled', true);
+    $("#file-selector").change(function (event){
+      if($("#file-selector").val() === "" ){
+        $('#file-btn').prop('disabled', true);
+      }
+      else {
+        $('#file-btn').prop('disabled', false);
+      }
+    });
+  });
 </script>
 
 
@@ -54,9 +66,9 @@
         {% end %}
       </select>
       {% if stats %}
-        <button class="btn btn-info btn-sm" onclick="sample_action('update')">Update</button>
+        <button class="btn btn-info btn-sm" id="file-btn" onclick="sample_action('update')">Update</button>
       {% else %}
-        <button class="btn btn-info btn-sm" onclick="sample_action('create')">Create</button><br/>
+        <button class="btn btn-info btn-sm" id="file-btn" onclick="sample_action('create')">Create</button><br/>
         If uploading a qiime mapping file, select data type:
         <select id="data_types" value="data_types">
           <option value="">Choose a data type...</option>

--- a/qiita_pet/templates/study_base.html
+++ b/qiita_pet/templates/study_base.html
@@ -214,8 +214,6 @@
     {% if editable %}
     <a href="/study/upload/{{study_info['study_id']}}">Upload Files</a><br />
     <a href="#" onclick="populate_main_div('/study/new_prep_template/', { study_id: {{study_info['study_id']}} })">Add New Preparation</a><br />
-    <a href="/study/edit/{{study_info['study_id']}}">Edit Study Information</a><br />
-    <a href="#" data-toggle="modal" data-target="#delete-study">Delete Study</a>
     {% end %}
 
     <div id="data-types-menu"></div>

--- a/qiita_pet/templates/study_base.html
+++ b/qiita_pet/templates/study_base.html
@@ -135,7 +135,7 @@
             bootstrapAlert(data.message.replace("\n", "<br/>"), "danger", 4000);
             $("#delete-study").modal('hide');
           } else {
-            window.location.replace = '/';
+            window.location.replace('/study/list/');
           }
         });
     }

--- a/qiita_pet/templates/study_base.html
+++ b/qiita_pet/templates/study_base.html
@@ -211,7 +211,9 @@
   <div class="col-md-3">
   <h3><a href="#" onclick="populate_main_div('/study/description/baseinfo/', { study_id: {{study_info['study_id']}} })">Study Information</a></h3>
     <a href="#" onclick="populate_main_div('/study/description/sample_template/', { study_id: {{study_info['study_id']}} })">Sample Template</a><br />
-    <a href="#" onclick="populate_main_div('/study/description/sample_summary/', { study_id: {{study_info['study_id']}} })">Sample Summary</a><br />
+    {% if study_info['num_samples'] != 0 %}
+      <a href="#" onclick="populate_main_div('/study/description/sample_summary/', { study_id: {{study_info['study_id']}} })">Sample Summary</a><br />
+    {% end %}
     {% if editable %}
     <a href="/study/upload/{{study_info['study_id']}}">Upload Files</a><br />
     <a href="#" onclick="populate_main_div('/study/new_prep_template/', { study_id: {{study_info['study_id']}} })">Add New Preparation</a><br />

--- a/qiita_pet/templates/study_base.html
+++ b/qiita_pet/templates/study_base.html
@@ -116,7 +116,7 @@
   }
 
   function validate_delete_study_text() {
-    if ($("#study-alias").val() == "{{study_info['study_alias']}}") {
+    if ($("#study-alias").val() == "{{study_info['study_title']}}") {
       $('#delete-study-button').prop('disabled', false);
     } else {
       $('#delete-study-button').prop('disabled', true);
@@ -124,7 +124,7 @@
   }
 
   function delete_study() {
-    if($("#study-alias").val() != "{{study_info['study_alias']}}") {
+    if($("#study-alias").val() != "{{study_info['study_title']}}") {
       alert("The entered study alias doesn't match the study");
       return false;
     }
@@ -133,6 +133,7 @@
         .done(function ( data ) {
           if(data.status == "error") {
             bootstrapAlert(data.message.replace("\n", "<br/>"), "danger", 4000);
+            $("#delete-study").modal('hide');
           } else {
             window.location.replace = '/';
           }
@@ -241,12 +242,12 @@
         <h3>Deleting:<br/></h3><h4>{{study_info['study_title']}}</h4>
       </div>
       <div class="modal-body">
-        You will only be able to delete a study that has no data associated with it.
+        You will only be able to delete a study that has no data associated with it.<br/>
+        To continue you need to write the title of the study:<br/>
+        <input type="text" name="study-alias" id="study-alias" onkeyup="validate_delete_study_text();" size="{{ len(study_info['study_title']) }}">
+        <button class="btn btn-danger glyphicon glyphicon-trash" onclick="delete_study();" id="delete-study-button" disabled></button>
       </div>
       <div class="modal-footer">
-        To continue you need to write the alias name of the study:
-        <input type="text" name="study-alias" id="study-alias" onkeyup="validate_delete_study_text();">
-        <button class="btn btn-danger glyphicon glyphicon-trash" onclick="delete_study();" id="delete-study-button" disabled></button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Improvements made and issues solved here:
 - The data type of the prep template is now shown in the prep template summary too
 - The default name of the artifact is changed form `dflt-name` to `noname`
 - The edit and delete links have been moved to the study description page, and changed to buttons
 - Ask for the study title instead of the study alias when deleting a study
 - Showing a message when no prep info is present for a study, instead of the empty list
 - When deleting a study, the user is now redirected to the study list page
 - The sample summary link is now shown only if the study has a sample template
 - Fixing the bug that prevented to upload QIIME mapping files
 - Disabling the button to upload/update a sample template if no file is selected
 - Fixing bug that prevented to edit the study info if the lab person did not exist
 - Once a workflow is submitted, the user is redirected out of the processing workflow page