### PR TITLE
fixing empty table error

### DIFF
--- a/qiita_db/analysis.py
+++ b/qiita_db/analysis.py
@@ -946,9 +946,10 @@ class Analysis(qdb.base.QiitaStatusObject):
                         new_table = new_table.merge(biom_table)
 
                 if not new_table or len(new_table.ids()) == 0:
-                        raise RuntimeError(
-                            "All samples filtered out from Artifact %s due "
-                            "to selected samples" % aid)
+                    # if we get to this point the only reason for failure is
+                    # rarefaction
+                    raise RuntimeError("All samples filtered out from "
+                                       "analysis due to rarefaction level")
 
                 # add the metadata column for study the samples come from,
                 # this is useful in case the user download the bioms

--- a/qiita_db/analysis.py
+++ b/qiita_db/analysis.py
@@ -933,9 +933,7 @@ class Analysis(qdb.base.QiitaStatusObject):
                     biom_table.filter(selected_samples, axis='sample',
                                       inplace=True)
                     if len(biom_table.ids()) == 0:
-                        raise RuntimeError(
-                            "All samples filtered out from Artifact %s due "
-                            "to selected samples" % aid)
+                        continue
 
                     if rename_dup_samples:
                         ids_map = {_id: "%d.%s" % (aid, _id)
@@ -946,6 +944,11 @@ class Analysis(qdb.base.QiitaStatusObject):
                         new_table = biom_table
                     else:
                         new_table = new_table.merge(biom_table)
+
+                if not new_table or len(new_table.ids()) == 0:
+                        raise RuntimeError(
+                            "All samples filtered out from Artifact %s due "
+                            "to selected samples" % aid)
 
                 # add the metadata column for study the samples come from,
                 # this is useful in case the user download the bioms


### PR DESCRIPTION
This error is that in the previous version we will stop analysis execution if all the samples within a study were rarefied out. However, this is not desirable. In this new version, it will raise an error only if the final merged biom there are no samples. Note that the merged table can be the result of only one biom.