### PR TITLE
Offload template processing from webserver

### DIFF
--- a/qiita_db/metadata_template/sample_template.py
+++ b/qiita_db/metadata_template/sample_template.py
@@ -137,7 +137,7 @@ class SampleTemplate(MetadataTemplate):
             has_prep_templates = qdb.sql_connection.TRN.execute_fetchlast()
             if has_prep_templates:
                 raise qdb.exceptions.QiitaDBError(
-                    "Sample template can not be erased because there are prep "
+                    "Sample template cannot be erased because there are prep "
                     "templates associated.")
 
             table_name = cls._table_name(id_)

--- a/qiita_pet/handlers/api_proxy/prep_template.py
+++ b/qiita_pet/handlers/api_proxy/prep_template.py
@@ -139,13 +139,11 @@ def prep_template_ajax_get_req(user_id, prep_id):
             alert_msg = 'This prep template is currently being updated'
         else:
             alert_type = redis_info['return']['status']
-            alert_msg = redis_info['return']['message']
+            alert_msg = redis_info['return']['message'].replace('\n', '</br>')
     else:
         processing = False
         alert_type = ''
         alert_msg = ''
-
-    alert_msg = alert_msg.replace('\n', '</br>')
 
     editable = Study(study_id).can_edit(User(user_id)) and not processing
 

--- a/qiita_pet/handlers/api_proxy/sample_template.py
+++ b/qiita_pet/handlers/api_proxy/sample_template.py
@@ -227,12 +227,11 @@ def sample_template_summary_get_req(samp_id, user_id):
             alert_msg = 'This sample template is currently being processed'
         else:
             alert_type = redis_info['return']['status']
-            alert_msg = redis_info['return']['message']
+            alert_msg = redis_info['return']['message'].replace('\n', '</br>')
     else:
         processing = False
         alert_type = ''
         alert_msg = ''
-    alert_msg = alert_msg.replace('\n', '</br>')
 
     exists = _check_sample_template_exists(int(samp_id))
     if exists['status'] != 'success':

--- a/qiita_pet/handlers/api_proxy/sample_template.py
+++ b/qiita_pet/handlers/api_proxy/sample_template.py
@@ -415,7 +415,7 @@ def sample_template_delete_req(study_id, user_id):
     # Store the job id attaching it to the sample template id
     r_client.set(SAMPLE_TEMPLATE_KEY_FORMAT % study_id, job_id)
 
-    return {'status': 'success'}
+    return {'status': 'success', 'message': ''}
 
 
 @execute_as_transaction

--- a/qiita_pet/handlers/api_proxy/tests/test_sample_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_sample_template.py
@@ -8,6 +8,8 @@
 from unittest import TestCase, main
 from os import remove, mkdir
 from os.path import join, exists
+from time import sleep
+from json import loads
 
 from moi import r_client
 
@@ -317,6 +319,14 @@ class TestSampleAPI(TestCase):
         obs = r_client.get('sample_template_1')
         self.assertIsNotNone(obs)
 
+        # This is needed so the clean up works - this is a distributed system
+        # so we need to make sure that all processes are done before we reset
+        # the test database
+        redis_info = loads(r_client.get(obs))
+        while redis_info['status_msg'] == 'Running':
+            sleep(0.05)
+            redis_info = loads(r_client.get(obs))
+
     def test_sample_template_post_req_no_access(self):
         obs = sample_template_post_req(1, 'demo@microbio.me', '16S',
                                        'filepath')
@@ -334,6 +344,14 @@ class TestSampleAPI(TestCase):
 
         obs = r_client.get('sample_template_1')
         self.assertIsNotNone(obs)
+
+        # This is needed so the clean up works - this is a distributed system
+        # so we need to make sure that all processes are done before we reset
+        # the test database
+        redis_info = loads(r_client.get(obs))
+        while redis_info['status_msg'] == 'Running':
+            sleep(0.05)
+            redis_info = loads(r_client.get(obs))
 
     def test_sample_template_put_req_no_access(self):
         obs = sample_template_put_req(1, 'demo@microbio.me', 'filepath')
