### PR TITLE
Addressing several small issues

### DIFF
--- a/qiita_pet/handlers/api_proxy/artifact.py
+++ b/qiita_pet/handlers/api_proxy/artifact.py
@@ -54,9 +54,16 @@ def artifact_summary_get_request(user_id, artifact_id):
     summary = artifact.html_summary_fp
     job_info = None
     errored_jobs = []
-    processing_jobs = [
-        [j.id, j.command.name, j.status, j.step] for j in artifact.jobs()
-        if j.command.software.type == "artifact transformation"]
+    processing_jobs = []
+    for j in artifact.jobs():
+        if j.command.software.type == "artifact transformation":
+            status = j.status
+            if status == 'success':
+                continue
+            j_msg = j.log.msg if status == 'error' else None
+            processing_jobs.append(
+                [j.id, j.command.name, j.status, j.step, j_msg])
+
     # Check if the HTML summary exists
     if summary:
         with open(summary[1]) as f:

--- a/qiita_pet/handlers/api_proxy/tests/test_artifact.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_artifact.py
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
 from unittest import TestCase, main
-from os.path import join, exists
+from os.path import join, exists, basename
 from os import remove, close
 from datetime import datetime
 from tempfile import mkstemp
@@ -134,16 +134,10 @@ class TestArtifactAPI(TestCase):
         # Artifact w/o summary
         obs = artifact_summary_get_request('test@foo.bar', 1)
         exp_p_jobs = [
-            ['6d368e16-2242-4cf8-87b4-a5dc40bb890b', 'Split libraries FASTQ',
-             'success', None],
-            ['4c7115e8-4c8e-424c-bf25-96c292ca1931', 'Split libraries FASTQ',
-             'success', None],
             ['063e553b-327c-4818-ab4a-adfe58e49860', 'Split libraries FASTQ',
-             'queued', None],
+             'queued', None, None],
             ['bcc7ebcd-39c1-43e4-af2d-822e3589f14d', 'Split libraries',
-             'running', 'demultiplexing'],
-            ['b72369f9-a886-4193-8d3d-f7b504168e75', 'Split libraries FASTQ',
-             'success', None]]
+             'running', 'demultiplexing', None]]
         exp_files = [
             (1L, '1_s_G1_L001_sequences.fastq.gz (raw forward seqs)'),
             (2L, '1_s_G1_L001_sequences_barcodes.fastq.gz (raw barcodes)')]
@@ -163,7 +157,7 @@ class TestArtifactAPI(TestCase):
                           'sandbox</button>',
                'files': exp_files,
                'editable': True}
-        self.assertItemsEqual(obs, exp)
+        self.assertEqual(obs, exp)
 
         # Artifact with summary being generated
         job = ProcessingJob.create(
@@ -188,7 +182,7 @@ class TestArtifactAPI(TestCase):
                           'sandbox</button>',
                'files': exp_files,
                'editable': True}
-        self.assertItemsEqual(obs, exp)
+        self.assertEqual(obs, exp)
 
         # Artifact with summary
         fd, fp = mkstemp(suffix=".html")
@@ -198,6 +192,9 @@ class TestArtifactAPI(TestCase):
         a = Artifact(1)
         a.html_summary_fp = fp
         self._files_to_remove.extend([fp, a.html_summary_fp[1]])
+        exp_files.append(
+            (a.html_summary_fp[0],
+             '%s (html summary)' % basename(a.html_summary_fp[1])))
         obs = artifact_summary_get_request('test@foo.bar', 1)
         exp = {'status': 'success',
                'message': '',
@@ -215,7 +212,7 @@ class TestArtifactAPI(TestCase):
                           'sandbox</button>',
                'files': exp_files,
                'editable': True}
-        self.assertItemsEqual(obs, exp)
+        self.assertEqual(obs, exp)
 
         # No access
         obs = artifact_summary_get_request('demo@microbio.me', 1)

--- a/qiita_pet/static/js/qiita.js
+++ b/qiita_pet/static/js/qiita.js
@@ -8,6 +8,9 @@
  *
  */
 function bootstrapAlert(message, severity, timeout){
+  // Clear the previous alert - so they don't keep stacking on top of each other
+  $('#bootstrap-alert').alert('close');
+
   // make timeout an optional parameter
   timeout = timeout || -1;
 

--- a/qiita_pet/templates/study_ajax/artifact_summary.html
+++ b/qiita_pet/templates/study_ajax/artifact_summary.html
@@ -77,10 +77,13 @@
     {% if processing_jobs %}
       <b>Jobs using this set of files:</b></br>
     {% end %}
-    {% for j_id, c_name, j_status, s_step in processing_jobs %}
+    {% for j_id, c_name, j_status, j_step, j_error in processing_jobs %}
       Job <b>{{j_id}}</b> ({{c_name}}). Status: <i>{{j_status}}</i>.
-      {% if s_step %}
-        Step: <i>{{s_step}}</i>
+      {% if j_step %}
+        Step: <i>{{j_step}}</i>
+      {% end %}
+      {% if j_error %}
+        Erro message: <i>{{j_error}}</i>
       {% end %}
       </br>
     {% end %}

--- a/qiita_pet/templates/study_ajax/artifact_summary.html
+++ b/qiita_pet/templates/study_ajax/artifact_summary.html
@@ -19,7 +19,7 @@
           $("#artifact-summary-content").html(html_contents);
         }
         else {
-          bootstrapAlert(data.message.replace("\n", "<br/>"), "danger", 4000);
+          bootstrapAlert(data.message.replace("\n", "<br/>"), "danger");
         }
       });
   }
