### PR TITLE
small fix

### DIFF
--- a/qiita_db/analysis.py
+++ b/qiita_db/analysis.py
@@ -1039,7 +1039,7 @@ class Analysis(qdb.base.QiitaStatusObject):
             _, base_fp = qdb.util.get_mountpoint(self._table)[0]
             mapping_fp = join(base_fp, "%d_analysis_mapping.txt" % self._id)
             merged_map.to_csv(mapping_fp, index_label='#SampleID',
-                              na_rep='unknown', sep='\t')
+                              na_rep='unknown', sep='\t', encoding='utf-8')
 
             self._add_file("%d_analysis_mapping.txt" % self._id, "plain_text")
 


### PR DESCRIPTION
Turns out we still have none valid ascii chars in old studies and when you try to make an analysis it fails with:
```
UnicodeEncodeError: 'ascii' codec can't encode character u'\xca' in position 576: ordinal not in range(128)
```

This solves it. 