@@ -356,6 +374,14 @@ class TestSampleAPI(TestCase):
 
         obs = r_client.get('sample_template_1')
         self.assertIsNotNone(obs)
+
+        # This is needed so the clean up works - this is a distributed system
+        # so we need to make sure that all processes are done before we reset
+        # the test database
+        redis_info = loads(r_client.get(obs))
+        while redis_info['status_msg'] == 'Running':
+            sleep(0.05)
+            redis_info = loads(r_client.get(obs))
 
     def test_sample_template_delete_req_no_access(self):
         obs = sample_template_delete_req(1, 'demo@microbio.me')

--- a/qiita_pet/handlers/api_proxy/tests/test_sample_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_sample_template.py
@@ -9,6 +9,8 @@ from unittest import TestCase, main
 from os import remove, mkdir
 from os.path import join, exists
 
+from moi import r_client
+
 from qiita_core.util import qiita_test_checker
 import qiita_db as qdb
 from qiita_pet.handlers.api_proxy.sample_template import (
@@ -58,6 +60,8 @@ class TestSampleAPI(TestCase):
 
         if exists(self.new_study_fp):
             remove(self.new_study_fp)
+
+        r_client.flushdb()
 
     def test_check_sample_template_exists(self):
         obs = _check_sample_template_exists(1)
@@ -125,7 +129,7 @@ class TestSampleAPI(TestCase):
 
     def test_sample_template_summary_get_req(self):
         obs = sample_template_summary_get_req(1, 'test@foo.bar')
-        exp = {'summary': {
+        exp = {'stats': {
             'physical_specimen_location': [('ANL', 27)],
             'texture': [('63.1 sand, 17.7 silt, 19.2 clay', 9),
                         ('64.6 sand, 17.6 silt, 17.8 clay', 9),
@@ -208,7 +212,9 @@ class TestSampleAPI(TestCase):
                'num_columns': 30,
                'editable': True,
                'status': 'success',
-               'message': ''}
+               'message': '',
+               'alert_type': '',
+               'alert_message': ''}
         self.assertEqual(obs, exp)
 
     def test_sample_template_summary_get_req_no_access(self):
@@ -303,10 +309,13 @@ class TestSampleAPI(TestCase):
     def test_sample_template_post_req(self):
         obs = sample_template_post_req(1, 'test@foo.bar', '16S',
                                        'uploaded_file.txt')
-        exp = {'status': 'error',
-               'message': 'Empty file passed!',
+        exp = {'status': 'success',
+               'message': '',
                'file': 'uploaded_file.txt'}
         self.assertEqual(obs, exp)
+
+        obs = r_client.get('sample_template_1')
+        self.assertIsNotNone(obs)
 
     def test_sample_template_post_req_no_access(self):
         obs = sample_template_post_req(1, 'demo@microbio.me', '16S',
@@ -318,10 +327,13 @@ class TestSampleAPI(TestCase):
     def test_sample_template_put_req(self):
         obs = sample_template_put_req(1, 'test@foo.bar',
                                       'uploaded_file.txt')
-        exp = {'status': 'error',
-               'message': 'Empty file passed!',
+        exp = {'status': 'success',
+               'message': '',
                'file': 'uploaded_file.txt'}
         self.assertEqual(obs, exp)
+
+        obs = r_client.get('sample_template_1')
+        self.assertIsNotNone(obs)
 
     def test_sample_template_put_req_no_access(self):
         obs = sample_template_put_req(1, 'demo@microbio.me', 'filepath')
@@ -338,10 +350,12 @@ class TestSampleAPI(TestCase):
 
     def test_sample_template_delete_req(self):
         obs = sample_template_delete_req(1, 'test@foo.bar')
-        exp = {'status': 'error',
-               'message': 'Sample template can not be erased because there are'
-                          ' prep templates associated.'}
+        exp = {'status': 'success',
+               'message': ''}
         self.assertEqual(obs, exp)
+
+        obs = r_client.get('sample_template_1')
+        self.assertIsNotNone(obs)
 
     def test_sample_template_delete_req_no_access(self):
         obs = sample_template_delete_req(1, 'demo@microbio.me')

--- a/qiita_pet/handlers/study_handlers/sample_template.py
+++ b/qiita_pet/handlers/study_handlers/sample_template.py
@@ -82,14 +82,18 @@ class SampleTemplateAJAX(BaseHandler):
                        if download['status'] == 'success' else None)
 
         stats = sample_template_summary_get_req(study_id, self.current_user.id)
-        summary = stats['summary'] if 'summary' in stats else {}
-        num_samples = stats['num_samples'] if 'num_samples' in stats else 0
-        num_columns = stats['num_columns'] if 'num_columns' in stats else 0
-        editable = stats['editable'] if 'editable' in stats else True
-        self.render('study_ajax/sample_summary.html', stats=summary,
-                    num_samples=num_samples, num_columns=num_columns,
-                    download_id=download_id, files=files, study_id=study_id,
-                    data_types=data_types, editable=editable)
+        if stats['status'] != 'success':
+            if 'does not exist' in stats['message']:
+                raise HTTPError(404, stats['message'])
+            if 'User does not have access to study' in stats['message']:
+                raise HTTPError(403, stats['message'])
+
+        stats['download_id'] = download_id
+        stats['files'] = files
+        stats['study_id'] = study_id
+        stats['data_types'] = data_types
+
+        self.render('study_ajax/sample_summary.html', **stats)
 
     @authenticated
     def post(self):

--- a/qiita_pet/handlers/study_handlers/tests/test_sample_template.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_sample_template.py
@@ -60,9 +60,8 @@ class TestSampleTemplateAJAX(TestHandlerBase):
                              {'study_id': 1,
                               'action': 'delete'})
         self.assertEqual(response.code, 200)
-        exp = ('{"status": "error", '
-               '"message": "Sample template can not be erased because there '
-               'are prep templates associated."}')
+        exp = ('{"status": "success", '
+               '"message": ""}')
         # checking that the action was sent
         self.assertEqual(response.body, exp)
 

--- a/qiita_pet/templates/study_ajax/prep_summary.html
+++ b/qiita_pet/templates/study_ajax/prep_summary.html
@@ -61,12 +61,7 @@
           bootstrapAlert(data.message, "danger");
         }
         else {
-          if(data.status == 'warning') {
-            bootstrapAlert(data.message.replace("\n", "<br/>"), "warning");
-          }
-          $("#file-selector option[value='" + fp +"']").remove();
-          $("#file-selector").val("");
-          $("#update-button-div").hide();
+          populate_main_div('/study/description/prep_template/', { prep_id: {{prep_id}}, study_id: {{study_id}} });
         }
       }
     });
@@ -330,6 +325,12 @@
           }
         }
     });
