### PR TITLE
Share analyses

### DIFF
--- a/qiita_db/analysis.py
+++ b/qiita_db/analysis.py
@@ -684,13 +684,14 @@ class Analysis(qdb.base.QiitaStatusObject):
             The user to share the analysis with
         """
         # Make sure the analysis is not already shared with the given user
-        if user.id in self.shared_with or user.id == self.owner:
+        if user.id == self.owner:
             return
 
-        sql = """INSERT INTO qiita.analysis_users (analysis_id, email)
-                 VALUES (%s, %s)"""
-        qdb.sql_connection.TRN.add(sql, [self._id, user.id])
-        qdb.sql_connection.TRN.execute()
+        with qdb.sql_connection.TRN:
+            sql = """INSERT INTO qiita.analysis_users (analysis_id, email)
+                     VALUES (%s, %s)"""
+            qdb.sql_connection.TRN.add(sql, [self._id, user.id])
+            qdb.sql_connection.TRN.execute()
 
     def unshare(self, user):
         """Unshare the analysis with another user
@@ -700,10 +701,11 @@ class Analysis(qdb.base.QiitaStatusObject):
         user: User object
             The user to unshare the analysis with
         """
-        sql = """DELETE FROM qiita.analysis_users
-                 WHERE analysis_id = %s AND email = %s"""
-        qdb.sql_connection.TRN.add(sql, [self._id, user.id])
-        qdb.sql_connection.TRN.execute()
+        with qdb.sql_connection.TRN:
+            sql = """DELETE FROM qiita.analysis_users
+                     WHERE analysis_id = %s AND email = %s"""
+            qdb.sql_connection.TRN.add(sql, [self._id, user.id])
+            qdb.sql_connection.TRN.execute()
 
     def add_samples(self, samples):
         """Adds samples to the analysis

