### PR TITLE
Assert items bug

### DIFF
--- a/qiita_db/test/test_search.py
+++ b/qiita_db/test/test_search.py
@@ -239,7 +239,9 @@ class SearchTest(TestCase):
             '1.SKD8.640184', '1.SKD9.640182', '1.SKM1.640183', '1.SKM2.640199',
             '1.SKM3.640197', '1.SKM4.640180', '1.SKM5.640177', '1.SKM6.640187',
             '1.SKM7.640188', '1.SKM8.640201', '1.SKM9.640192']}
-        self.assertItemsEqual(pds, exp_pds)
+        self.assertItemsEqual(pds.keys(), exp_pds.keys())
+        for k in exp_pds:
+            self.assertItemsEqual(pds[k], exp_pds[k])
 
         exp_meta = pd.DataFrame.from_dict({x: 1 for x in exp_pds[4]},
                                           orient='index')

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -111,12 +111,19 @@ class CommandTestsReadOnly(TestCase):
     def test_required_parameters(self):
         exp_params = {
             'input_data': ('artifact', ['FASTQ', 'per_sample_FASTQ'])}
-        self.assertItemsEqual(qdb.software.Command(1).required_parameters,
-                              exp_params)
+        obs = qdb.software.Command(1).required_parameters
+        self.assertItemsEqual(obs.keys(), exp_params.keys())
+        self.assertEqual(obs['input_data'][0],  exp_params['input_data'][0])
+        self.assertItemsEqual(obs['input_data'][1],
+                              exp_params['input_data'][1])
+
         exp_params = {
             'input_data': ('artifact', ['SFF', 'FASTA', 'FASTA_Sanger'])}
-        self.assertItemsEqual(qdb.software.Command(2).required_parameters,
-                              exp_params)
+        obs = qdb.software.Command(2).required_parameters
+        self.assertItemsEqual(obs.keys(), exp_params.keys())
+        self.assertEqual(obs['input_data'][0],  exp_params['input_data'][0])
+        self.assertItemsEqual(obs['input_data'][1],
+                              exp_params['input_data'][1])
 
     def test_optional_parameters(self):
         exp_params = {'barcode_type': ['string', 'golay_12'],

--- a/qiita_db/test/test_study.py
+++ b/qiita_db/test/test_study.py
@@ -214,7 +214,7 @@ class TestStudy(TestCase):
             'Soils', 'number_samples_collected': 27,
             'ebi_submission_status': 'submitted',
             'ebi_study_accession': 'EBI123456-BB'}
-        self.assertItemsEqual(obs, exp)
+        self.assertEqual(obs, exp)
 
         # Test get specific keys for single study
         exp_keys = ['metadata_complete', 'reprocess', 'timeseries_type',
@@ -228,7 +228,7 @@ class TestStudy(TestCase):
             'publication_doi': ['10.100/123456', '10.100/7891011'],
             'study_title': 'Identification of the Microbiomes for Cannabis '
             'Soils'}
-        self.assertItemsEqual(obs, exp)
+        self.assertEqual(obs, exp)
 
         # Test get specific keys for all studies
         info = {

--- a/qiita_pet/handlers/api_proxy/tests/test_artifact.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_artifact.py
@@ -75,9 +75,13 @@ class TestArtifactAPIReadOnly(TestCase):
                                (3, 'Demultiplexed 2 - Demultiplexed'),
                                (2, 'Demultiplexed 1 - Demultiplexed'),
                                (4, 'BIOM - BIOM'),
-                               (5, 'BIOM - BIOM')],
-               'edge_list': [(1, 3), (1, 2), (2, 5), (2, 4)]}
-        self.assertItemsEqual(obs, exp)
+                               (5, 'BIOM - BIOM'),
+                               (6, 'BIOM - BIOM')],
+               'edge_list': [(1, 3), (1, 2), (2, 5), (2, 4), (2, 6)]}
+        self.assertEqual(obs['message'], exp['message'])
+        self.assertEqual(obs['status'], exp['status'])
+        self.assertItemsEqual(obs['node_labels'], exp['node_labels'])
+        self.assertItemsEqual(obs['edge_list'], exp['edge_list'])
 
     def test_artifact_graph_get_req_no_access(self):
         obs = artifact_graph_get_req(1, 'ancestors', 'demo@microbio.me')

--- a/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
@@ -169,11 +169,11 @@ class TestPrepAPIReadOnly(TestCase):
         exp = {'status': 'success',
                'message': '',
                'filepaths': [
-                   (15, join(get_mountpoint('templates')[0][1],
-                             '1_prep_1_19700101-000000.txt')),
-                   (16, join(get_mountpoint('templates')[0][1],
-                             '1_prep_1_qiime_19700101-000000.txt'))]}
-        self.assertItemsEqual(obs, exp)
+                   (19, join(get_mountpoint('templates')[0][1],
+                             '1_prep_1_qiime_19700101-000000.txt')),
+                   (18, join(get_mountpoint('templates')[0][1],
+                             '1_prep_1_19700101-000000.txt'))]}
+        self.assertEqual(obs, exp)
 
     def test_prep_template_filepaths_get_req_no_access(self):
         obs = prep_template_filepaths_get_req(1, 'demo@microbio.me')
@@ -278,15 +278,19 @@ class TestPrepAPI(TestCase):
 
     def test_prep_template_graph_get_req(self):
         obs = prep_template_graph_get_req(1, 'test@foo.bar')