+
+    {% if alert_type != 'success' and alert_message != '' %}
+      bootstrapAlert("{% raw alert_message %}", "{{alert_type}}");
+    {% else %}
+      $('#bootstrap-alert').alert('close');
+    {% end %}
   });
 </script>
 

--- a/qiita_pet/templates/study_ajax/sample_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_summary.html
@@ -47,6 +47,12 @@
         $('#file-btn').prop('disabled', false);
       }
     });
+
+    {% if alert_type != 'success' and alert_message != '' %}
+      bootstrapAlert("{% raw alert_message %}", "{{alert_type}}");
+    {% else %}
+      $('#bootstrap-alert').alert('close');
+    {% end %}
   });
 </script>
 

--- a/qiita_ware/context.py
+++ b/qiita_ware/context.py
@@ -274,7 +274,7 @@ def safe_submit(*args, **kwargs):
     acceptable, so this wrapper makes sure that the job_id
     is returned only once the job has already been submitted.
 
-    From previous tests, the while loop is executed ~2 times, so there is no
+    From previous tests, the while loop is executed ~2 times, so there is not
     much time lost in here
     """
     job_id = submit(*args, **kwargs)

--- a/qiita_ware/context.py
+++ b/qiita_ware/context.py
@@ -272,7 +272,7 @@ def safe_submit(*args, **kwargs):
     There are cases in which a race condition may occur: submit returns the
     job id but moi hasn't submitted the job. In some cases this is not
     acceptable, so this wrapper makes sure that the job_id
-    is returned only once the job has already been submitted
+    is returned only once the job has already been submitted.
 
     From previous tests, the while loop is executed ~2 times, so there is no
     much time lost in here

--- a/qiita_ware/context.py
+++ b/qiita_ware/context.py
@@ -270,9 +270,9 @@ def safe_submit(*args, **kwargs):
     """Safe wraper for the submit function
 
     There are cases in which a race condition may occur: submit returns the