--- a/qiita_db/analysis.py
+++ b/qiita_db/analysis.py
@@ -684,7 +684,7 @@ class Analysis(qdb.base.QiitaStatusObject):
             The user to share the analysis with
         """
         # Make sure the analysis is not already shared with the given user
-        if user.id == self.owner:
+        if user.id == self.owner or user.id in self.shared_with:
             return
 
         with qdb.sql_connection.TRN:

--- a/qiita_db/support_files/populate_test_db.sql
+++ b/qiita_db/support_files/populate_test_db.sql
@@ -427,7 +427,7 @@ INSERT INTO qiita.job (data_type_id, job_status_id, command_id, options, input_f
 INSERT INTO qiita.job_results_filepath (job_id, filepath_id) VALUES (1, 13), (2, 14);
 
 -- Insert Analysis
-INSERT INTO qiita.analysis (email, name, description, analysis_status_id, pmid) VALUES ('test@foo.bar', 'SomeAnalysis', 'A test analysis', 1, '121112'), ('test@foo.bar', 'SomeSecondAnalysis', 'Another test analysis', 1, '22221112');
+INSERT INTO qiita.analysis (email, name, description, analysis_status_id, pmid) VALUES ('test@foo.bar', 'SomeAnalysis', 'A test analysis', 1, '121112'), ('admin@foo.bar', 'SomeSecondAnalysis', 'Another test analysis', 1, '22221112');
 INSERT INTO qiita.analysis_portal (analysis_id, portal_type_id) VALUES (1, 1), (2, 1);
 -- Insert Analysis Workflow
 INSERT INTO qiita.analysis_workflow (analysis_id, step) VALUES (1, 3), (2, 3);

--- a/qiita_db/test/test_user.py
+++ b/qiita_db/test/test_user.py
@@ -261,7 +261,7 @@ class UserTest(TestCase):
     def test_get_private_analyses(self):
         user = qdb.user.User('test@foo.bar')
         qiita_config.portal = "QIITA"
-        exp = {qdb.analysis.Analysis(1), qdb.analysis.Analysis(2)}
+        exp = {qdb.analysis.Analysis(1)}
         self.assertEqual(user.private_analyses, exp)
 
         qiita_config.portal = "EMP"

--- a/qiita_pet/handlers/analysis_handlers.py
+++ b/qiita_pet/handlers/analysis_handlers.py
@@ -175,8 +175,8 @@ class AnalysisResultsHandler(BaseHandler):
             data_type = proc_data.data_type
             dropped[data_type].append((proc_data.study.title, len(samples),
                                        ', '.join(samples)))
-        share_access = (self.current_user.id in Analysis.shared_with or
-                        self.current_user.id == Analysis.owner)
+        share_access = (self.current_user.id in analysis.shared_with or
+                        self.current_user.id == analysis.owner)
 
         self.render("analysis_results.html", analysis_id=analysis_id,
                     jobres=jobres, aname=analysis.name, dropped=dropped,
@@ -389,6 +389,6 @@ class ShareAnalysisAJAX(BaseHandler):
         if deselected is not None:
             yield Task(self._unshare, analysis, deselected)
 
-        users, links = yield Task(self._get_shared_for_analysis, analysis)
+        users, links = yield Task(self._get_shared_for_study, analysis)
 
         self.write(dumps({'users': users, 'links': links}))

--- a/qiita_pet/handlers/analysis_handlers.py
+++ b/qiita_pet/handlers/analysis_handlers.py
@@ -380,6 +380,10 @@ class ShareAnalysisAJAX(BaseHandler):
     def get(self):
         analysis_id = int(self.get_argument('id'))
         analysis = Analysis(analysis_id)
+        if self.current_user != analysis.owner:
+            raise HTTPError(403, 'User %s does not have permissions to share '
+                            'analysis %s' % (
+                                self.current_user.id, analysis.id))
 
         selected = self.get_argument('selected', None)
         deselected = self.get_argument('deselected', None)

--- a/qiita_pet/handlers/analysis_handlers.py
+++ b/qiita_pet/handlers/analysis_handlers.py
@@ -17,18 +17,21 @@ from json import dumps
 from functools import partial
 
 from tornado.web import authenticated, HTTPError, StaticFileHandler
+from tornado.gen import coroutine, Task
 from moi import ctx_default, r_client
 from moi.job import submit
 from moi.group import get_id_from_user, create_info
 
 from qiita_pet.util import is_localhost
 from qiita_pet.handlers.base_handlers import BaseHandler
-from qiita_pet.handlers.util import download_link_or_path
+from qiita_pet.handlers.util import (
+    download_link_or_path, get_shared_links)
 from qiita_pet.exceptions import QiitaPetAuthorizationError
 from qiita_ware.dispatchable import run_analysis
 from qiita_db.analysis import Analysis
 from qiita_db.artifact import Artifact
 from qiita_db.job import Command
+from qiita_db.user import User
 from qiita_db.util import (get_db_files_base_dir,
                            check_access_to_analysis_result,
                            filepath_ids_to_rel_paths, get_filepath_id)
@@ -172,10 +175,13 @@ class AnalysisResultsHandler(BaseHandler):
             data_type = proc_data.data_type
             dropped[data_type].append((proc_data.study.title, len(samples),
                                        ', '.join(samples)))
+        share_access = (self.current_user.id in Analysis.shared_with or
+                        self.current_user.id == Analysis.owner)
 
         self.render("analysis_results.html", analysis_id=analysis_id,
                     jobres=jobres, aname=analysis.name, dropped=dropped,
-                    basefolder=get_db_files_base_dir())
+                    basefolder=get_db_files_base_dir(),
+                    share_access=share_access)
 
     @authenticated
     @execute_as_transaction
@@ -349,3 +355,40 @@ class AnalysisSummaryAJAX(BaseHandler):
     def get(self):
         info = self.current_user.default_analysis.summary_data()
         self.write(dumps(info))
+
+
+class ShareAnalysisAJAX(BaseHandler):
+    @execute_as_transaction
+    def _get_shared_for_study(self, analysis, callback):
+        shared_links = get_shared_links(analysis)
+        users = [u.email for u in analysis.shared_with]
+        callback((users, shared_links))
+
+    @execute_as_transaction
+    def _share(self, analysis, user, callback):
+        user = User(user)
+        callback(analysis.share(user))
+
+    @execute_as_transaction
+    def _unshare(self, analysis, user, callback):
+        user = User(user)
+        callback(analysis.unshare(user))
+
+    @authenticated
+    @coroutine
+    @execute_as_transaction
+    def get(self):
+        analysis_id = int(self.get_argument('id'))
+        analysis = Analysis(analysis_id)
+
+        selected = self.get_argument('selected', None)
+        deselected = self.get_argument('deselected', None)
+
+        if selected is not None:
+            yield Task(self._share, analysis, selected)
+        if deselected is not None:
+            yield Task(self._unshare, analysis, deselected)
+
+        users, links = yield Task(self._get_shared_for_analysis, analysis)
+
+        self.write(dumps({'users': users, 'links': links}))

--- a/qiita_pet/handlers/analysis_handlers.py
+++ b/qiita_pet/handlers/analysis_handlers.py
@@ -32,7 +32,7 @@ from qiita_db.analysis import Analysis
 from qiita_db.artifact import Artifact
 from qiita_db.job import Command
 from qiita_db.user import User
-from qiita_db.util import (get_db_files_base_dir,
+from qiita_db.util import (get_db_files_base_dir, add_message,
                            check_access_to_analysis_result,
                            filepath_ids_to_rel_paths, get_filepath_id)
 from qiita_db.exceptions import QiitaDBUnknownIDError
@@ -367,11 +367,16 @@ class ShareAnalysisAJAX(BaseHandler):
     @execute_as_transaction
     def _share(self, analysis, user, callback):
         user = User(user)
+        add_message('Analysis <a href="/analysis/results/%d">\'%s\'</a> '
+                    'has been shared with you.' %
+                    (analysis.id, analysis.name), [user])
         callback(analysis.share(user))
 
     @execute_as_transaction
     def _unshare(self, analysis, user, callback):
         user = User(user)
+        add_message('Analysis \'%s\' has been unshared from you.' %
+                    analysis.name, [user])
         callback(analysis.unshare(user))
 
     @authenticated

--- a/qiita_pet/handlers/study_handlers/listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/listing_handlers.py
@@ -28,23 +28,8 @@ from qiita_core.exceptions import IncompetentQiitaDeveloperError
 from qiita_core.util import execute_as_transaction
 from qiita_pet.handlers.base_handlers import BaseHandler
 from qiita_pet.handlers.util import (
-    study_person_linkifier, doi_linkifier, pubmed_linkifier, check_access)
-
-
-@execute_as_transaction
-def _get_shared_links_for_study(study):
-    shared = []
-    for person in study.shared_with:
-        name = person.info['name']
-        email = person.email
-        # Name is optional, so default to email if non existant
-        if name:
-            shared.append(study_person_linkifier(
-                (email, name)))
-        else:
-            shared.append(study_person_linkifier(
-                (email, email)))
-    return ", ".join(shared)
+    study_person_linkifier, doi_linkifier, pubmed_linkifier, check_access,
+    get_shared_links)
 
 
 @execute_as_transaction
@@ -83,7 +68,7 @@ def _build_single_study_info(study, info, study_proc, proc_samples):
         info['pmid'] = ""
     if info["number_samples_collected"] is None:
         info["number_samples_collected"] = 0
-    info["shared"] = _get_shared_links_for_study(study)
+    info["shared"] = get_shared_links(study)
     # raw data is any artifact that is not Demultiplexed or BIOM
 
     info["num_raw_data"] = len([a for a in study.artifacts()
@@ -258,7 +243,7 @@ class AutocompleteHandler(BaseHandler):
 class ShareStudyAJAX(BaseHandler):
     @execute_as_transaction
     def _get_shared_for_study(self, study, callback):
-        shared_links = _get_shared_links_for_study(study)
+        shared_links = get_shared_links(study)
         users = [u.email for u in study.shared_with]
         callback((users, shared_links))
 
@@ -276,7 +261,7 @@ class ShareStudyAJAX(BaseHandler):
     @coroutine
     @execute_as_transaction
     def get(self):
-        study_id = int(self.get_argument('study_id'))
+        study_id = int(self.get_argument('id'))
         study = Study(study_id)
         check_access(self.current_user, study, no_public=True,
                      raise_error=True)

--- a/qiita_pet/handlers/study_handlers/listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/listing_handlers.py
@@ -23,7 +23,7 @@ from qiita_db.search import QiitaStudySearch
 from qiita_db.logger import LogEntry
 from qiita_db.exceptions import QiitaDBIncompatibleDatatypeError
 from qiita_db.reference import Reference
-from qiita_db.util import get_pubmed_ids_from_dois
+from qiita_db.util import get_pubmed_ids_from_dois, add_message
 from qiita_core.exceptions import IncompetentQiitaDeveloperError
 from qiita_core.util import execute_as_transaction
 from qiita_pet.handlers.base_handlers import BaseHandler
@@ -250,11 +250,16 @@ class ShareStudyAJAX(BaseHandler):
     @execute_as_transaction
     def _share(self, study, user, callback):
         user = User(user)
+        add_message('Study \'%s\' has been unshared from you.' %
+                    study.title, [user])
         callback(study.share(user))
 
     @execute_as_transaction
     def _unshare(self, study, user, callback):
         user = User(user)
+        add_message('Study <a href="/study/description/%d">\'%s\'</a> '
+                    'has been shared with you.' %
+                    (study.id, study.title), [user])
         callback(study.unshare(user))
 
     @authenticated

--- a/qiita_pet/handlers/study_handlers/listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/listing_handlers.py
@@ -250,16 +250,16 @@ class ShareStudyAJAX(BaseHandler):
     @execute_as_transaction
     def _share(self, study, user, callback):
         user = User(user)
-        add_message('Study \'%s\' has been unshared from you.' %
-                    study.title, [user])
+        add_message('Study <a href="/study/description/%d">\'%s\'</a> '
+                    'has been shared with you.' %
+                    (study.id, study.title), [user])
         callback(study.share(user))
 
     @execute_as_transaction
     def _unshare(self, study, user, callback):
         user = User(user)
-        add_message('Study <a href="/study/description/%d">\'%s\'</a> '
-                    'has been shared with you.' %
-                    (study.id, study.title), [user])
+        add_message('Study \'%s\' has been unshared from you.' %
+                    study.title, [user])
         callback(study.unshare(user))
 
     @authenticated

--- a/qiita_pet/handlers/study_handlers/tests/test_listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_listing_handlers.py
@@ -258,7 +258,7 @@ class TestShareStudyAjax(TestHandlerBase):
         self.assertEqual(s.shared_with, [User('shared@foo.bar'), u])
 
         # Make sure shared message added to the system
-        self.assertEqual('Analysis <a href="/study/description/1">'
+        self.assertEqual('Study <a href="/study/description/1">'
                          '\'Identification of the Microbiomes for Cannabis '
                          'Soils\'</a> has been shared with you.',
                          u.messages()[0][1])

--- a/qiita_pet/handlers/study_handlers/tests/test_listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_listing_handlers.py
@@ -14,8 +14,7 @@ from moi import r_client
 from qiita_core.exceptions import IncompetentQiitaDeveloperError
 from qiita_pet.test.tornado_test_base import TestHandlerBase
 from qiita_pet.handlers.study_handlers.listing_handlers import (
-    _get_shared_links_for_study, _build_study_info, _build_single_study_info,
-    _build_single_proc_data_info)
+    _build_study_info, _build_single_study_info, _build_single_proc_data_info)
 from qiita_pet.handlers.base_handlers import BaseHandler
 from qiita_db.study import Study
 from qiita_db.user import User
@@ -134,11 +133,6 @@ class TestHelpers(TestHandlerBase):
         }
         self.exp = [self.single_exp]
 
-    def test_get_shared_links_for_study(self):
-        obs = _get_shared_links_for_study(Study(1))
-        exp = '<a target="_blank" href="mailto:shared@foo.bar">Shared</a>'
-        self.assertEqual(obs, exp)
-
     def test_build_single_study_info(self):
         study_proc = {1: {'18S': [4, 5, 6]}}
         proc_samples = {4: self.proc_data_exp[0]['samples'],
@@ -236,7 +230,7 @@ class TestShareStudyAjax(TestHandlerBase):
     def test_get_deselected(self):
         s = Study(1)
         u = User('shared@foo.bar')
-        args = {'deselected': u.id, 'study_id': s.id}
+        args = {'deselected': u.id, 'id': s.id}
         self.assertEqual(s.shared_with, [u])
         response = self.get('/study/sharing/', args)
         self.assertEqual(response.code, 200)
@@ -247,7 +241,7 @@ class TestShareStudyAjax(TestHandlerBase):
     def test_get_selected(self):
         s = Study(1)
         u = User('admin@foo.bar')
-        args = {'selected': u.id, 'study_id': s.id}
+        args = {'selected': u.id, 'id': s.id}
         response = self.get('/study/sharing/', args)
         self.assertEqual(response.code, 200)
         exp = {
@@ -274,7 +268,7 @@ class TestShareStudyAjax(TestHandlerBase):
         s = Study.create(u, 'test_study', efo=[1], info=info)
         self.assertEqual(s.shared_with, [])
 
-        args = {'selected': 'test@foo.bar', 'study_id': s.id}
+        args = {'selected': 'test@foo.bar', 'id': s.id}
         response = self.get('/study/sharing/', args)
         self.assertEqual(response.code, 403)
         self.assertEqual(s.shared_with, [])

--- a/qiita_pet/handlers/study_handlers/tests/test_listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_listing_handlers.py
@@ -238,6 +238,11 @@ class TestShareStudyAjax(TestHandlerBase):
         self.assertEqual(loads(response.body), exp)
         self.assertEqual(s.shared_with, [])
 
+        # Make sure unshared message added to the system
+        self.assertEqual('Study \'Identification of the Microbiomes for '
+                         'Cannabis Soils\' has been unshared from you.',
+                         u.messages()[0][1])
+
     def test_get_selected(self):
         s = Study(1)
         u = User('admin@foo.bar')
@@ -251,6 +256,12 @@ class TestShareStudyAjax(TestHandlerBase):
                  '<a target="_blank" href="mailto:admin@foo.bar">Admin</a>')}
         self.assertEqual(loads(response.body), exp)
         self.assertEqual(s.shared_with, [User('shared@foo.bar'), u])
+
+        # Make sure shared message added to the system
+        self.assertEqual('Analysis <a href="/study/description/1">'
+                         '\'Identification of the Microbiomes for Cannabis '
+                         'Soils\'</a> has been shared with you.',
+                         u.messages()[0][1])
 
     def test_get_no_access(self):
         # Create a new study belonging to the 'shared' user, so 'test' doesn't

--- a/qiita_pet/handlers/util.py
+++ b/qiita_pet/handlers/util.py
@@ -89,3 +89,32 @@ def to_int(value):
     except ValueError:
         raise HTTPError(400, "%s cannot be converted to an integer" % value)
     return res
+
+
+@execute_as_transaction
+def get_shared_links(obj):
+    """Createse HTML links for users obj is shared with
+
+    Parameters
+    ----------
+    obj : QiitaObject
+        A qiita object with a 'shared_with' property that returns a list of
+        User objects
+
+    Returns
+    -------
+    str
+        Email links for each person obj is shared with
+    """
+    shared = []
+    for person in obj.shared_with:
+        name = person.info['name']
+        email = person.email
+        # Name is optional, so default to email if non existant
+        if name:
+            shared.append(study_person_linkifier(
+                (email, name)))
+        else:
+            shared.append(study_person_linkifier(
+                (email, email)))
+    return ", ".join(shared)

--- a/qiita_pet/handlers/util.py
+++ b/qiita_pet/handlers/util.py
@@ -93,7 +93,7 @@ def to_int(value):
 
 @execute_as_transaction
 def get_shared_links(obj):
-    """Createse HTML links for users obj is shared with
+    """Creates email links for the users obj is shared with
 
     Parameters
     ----------

--- a/qiita_pet/static/js/sharing.js
+++ b/qiita_pet/static/js/sharing.js
@@ -49,7 +49,7 @@ function update_share(share_type, params) {
   $.get('/' + share_type + '/sharing/', data)
     .done(function(data) {
       users_links = JSON.parse(data);
-      links = users_links['links'];
+      links = users_links.links;
       $("#shared_html_"+current_id).html(links);
     });
 }

--- a/qiita_pet/static/js/sharing.js
+++ b/qiita_pet/static/js/sharing.js
@@ -1,4 +1,4 @@
-var current_study = null;
+var current_id = null;
 
 $(document).ready(function () {
   $('#shares-select').select2({
@@ -27,10 +27,10 @@ $(document).ready(function () {
   });
 });
 
-function modify_sharing(study_id) {
+function modify_sharing(base, id) {
 var shared_list;
-current_study = study_id;
-$.get('/study/sharing/', {study_id: study_id})
+current_id = id;
+$.get('/' + base + '/sharing/', {id: id})
     .done(function(data) {
       users_links = JSON.parse(data);
       users = users_links.users;
@@ -46,11 +46,11 @@ $.get('/study/sharing/', {study_id: study_id})
 
 function update_share(params) {
   data = params || {};
-  data.study_id = current_study;
+  data.id = current_id;
   $.get('/study/sharing/', data)
     .done(function(data) {
       users_links = JSON.parse(data);
       links = users_links['links'];
-      document.getElementById("shared_html_"+current_study).innerHTML = links;
+      document.getElementById("shared_html_"+current_id).innerHTML = links;
     });
 }

--- a/qiita_pet/static/js/sharing.js
+++ b/qiita_pet/static/js/sharing.js
@@ -1,5 +1,4 @@
 var current_id = null;
-var share_type = null;
 
 $(document).ready(function () {
   $('#shares-select').select2({
@@ -19,15 +18,15 @@ $(document).ready(function () {
   });
 
   $('#shares-select').on("select2:select", function (e) {
-    update_share({selected: e.params.data.text});
+    update_share(e.target.classList[0], {selected: e.params.data.text});
   });
 
   $('#shares-select').on("select2:unselect", function (e) {
-    update_share({deselected: e.params.data.text});
+    update_share(e.target.classList[0], {deselected: e.params.data.text});
   });
 });
 
-function modify_sharing(id) {
+function modify_sharing(share_type, id) {
 var shared_list;
 current_id = id;
 $.get('/' + share_type + '/sharing/', {id: id})
@@ -44,13 +43,13 @@ $.get('/' + share_type + '/sharing/', {id: id})
     });
 }
 
-function update_share(params) {
+function update_share(share_type, params) {
   data = params || {};
   data.id = current_id;
   $.get('/' + share_type + '/sharing/', data)
     .done(function(data) {
       users_links = JSON.parse(data);
       links = users_links['links'];
-      $("#shared_html_"+current_study).innerHTML = links;
+      $("#shared_html_"+current_id).html(links);
     });
 }

--- a/qiita_pet/static/js/sharing.js
+++ b/qiita_pet/static/js/sharing.js
@@ -27,9 +27,9 @@ $(document).ready(function () {
 });
 
 function modify_sharing(share_type, id) {
-var shared_list;
-current_id = id;
-$.get('/' + share_type + '/sharing/', {id: id})
+  var shared_list;
+  current_id = id;
+  $.get('/' + share_type + '/sharing/', {id: id})
     .done(function(data) {
       var users_links = JSON.parse(data);
       var users = users_links.users;

--- a/qiita_pet/static/js/sharing.js
+++ b/qiita_pet/static/js/sharing.js
@@ -1,5 +1,3 @@
-var current_id = null;
-
 $(document).ready(function () {
   $('#shares-select').select2({
     ajax: {
@@ -28,7 +26,7 @@ $(document).ready(function () {
 
 function modify_sharing(share_type, id) {
   var shared_list;
-  current_id = id;
+  $('#shares-select').attr('data-current-id', id);
   $.get('/' + share_type + '/sharing/', {id: id})
     .done(function(data) {
       var users_links = JSON.parse(data);
@@ -44,12 +42,13 @@ function modify_sharing(share_type, id) {
 }
 
 function update_share(share_type, params) {
+  share_id = $('#shares-select').attr('data-current-id');
   data = params || {};
-  data.id = current_id;
+  data.id = share_id;
   $.get('/' + share_type + '/sharing/', data)
     .done(function(data) {
       users_links = JSON.parse(data);
       links = users_links.links;
-      $("#shared_html_"+current_id).html(links);
+      $("#shared_html_"+share_id).html(links);
     });
 }

--- a/qiita_pet/static/js/sharing.js
+++ b/qiita_pet/static/js/sharing.js
@@ -1,4 +1,5 @@
 var current_id = null;
+var share_type = null;
 
 $(document).ready(function () {
   $('#shares-select').select2({
@@ -27,10 +28,10 @@ $(document).ready(function () {
   });
 });
 
-function modify_sharing(base, id) {
+function modify_sharing(id) {
 var shared_list;
 current_id = id;
-$.get('/' + base + '/sharing/', {id: id})
+$.get('/' + share_type + '/sharing/', {id: id})
     .done(function(data) {
       users_links = JSON.parse(data);
       users = users_links.users;
@@ -47,7 +48,7 @@ $.get('/' + base + '/sharing/', {id: id})
 function update_share(params) {
   data = params || {};
   data.id = current_id;
-  $.get('/study/sharing/', data)
+  $.get('/' + share_type + '/sharing/', data)
     .done(function(data) {
       users_links = JSON.parse(data);
       links = users_links['links'];

--- a/qiita_pet/templates/analysis_results.html
+++ b/qiita_pet/templates/analysis_results.html
@@ -7,8 +7,7 @@
 <script type="text/javascript">
 $(document).ready(function () {
   current_id = {{analysis_id}};
-  share_type = 'analysis';
-  update_share();
+  update_share('analysis');
 });
 </script>
 {%end%}
@@ -23,7 +22,7 @@ $(document).ready(function () {
         <td><h1>&nbsp;Analysis: <u>{{aname}}</u></h1></td>
         <td width="20px"></td>
         <td>
-          <a class="btn btn-info glyphicon glyphicon-share" data-toggle="modal" data-target="#share-analysis-modal-view" onclick="modify_sharing({{analysis_id}});"></a>
+          <a class="btn btn-info glyphicon glyphicon-share" data-toggle="modal" data-target="#share-analysis-modal-view" onclick="modify_sharing('analysis', {{analysis_id}});"></a>
         </td>
         <td width="20px"></td>
         <td>
@@ -107,7 +106,7 @@ $(document).ready(function () {
           <div>
             <div class="form-group">
               <label for="shares-select">Add/Remove Users</label>
-              <select multiple id="shares-select" style="width:50%"></select>
+              <select multiple class="analysis" id="shares-select" style="width:50%"></select>
               <br>
               <br>
               Adding or removing email addresses automatically updates who the analysis is shared with. Once you click the `X` or give mouse focus to the analysis page you'll see your new sharing settings.

--- a/qiita_pet/templates/analysis_results.html
+++ b/qiita_pet/templates/analysis_results.html
@@ -6,7 +6,6 @@
 <script type="text/javascript" src="/static/js/sharing.js"></script>
 <script type="text/javascript">
 $(document).ready(function () {
-  current_id = {{analysis_id}};
   update_share('analysis');
 });
 </script>
@@ -106,7 +105,7 @@ $(document).ready(function () {
           <div>
             <div class="form-group">
               <label for="shares-select">Add/Remove Users</label>
-              <select multiple class="analysis" id="shares-select" style="width:50%"></select>
+              <select multiple class="analysis" id="shares-select" data-current-id={{analysis_id}} style="width:50%"></select>
               <br>
               <br>
               Adding or removing email addresses automatically updates who the analysis is shared with. Once you click the `X` or give mouse focus to the analysis page you'll see your new sharing settings.

--- a/qiita_pet/templates/analysis_results.html
+++ b/qiita_pet/templates/analysis_results.html
@@ -1,8 +1,16 @@
 {% extends sitebase.html%}
 
 {%block head%}
-
-
+<link rel="stylesheet" href="/static/vendor/css/select2.min.css" type="text/css">
+<script type="text/javascript" src="/static/vendor/js/select2.min.js"></script>
+<script type="text/javascript" src="/static/js/sharing.js"></script>
+<script type="text/javascript">
+$(document).ready(function () {
+  current_id = {{analysis_id}};
+  share_type = 'analysis';
+  update_share();
+});
+</script>
 {%end%}
 
 {%block content%}
@@ -15,11 +23,15 @@
         <td><h1>&nbsp;Analysis: <u>{{aname}}</u></h1></td>
         <td width="20px"></td>
         <td>
-          <h1><a class="btn btn-danger glyphicon glyphicon-trash" onclick="delete_analysis('{{aname}}', {{analysis_id}});"></a></h1>
+          <a class="btn btn-info glyphicon glyphicon-share" data-toggle="modal" data-target="#share-analysis-modal-view" onclick="modify_sharing({{analysis_id}});"></a>
+        </td>
+        <td width="20px"></td>
+        <td>
+          <a class="btn btn-danger glyphicon glyphicon-trash" onclick="delete_analysis('{{aname}}', {{analysis_id}});"></a>
         </td>
       </tr>
     </table>
-  </h1>
+  Shared with: <span id="shared_html_{{analysis_id}}"></span> 
 </div>
 
 
@@ -83,4 +95,28 @@
   </div>
 </div>
 
+ <!-- Modal used to share the analysis -->
+<div class="modal fade" id="share-analysis-modal-view" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title" id="myModalLabel">Modify Sharing Settings</h4>
+      </div>
+        <div class="modal-body">
+          <div>
+            <div class="form-group">
+              <label for="shares-select">Add/Remove Users</label>
+              <select multiple id="shares-select" style="width:50%"></select>
+              <br>
+              <br>
+              Adding or removing email addresses automatically updates who the analysis is shared with. Once you click the `X` or give mouse focus to the analysis page you'll see your new sharing settings.
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+        </div>
+    </div>
+  </div>
+</div>
 {%end%}

--- a/qiita_pet/templates/list_studies.html
+++ b/qiita_pet/templates/list_studies.html
@@ -20,7 +20,6 @@ td.details-control {
 <script src="/static/js/sharing.js"></script>
 
 <script type="text/javascript">
-share_type = 'study';
 var ajaxURL = "/study/search/?&user={{current_user.id}}&sEcho=" + Math.floor(Math.random()*1001);
 function error(evt) { $('#search-error').html("<b>Server communication error. Sample selection will not be recorded. Please try again later.</b>"); }
 
@@ -114,7 +113,7 @@ $(document).ready(function() {
               {"render": function ( data, type, row, meta ) {
                     var glyph = 'remove';
                     if(data === true) { glyph = 'ok' }
-                    return "<span id='shared_html_"+ row.study_id +"'>"+ data +"</span><br/><a class='btn btn-primary btn-xs' data-toggle='modal' data-target='#share-study-modal-view' onclick='modify_sharing("+ row.study_id +");'>Modify</a>";
+                    return "<span id='shared_html_"+ row.study_id +"'>"+ data +"</span><br/><a class='btn btn-primary btn-xs' data-toggle='modal' data-target='#share-study-modal-view' onclick='modify_sharing(\"study\", "+ row.study_id +");'>Modify</a>";
               }, targets: [8]},
               ],
             "oLanguage": {
@@ -265,7 +264,7 @@ function add_metacat(metacat) {
           <div>
             <div class="form-group">
               <label for="shares-select">Add/Remove Users</label>
-              <select multiple id="shares-select" style="width:50%"></select>
+              <select multiple class="study" id="shares-select" style="width:50%"></select>
               <br>
               <br>
               Adding or removing email addresses automatically updates who the study is shared with.

--- a/qiita_pet/templates/list_studies.html
+++ b/qiita_pet/templates/list_studies.html
@@ -20,6 +20,7 @@ td.details-control {
 <script src="/static/js/sharing.js"></script>
 
 <script type="text/javascript">
+share_type = 'study';
 var ajaxURL = "/study/search/?&user={{current_user.id}}&sEcho=" + Math.floor(Math.random()*1001);
 function error(evt) { $('#search-error').html("<b>Server communication error. Sample selection will not be recorded. Please try again later.</b>"); }
 
@@ -113,7 +114,7 @@ $(document).ready(function() {
               {"render": function ( data, type, row, meta ) {
                     var glyph = 'remove';
                     if(data === true) { glyph = 'ok' }
-                    return "<span id='shared_html_"+ row.study_id +"'>"+ data +"</span><br/><a class='btn btn-primary btn-xs' data-toggle='modal' data-target='#share-study-modal-view' onclick='modify_sharing(\"study\", "+ row.study_id +");'>Modify</a>";
+                    return "<span id='shared_html_"+ row.study_id +"'>"+ data +"</span><br/><a class='btn btn-primary btn-xs' data-toggle='modal' data-target='#share-study-modal-view' onclick='modify_sharing("+ row.study_id +");'>Modify</a>";
               }, targets: [8]},
               ],
             "oLanguage": {

--- a/qiita_pet/templates/list_studies.html
+++ b/qiita_pet/templates/list_studies.html
@@ -113,7 +113,7 @@ $(document).ready(function() {
               {"render": function ( data, type, row, meta ) {
                     var glyph = 'remove';
                     if(data === true) { glyph = 'ok' }
-                    return "<span id='shared_html_"+ row.study_id +"'>"+ data +"</span><br/><a class='btn btn-primary btn-xs' data-toggle='modal' data-target='#share-study-modal-view' onclick='modify_sharing("+ row.study_id +");'>Modify</a>";
+                    return "<span id='shared_html_"+ row.study_id +"'>"+ data +"</span><br/><a class='btn btn-primary btn-xs' data-toggle='modal' data-target='#share-study-modal-view' onclick='modify_sharing(\"study\", "+ row.study_id +");'>Modify</a>";
               }, targets: [8]},
               ],
             "oLanguage": {

--- a/qiita_pet/templates/study_ajax/base_info.html
+++ b/qiita_pet/templates/study_ajax/base_info.html
@@ -3,8 +3,7 @@
 <script type="text/javascript" src="/static/js/sharing.js"></script>
 <script type="text/javascript">
 $(document).ready(function () {
-	current_id = {{study_info['study_id']}};
-	update_share('study');
+  update_share('study');
 });
 </script>
 <p style="font-weight:bold;">Abstract</p>
@@ -35,7 +34,7 @@ Samples: {{study_info['num_samples']}}<br />
           <div>
             <div class="form-group">
               <label for="shares-select">Add/Remove Users</label>
-              <select multiple class="study" id="shares-select" style="width:50%"></select>
+              <select multiple class="study" id="shares-select" data-current-id={{study_info['study_id']}} style="width:50%"></select>
               <br>
               <br>
               Adding or removing email addresses automatically updates who the study is shared with.

--- a/qiita_pet/templates/study_ajax/base_info.html
+++ b/qiita_pet/templates/study_ajax/base_info.html
@@ -3,7 +3,8 @@
 <script type="text/javascript" src="/static/js/sharing.js"></script>
 <script type="text/javascript">
 $(document).ready(function () {
-	current_study = {{study_info['study_id']}};
+	current_id = {{study_info['study_id']}};
+  share_type = 'study';
 	update_share();
 });
 </script>
@@ -17,7 +18,7 @@ Shared With: <span id="shared_html_{{study_info['study_id']}}">
 </span><br/>
 Samples: {{study_info['num_samples']}}<br />
 {% if share_access %}
-<a class="btn btn-default" data-toggle="modal" data-target="#share-study-modal-view" onclick="modify_sharing('study', {{study_info['study_id']}});"><span class="glyphicon glyphicon-share"></span> Share</a>
+<a class="btn btn-default" data-toggle="modal" data-target="#share-study-modal-view" onclick="modify_sharing({{study_info['study_id']}});"><span class="glyphicon glyphicon-share"></span> Share</a>
 {% end %}
 {% if editable %}
   <a class="btn btn-default" href="/study/edit/{{study_info['study_id']}}"><span class="glyphicon glyphicon-edit"></span> Edit</a>

--- a/qiita_pet/templates/study_ajax/base_info.html
+++ b/qiita_pet/templates/study_ajax/base_info.html
@@ -4,8 +4,7 @@
 <script type="text/javascript">
 $(document).ready(function () {
 	current_id = {{study_info['study_id']}};
-  share_type = 'study';
-	update_share();
+	update_share('study');
 });
 </script>
 <p style="font-weight:bold;">Abstract</p>
@@ -18,7 +17,7 @@ Shared With: <span id="shared_html_{{study_info['study_id']}}">
 </span><br/>
 Samples: {{study_info['num_samples']}}<br />
 {% if share_access %}
-<a class="btn btn-default" data-toggle="modal" data-target="#share-study-modal-view" onclick="modify_sharing({{study_info['study_id']}});"><span class="glyphicon glyphicon-share"></span> Share</a>
+<a class="btn btn-default" data-toggle="modal" data-target="#share-study-modal-view" onclick="modify_sharing('study', {{study_info['study_id']}});"><span class="glyphicon glyphicon-share"></span> Share</a>
 {% end %}
 {% if editable %}
   <a class="btn btn-default" href="/study/edit/{{study_info['study_id']}}"><span class="glyphicon glyphicon-edit"></span> Edit</a>
@@ -36,7 +35,7 @@ Samples: {{study_info['num_samples']}}<br />
           <div>
             <div class="form-group">
               <label for="shares-select">Add/Remove Users</label>
-              <select multiple id="shares-select" style="width:50%"></select>
+              <select multiple class="study" id="shares-select" style="width:50%"></select>
               <br>
               <br>
               Adding or removing email addresses automatically updates who the study is shared with.

--- a/qiita_pet/templates/study_ajax/base_info.html
+++ b/qiita_pet/templates/study_ajax/base_info.html
@@ -17,7 +17,7 @@ Shared With: <span id="shared_html_{{study_info['study_id']}}">
 </span><br/>
 Samples: {{study_info['num_samples']}}<br />
 {% if share_access %}
-<a class="btn btn-default" data-toggle="modal" data-target="#share-study-modal-view" onclick="modify_sharing({{study_info['study_id']}});"><span class="glyphicon glyphicon-share"></span> Share</a>
+<a class="btn btn-default" data-toggle="modal" data-target="#share-study-modal-view" onclick="modify_sharing('study', {{study_info['study_id']}});"><span class="glyphicon glyphicon-share"></span> Share</a>
 {% end %}
 {% if editable %}
   <a class="btn btn-default" href="/study/edit/{{study_info['study_id']}}"><span class="glyphicon glyphicon-edit"></span> Edit</a>

--- a/qiita_pet/test/test_analysis_handlers.py
+++ b/qiita_pet/test/test_analysis_handlers.py
@@ -81,6 +81,10 @@ class TestShareAnalysisAjax(TestHandlerBase):
         self.assertEqual(loads(response.body), exp)
         self.assertEqual(s.shared_with, [])
 
+        # Make sure unshared message added to the system
+        self.assertEqual('Analysis \'SomeAnalysis\' has been unshared from '
+                         'you.', u.messages()[0][1])
+
     def test_get_selected(self):
         s = Analysis(1)
         u = User('admin@foo.bar')
@@ -94,6 +98,11 @@ class TestShareAnalysisAjax(TestHandlerBase):
                  '<a target="_blank" href="mailto:admin@foo.bar">Admin</a>')}
         self.assertEqual(loads(response.body), exp)
         self.assertEqual(s.shared_with, [User('shared@foo.bar'), u])
+
+        # Make sure shared message added to the system
+        self.assertEqual('Analysis <a href="/analysis/results/1">'
+                         '\'SomeAnalysis\'</a> has been shared with you.',
+                         u.messages()[0][1])
 
     def test_get_no_access(self):
         s = Analysis(2)

--- a/qiita_pet/webserver.py
+++ b/qiita_pet/webserver.py
@@ -20,7 +20,7 @@ from qiita_pet.handlers.user_handlers import (
 from qiita_pet.handlers.analysis_handlers import (
     SelectCommandsHandler, AnalysisWaitHandler, AnalysisResultsHandler,
     ShowAnalysesHandler, ResultsHandler, SelectedSamplesHandler,
-    AnalysisSummaryAJAX)
+    AnalysisSummaryAJAX, ShareAnalysisAJAX)
 from qiita_pet.handlers.study_handlers import (
     StudyIndexHandler, StudyBaseInfoAJAX, SampleTemplateAJAX,
     StudyEditHandler, ListStudiesHandler, SearchStudiesAJAX, EBISubmitHandler,
@@ -95,6 +95,7 @@ class Application(tornado.web.Application):
             (r"/analysis/dflt/sumary/", AnalysisSummaryAJAX),
             (r"/analysis/selected/", SelectedSamplesHandler),
             (r"/analysis/selected/socket/", SelectedSocketHandler),
+            (r"/analysis/sharing/", ShareAnalysisAJAX),
             (r"/moi-ws/", MOIMessageHandler),
             (r"/consumer/", MessageHandler),
             (r"/admin/error/", LogEntryViewerHandler),


### PR DESCRIPTION
Fixes #1615 

Requires #1755 

This adds the ability to share analyses to the completed analysis page. It also adds messaging to sharing, so users will receive a message when a study or analysis is shared or unshared with them. 

<img width="705" alt="screen shot 2016-04-08 at 11 16 56" src="https://cloud.githubusercontent.com/assets/3079066/14393351/71afc3c4-fd7b-11e5-989f-8996fbf00a1c.png">