@@ -40,7 +40,7 @@
         var status = "info";
         if(data["status"] == "error") { status = "danger"; }
         //Show for 4 seconds (4000 ms), then remove
-        bootstrapAlert(data.message.replace("\n", "<br/>"), status, 4000);
+        bootstrapAlert(data.message.replace("\n", "<br/>"), status);
         //update buttons to match new status
         load_artifact_summary(aid);
       });

--- a/qiita_pet/templates/study_ajax/prep_summary.html
+++ b/qiita_pet/templates/study_ajax/prep_summary.html
@@ -84,7 +84,7 @@
   function add_new_investigation_type_term_and_update() {
     var new_val = $("#new-ontology").val();
     if (!new_val.match(/^[0-9a-zA-Z ]+$/)) {
-      bootstrapAlert("Only alphanumeric characters and space are allowed.", "danger", 4000);
+      bootstrapAlert("Only alphanumeric characters and space are allowed.", "danger");
     }
     else {
       $.ajax({

--- a/qiita_pet/templates/study_ajax/sample_prep_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_prep_summary.html
@@ -33,7 +33,7 @@ Add sample column information to table
         if(data.status == "success"){
           addColumn(meta_val, data.values);
         } else {
-          bootstrapAlert(data.message.replace("\n", "<br/>"), "danger", 4000);
+          bootstrapAlert(data.message.replace("\n", "<br/>"), "danger");
         }
       });
   }

--- a/qiita_pet/templates/study_ajax/sample_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_summary.html
@@ -10,15 +10,28 @@
   function sample_action(act) {
     $.post('/study/description/sample_template/', { study_id: {{study_id}}, action: act, filepath: $("#file-selector").val(), data_type: $("#data_types").val() })
       .done(function ( data ) {
+        var msg_type = "info";
         if(data.status == "error") {
-          bootstrapAlert("<p>An error occurred processing your request:</p>" + data.message, "danger");
+          msg_type = "danger";
         } else if(data.status == "warning") {
-          bootstrapAlert(data.message.replace("\n", "<br/>"), "warning");
-        } else {
-          bootstrapAlert(data.message.replace("\n", "<br/>"), "info");
+          msg_type = "warning";
         }
-        //reload section of the page with new info
-         fill_sample({{study_id}})
+
+        if (data.message) {
+          bootstrapAlert(data.message.replace("\n", "<br/>"), msg_type);
+        }
+
+        if (data.status != 'error') {
+          //reload section of the page with new info
+          populate_main_div('/study/description/sample_template/', { study_id: {{study_id}} });
+          populate_data_type_menu_div();
+          if (act == 'delete') {
+            $("#sample-summary-btn").hide();
+          }
+          else if(act == 'create') {
+            $("#sample-summary-btn").show();
+          }
+        }
       })
   }
 
@@ -64,7 +77,7 @@
 {% if editable %}
   <div class="row">
     <div class="col-md-12">
-      <b>Upload information</b>
+      <b>Upload information:</b>
       <select id="file-selector">
         <option value="">Choose file...</option>
         {% for fp in files %}

--- a/qiita_pet/templates/study_ajax/sample_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_summary.html
@@ -11,11 +11,11 @@
     $.post('/study/description/sample_template/', { study_id: {{study_id}}, action: act, filepath: $("#file-selector").val(), data_type: $("#data_types").val() })
       .done(function ( data ) {
         if(data.status == "error") {
-          bootstrapAlert("<p>An error occurred processing your request:</p>" + data.message, "danger", 4000);
+          bootstrapAlert("<p>An error occurred processing your request:</p>" + data.message, "danger");
         } else if(data.status == "warning") {
-          bootstrapAlert(data.message.replace("\n", "<br/>"), "warning", 4000);
+          bootstrapAlert(data.message.replace("\n", "<br/>"), "warning");
         } else {
-          bootstrapAlert(data.message.replace("\n", "<br/>"), "info", 4000);
+          bootstrapAlert(data.message.replace("\n", "<br/>"), "info");
         }
         //reload section of the page with new info
          fill_sample({{study_id}})

--- a/qiita_pet/templates/study_ajax/sample_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_summary.html
@@ -1,11 +1,17 @@
 {% from future.utils import viewitems %}
 
 <script type="text/javascript">
+  function delete_sample_template() {
+    if(confirm("Are you sure you want to delete the sample information?")) {
+      sample_action('delete');
+    }
+  }
+
   function sample_action(act) {
     $.post('/study/description/sample_template/', { study_id: {{study_id}}, action: act, filepath: $("#file-selector").val(), data_type: $("#data_types").val() })
       .done(function ( data ) {
         if(data.status == "error") {
-          bootstrapAlert("<p>Error updating sample template</p>" + data.message, "danger", 4000);
+          bootstrapAlert("<p>An error occurred processing your request:</p>" + data.message, "danger", 4000);
         } else if(data.status == "warning") {
           bootstrapAlert(data.message.replace("\n", "<br/>"), "warning", 4000);
         } else {
@@ -38,7 +44,7 @@
       {% if download_id %}
         <a class="btn btn-default" href="/download/{{download_id}}"><span class="glyphicon glyphicon-download-alt"></span> Sample info</a>
         {% if editable %}
-          <a class="btn btn-danger" onclick="sample_action('delete');"><span class="glyphicon glyphicon-trash"></span> Delete</a>
+          <a class="btn btn-danger" onclick="delete_sample_template();"><span class="glyphicon glyphicon-trash"></span> Delete</a>
         {% end %}
       {% end %}
     </h4>

--- a/qiita_pet/templates/study_base.html
+++ b/qiita_pet/templates/study_base.html
@@ -37,7 +37,7 @@
     $.post("/artifact/", {artifact_id: +aid })
       .done(function ( data ) {
         if( data.status == "success"  && curr_prep != -1 ) { fill_prep(curr_prep); }
-        if( data.status == "error") { bootstrapAlert(data.message.replace("\n", "<br/>"), "danger", 4000); }
+        if( data.status == "error") { bootstrapAlert(data.message.replace("\n", "<br/>"), "danger"); }
       });
   }
 
@@ -132,7 +132,7 @@
       $.post('/study/delete/', { study_id: {{study_info['study_id']}} })
         .done(function ( data ) {
           if(data.status == "error") {
-            bootstrapAlert(data.message.replace("\n", "<br/>"), "danger", 4000);
+            bootstrapAlert(data.message.replace("\n", "<br/>"), "danger");
             $("#delete-study").modal('hide');
           } else {
             window.location.replace('/study/list/');

--- a/qiita_pet/templates/study_base.html
+++ b/qiita_pet/templates/study_base.html
@@ -196,6 +196,12 @@
     populate_data_type_menu_div();
     // The initial page to be shown is the base information of the study
     populate_main_div("/study/description/baseinfo/", { study_id: {{study_info['study_id']}}});
+
+    {% if study_info['num_samples'] > 0 %}
+      $("#sample-summary-btn").show();
+    {% else %}
+      $("#sample-summary-btn").hide();
+    {% end %}
   });
 </script>
 <style>
@@ -209,14 +215,12 @@
 {% block content %}
 <div class="row">
   <div class="col-md-3">
-  <h3><a href="#" onclick="populate_main_div('/study/description/baseinfo/', { study_id: {{study_info['study_id']}} })">Study Information</a></h3>
-    <a href="#" onclick="populate_main_div('/study/description/sample_template/', { study_id: {{study_info['study_id']}} })">Sample Template</a><br />
-    {% if study_info['num_samples'] != 0 %}
-      <a href="#" onclick="populate_main_div('/study/description/sample_summary/', { study_id: {{study_info['study_id']}} })">Sample Summary</a><br />
-    {% end %}
+    <button class="btn btn-info btn-block" onclick="populate_main_div('/study/description/baseinfo/', { study_id: {{study_info['study_id']}} })"><span class="glyphicon glyphicon-info-sign"></span> Study Information</button>
+    <button class="btn btn-info btn-block" onclick="populate_main_div('/study/description/sample_template/', { study_id: {{study_info['study_id']}} })"><span class="glyphicon glyphicon-info-sign"></span> Sample Template</button>
+    <button class="btn btn-info btn-block" onclick="populate_main_div('/study/description/sample_summary/', { study_id: {{study_info['study_id']}} })" id="sample-summary-btn"><span class="glyphicon glyphicon-th-list"></span> Sample Summary</button>
     {% if editable %}
-    <a href="/study/upload/{{study_info['study_id']}}">Upload Files</a><br />
-    <a href="#" onclick="populate_main_div('/study/new_prep_template/', { study_id: {{study_info['study_id']}} })">Add New Preparation</a><br />
+      <a class="btn btn-info btn-block" href="/study/upload/{{study_info['study_id']}}"><span class="glyphicon glyphicon-upload"></span> Upload Files</a>
+      <button class="btn btn-info btn-block" onclick="populate_main_div('/study/new_prep_template/', { study_id: {{study_info['study_id']}} })"><span class="glyphicon glyphicon-plus-sign"></span> Add New Preparation</button>
     {% end %}
 
     <div id="data-types-menu"></div>


### PR DESCRIPTION
Issues addressed here:
 - It now asks for confirmation when deleting a sample template
 - In the bootstrapAlert messages, the timeout has been remove and we let the user decide when to close them (using the x in the message). Also, clear the previous message before adding the new one to avoid stacking of error messages.
 - The menu on the left with the boring links have been changed to buttons, and the button to the sample summary is now shown/hidden when necessary.
 - The successfully completed jobs are not shown in the interface.
 - The error message of the failed jobs is shown in the interface