-    job id but moi still did not had time to actually submit the job. In some
-    cases this is not acceptable, so this wrapper makes sure that the job_id
-    is returned only once the job has been already submitted.
+    job id but moi hasn't submitted the job. In some cases this is not
+    acceptable, so this wrapper makes sure that the job_id
+    is returned only once the job has already been submitted
 
     From previous tests, the while loop is executed ~2 times, so there is no
     much time lost in here

--- a/qiita_ware/dispatchable.py
+++ b/qiita_ware/dispatchable.py
@@ -44,7 +44,7 @@ def copy_raw_data(prep_template, artifact_id):
     Artifact.copy(Artifact(artifact_id), prep_template)
 
 
-def create_sample_template(fp, study, is_mapping_file, data_type):
+def create_sample_template(fp, study, is_mapping_file, data_type=None):
     """Creates a sample template
 
     Parameters
@@ -55,7 +55,7 @@ def create_sample_template(fp, study, is_mapping_file, data_type):
         The study to add the sample template to
     is_mapping_file : bool
         Whether `fp` contains a mapping file or a sample template
-    data_type : str
+    data_type : str, optional
         If `is_mapping_file` is True, the data type of the prep template to be
         created
 
@@ -170,7 +170,20 @@ def delete_sample_template(study_id):
 
 
 def update_prep_template(prep_id, fp):
-    """Updates a prep template"""
+    """Updates a prep template
+
+    Parameters
+    ----------
+    prep_id : int
+        Prep template id to be updated
+    fp : str
+        The file path to the template file
+
+    Returns
+    -------
+    dict of {str: str}
+        A dict of the form {'status': str, 'message': str}
+    """
     import warnings
     from os import remove
     from qiita_db.metadata_template.util import load_template_to_dataframe

--- a/qiita_ware/dispatchable.py
+++ b/qiita_ware/dispatchable.py
@@ -167,3 +167,32 @@ def delete_sample_template(study_id):
         msg = str(e)
 
     return {'status': status, 'message': msg}
+
+
+def update_prep_template(prep_id, fp):
+    """Updates a prep template"""
+    import warnings
+    from os import remove
+    from qiita_db.metadata_template.util import load_template_to_dataframe
+    from qiita_db.metadata_template.prep_template import PrepTemplate
+
+    msg = ''
+    status = 'success'
+
+    prep = PrepTemplate(prep_id)
+
+    try:
+        with warnings.catch_warnings(record=True) as warns:
+            df = load_template_to_dataframe(fp)
+            prep.extend(df)
+            prep.update(df)
+            remove(fp)
+
+            if warns:
+                msg = '\n'.join(set(str(w.message) for w in warns))
+                status = 'warning'
+    except Exception as e:
+            status = 'danger'
+            msg = str(e)
+
+    return {'status': status, 'message': msg}

--- a/qiita_ware/dispatchable.py
+++ b/qiita_ware/dispatchable.py
@@ -42,3 +42,128 @@ def create_raw_data(filetype, prep_template, filepaths):
 def copy_raw_data(prep_template, artifact_id):
     """Creates a new raw data by copying from artifact_id"""
     Artifact.copy(Artifact(artifact_id), prep_template)
+
+
+def create_sample_template(fp, study, is_mapping_file, data_type):
+    """Creates a sample template
+
+    Parameters
+    ----------
+    fp : str
+        The file path to the template file
+    study : qiita_db.study.Study
+        The study to add the sample template to
+    is_mapping_file : bool
+        Whether `fp` contains a mapping file or a sample template
+    data_type : str
+        If `is_mapping_file` is True, the data type of the prep template to be
+        created
+
+    Returns
+    -------
+    dict of {str: str}
+        A dict of the form {'status': str, 'message': str}
+    """
+    # The imports need to be in here because this code is executed in
+    # the ipython workers
+    import warnings
+    from os import remove
+    from qiita_db.metadata_template.sample_template import SampleTemplate
+    from qiita_db.metadata_template.util import load_template_to_dataframe
+    from qiita_ware.metadata_pipeline import (
+        create_templates_from_qiime_mapping_file)
+
+    status = 'success'
+    msg = ''
+    try:
+        with warnings.catch_warnings(record=True) as warns:
+            if is_mapping_file:
+                create_templates_from_qiime_mapping_file(fp, study,
+                                                         data_type)
+            else:
+                SampleTemplate.create(load_template_to_dataframe(fp),
+                                      study)
+            remove(fp)
+
+            # join all the warning messages into one. Note that this
+            # info will be ignored if an exception is raised
+            if warns:
+                msg = '\n'.join(set(str(w.message) for w in warns))
+                status = 'warning'
+    except Exception as e:
+        # Some error occurred while processing the sample template
+        # Show the error to the user so they can fix the template
+        status = 'danger'
+        msg = str(e)
+
+    return {'status': status, 'message': msg}
+
+
+def update_sample_template(study_id, fp):
+    """Updates a sample template
+
+    Parameters
+    ----------
+    study_id : int
+        Study id whose template is going to be updated
+    fp : str
+        The file path to the template file
+
+    Returns
+    -------
+    dict of {str: str}
+        A dict of the form {'status': str, 'message': str}
+    """
+    import warnings
+    from os import remove
+    from qiita_db.metadata_template.util import load_template_to_dataframe
+    from qiita_db.metadata_template.sample_template import SampleTemplate
+
+    msg = ''
+    status = 'success'
+
+    try:
+        with warnings.catch_warnings(record=True) as warns:
+            # deleting previous uploads and inserting new one
+            st = SampleTemplate(study_id)
+            df = load_template_to_dataframe(fp)
+            st.extend(df)
+            st.update(df)
+            remove(fp)
+
+            # join all the warning messages into one. Note that this info
+            # will be ignored if an exception is raised
+            if warns:
+                msg = '\n'.join(set(str(w.message) for w in warns))
+                status = 'warning'
+    except Exception as e:
+            status = 'danger'
+            msg = str(e)
+
+    return {'status': status, 'message': msg}
+
+
+def delete_sample_template(study_id):
+    """Delete a sample template
+
+    Parameters
+    ----------
+    study_id : int
+        Study id whose template is going to be deleted
+
+    Returns
+    -------
+    dict of {str: str}
+        A dict of the form {'status': str, 'message': str}
+    """
+    from qiita_db.metadata_template.sample_template import SampleTemplate
+
+    msg = ''
+    status = 'success'
+    try:
+        SampleTemplate.delete(study_id)
+    except Exception as e:
+        status = 'danger'
+        msg = str(e)
+
+    return {'status': status, 'message': msg}

--- a/qiita_ware/test/test_dispatchable.py
+++ b/qiita_ware/test/test_dispatchable.py
@@ -1,0 +1,76 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014--, The Qiita Development Team.
+#
+# Distributed under the terms of the BSD 3-clause License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# -----------------------------------------------------------------------------
+
+from unittest import TestCase, main
+from tempfile import mkstemp
+from os import close, remove
+from os.path import exists
+
+from qiita_core.util import qiita_test_checker
+from qiita_ware.dispatchable import (
+    create_sample_template, update_sample_template, delete_sample_template,
+    update_prep_template)
+from qiita_db.study import Study
+
+
+@qiita_test_checker()
+class TestDispatchable(TestCase):
+    def setUp(self):
+        fd, self.fp = mkstemp(suffix=".txt")
+        close(fd)
+        with open(self.fp, 'w') as f:
+            f.write("sample_name\tnew_col\n"
+                    "1.SKD6.640190\tnew_vale")
+
+        self._clean_up_files = [self.fp]
+
+    def tearDown(self):
+        for fp in self._clean_up_files:
+            if exists(fp):
+                remove(fp)
+
+    def test_create_sample_template(self):
+        obs = create_sample_template(self.fp, Study(1), False)
+        exp = {'status': 'danger',
+               'message': "The 'SampleTemplate' object with attributes "
+                          "(id: 1) already exists."}
+        self.assertEqual(obs, exp)
+
+    def test_update_sample_template(self):
+        obs = update_sample_template(1, self.fp)
+        exp = {'status': 'warning',
+               'message': 'Sample names were already prefixed with the study '
+                          'id.\nThe following columns have been added to the '
+                          'existing template: new_col\nThere are no '
+                          'differences between the data stored in the DB and '
+                          'the new data provided'}
+        self.assertEqual(obs['status'], exp['status'])
+        self.assertItemsEqual(obs['message'].split('\n'),
+                              exp['message'].split('\n'))
+
+    def test_delete_sample_template(self):
+        obs = delete_sample_template(1)
+        exp = {'status': 'danger',
+               'message': 'Sample template can not be erased because there '
+                          'are prep templates associated.'}
+        self.assertEqual(obs, exp)
+
+    def test_update_prep_template(self):
+        obs = update_prep_template(1, self.fp)
+        exp = {'status': 'warning',
+               'message': 'Sample names were already prefixed with the study '
+                          'id.\nThe following columns have been added to the '
+                          'existing template: new_col\nThere are no '
+                          'differences between the data stored in the DB and '
+                          'the new data provided'}
+        self.assertEqual(obs['status'], exp['status'])
+        self.assertItemsEqual(obs['message'].split('\n'),
+                              exp['message'].split('\n'))
+
+if __name__ == '__main__':
+    main()

--- a/qiita_ware/test/test_dispatchable.py
+++ b/qiita_ware/test/test_dispatchable.py
@@ -56,7 +56,7 @@ class TestDispatchable(TestCase):
     def test_delete_sample_template(self):
         obs = delete_sample_template(1)
         exp = {'status': 'danger',
-               'message': 'Sample template can not be erased because there '
+               'message': 'Sample template cannot be erased because there '
                           'are prep templates associated.'}
         self.assertEqual(obs, exp)
 


### PR DESCRIPTION
:finnadie::finnadie::finnadie::finnadie::finnadie::finnadie::finnadie::finnadie:

This PR offloads the sample template create/update/delete and the prep template udpate from the webserver. The create/delete prep template are a bit more tricky given that those operations perform bigger changes in the interface, so I open an issue to keep track of it: https://github.com/biocore/qiita/issues/1719

Some of the fun stuff that starts happening here. The system becomes now way more distributed, as some of the processing is happening through moi and the interface is just checking it is done or not. It becomes really interesting at the time of testing the handlers, since they just submit and return right away, which means that we can't reset the DB at this point until the process running the job is done. Thus, I needed to put some waiting code on those tests.

In order to make the interface more responsive to this changes, we will need to introduce websockets, but I don't think it is blocking ATM.