-        exp = {'edge_list': [(1, 3), (1, 2), (2, 4), (2, 5)],
+        exp = {'edge_list': [(1, 3), (1, 2), (2, 4), (2, 5), (2, 6)],
                'node_labels': [(1, 'Raw data 1 - FASTQ'),
                                (2, 'Demultiplexed 1 - Demultiplexed'),
                                (3, 'Demultiplexed 2 - Demultiplexed'),
                                (4, 'BIOM - BIOM'),
-                               (5, 'BIOM - BIOM')],
+                               (5, 'BIOM - BIOM'),
+                               (6, 'BIOM - BIOM')],
                'status': 'success',
                'message': ''}
-        self.assertItemsEqual(obs, exp)
+        self.assertItemsEqual(obs['edge_list'], exp['edge_list'])
+        self.assertItemsEqual(obs['node_labels'], exp['node_labels'])
+        self.assertEqual(obs['status'], exp['status'])
+        self.assertEqual(obs['message'], exp['message'])
 
         Artifact(4).visibility = "public"
         obs = prep_template_graph_get_req(1, 'demo@microbio.me')
@@ -296,7 +300,10 @@ class TestPrepAPI(TestCase):
                                (4, 'BIOM - BIOM')],
                'status': 'success',
                'message': ''}
-        self.assertItemsEqual(obs, exp)
+        self.assertItemsEqual(obs['edge_list'], exp['edge_list'])
+        self.assertItemsEqual(obs['node_labels'], exp['node_labels'])
+        self.assertEqual(obs['status'], exp['status'])
+        self.assertEqual(obs['message'], exp['message'])
 
     def test_process_investigation_type(self):
         obs = _process_investigation_type('Metagenomics', '', '')

--- a/qiita_pet/handlers/api_proxy/tests/test_processing.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_processing.py
@@ -64,9 +64,11 @@ class TestProcessingAPIReadOnly(TestCase):
                                        'sortmerna_e_value': 1,
                                        'sortmerna_max_pos': 10000,
                                        'threads': 1}}],
-               'req_options': {'input_data':
-                               ('artifact', ['per_sample_FASTQ', 'FASTQ'])}}
-        self.assertItemsEqual(obs, exp)
+               'req_options': {'input_data': ('artifact', ['Demultiplexed'])}}
+        self.assertEqual(obs['status'], exp['status'])
+        self.assertEqual(obs['message'], exp['message'])
+        self.assertEqual(obs['options'], exp['options'])
+        self.assertEqual(obs['req_options'], exp['req_options'])
 
     def test_job_ajax_get_req(self):
         obs = job_ajax_get_req("063e553b-327c-4818-ab4a-adfe58e49860")

--- a/qiita_pet/handlers/study_handlers/tests/test_artifact.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_artifact.py
@@ -43,10 +43,15 @@ class ArtifactGraphAJAXTests(TestHandlerBase):
                                [3, 'Demultiplexed 2 - Demultiplexed'],
                                [2, 'Demultiplexed 1 - Demultiplexed'],
                                [4, 'BIOM - BIOM'],
-                               [5, 'BIOM - BIOM']],
-               'edge_list': [[1, 3], [1, 2], [2, 4], [2, 5]]}
+                               [5, 'BIOM - BIOM'],
+                               [6, 'BIOM - BIOM']],
+               'edge_list': [[1, 3], [1, 2], [2, 4], [2, 5], [2, 6]]}
         self.assertEqual(response.code, 200)
-        self.assertItemsEqual(loads(response.body), exp)
+        obs = loads(response.body)
+        self.assertEqual(obs['status'], exp['status'])
+        self.assertEqual(obs['message'], exp['message'])
+        self.assertItemsEqual(obs['node_labels'], exp['node_labels'])
+        self.assertItemsEqual(obs['edge_list'], exp['edge_list'])
 
     def test_get_unknown(self):
         response = self.get('/artifact/graph/', {'direction': 'BAD',

--- a/qiita_pet/handlers/study_handlers/tests/test_prep_template.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_prep_template.py
@@ -26,10 +26,15 @@ class TestPrepTemplateGraphAJAX(TestHandlerBase):
                                [3, "Demultiplexed 2 - Demultiplexed"],
                                [2, "Demultiplexed 1 - Demultiplexed"],
                                [4, "BIOM - BIOM"],
-                               [4, "BIOM - BIOM"]],
+                               [5, "BIOM - BIOM"],
+                               [6, "BIOM - BIOM"]],
                "message": "",
-               "edge_list": [[1, 3], [1, 2], [2, 4], [2, 5]]}
-        self.assertItemsEqual(loads(response.body), exp)
+               "edge_list": [[1, 3], [1, 2], [2, 4], [2, 5], [2, 6]]}
+        obs = loads(response.body)
+        self.assertEqual(obs['status'], exp['status'])
+        self.assertEqual(obs['message'], exp['message'])
+        self.assertItemsEqual(obs['node_labels'], exp['node_labels'])
+        self.assertItemsEqual(obs['edge_list'], exp['edge_list'])
 
 
 class TestPrepTemplateAJAXReadOnly(TestHandlerBase):


### PR DESCRIPTION
`assertItemsEqual` can't be used on dictionaries, it only tests the keys. I've done a search in the code base and fixed all the cases in which `assertItemsEqual` was incorrectly used.

@antgonza it will be good to let this one to run the tests - and I have a problem fixing an instance in `qiita_db/test/test_analysis.py` so let me know when you're online and we can chat about it.