### PR TITLE
Fix showing metadata header problems

### DIFF
--- a/qiita_pet/handlers/study_handlers/prep_template.py
+++ b/qiita_pet/handlers/study_handlers/prep_template.py
@@ -9,6 +9,7 @@ from __future__ import division
 from os.path import join
 
 from tornado.web import authenticated
+from tornado.escape import url_escape
 import pandas as pd
 
 from qiita_pet.handlers.util import to_int
@@ -56,7 +57,8 @@ class PrepTemplateAJAX(BaseHandler):
 
         res = prep_template_ajax_get_req(self.current_user.id, prep_id)
         res['prep_id'] = prep_id
-
+        # Escape the message just in case javascript breaking characters in it
+        res['alert_message'] = url_escape(res['alert_message'])
         self.render('study_ajax/prep_summary.html', **res)
 
 

--- a/qiita_pet/handlers/study_handlers/sample_template.py
+++ b/qiita_pet/handlers/study_handlers/sample_template.py
@@ -7,6 +7,7 @@
 # -----------------------------------------------------------------------------
 
 from tornado.web import authenticated, HTTPError
+from tornado.escape import url_escape
 
 from qiita_pet.handlers.base_handlers import BaseHandler
 from qiita_db.util import get_files_from_uploads_folders
@@ -92,7 +93,8 @@ class SampleTemplateAJAX(BaseHandler):
         stats['files'] = files
         stats['study_id'] = study_id
         stats['data_types'] = data_types
-
+        # URL encode in case message has javascript-breaking characters in it
+        stats['alert_message'] = url_escape(stats['alert_message'])
         self.render('study_ajax/sample_summary.html', **stats)
 
     @authenticated

--- a/qiita_pet/templates/study_ajax/prep_summary.html
+++ b/qiita_pet/templates/study_ajax/prep_summary.html
@@ -326,7 +326,7 @@
     });
 
     {% if alert_type != 'success' and alert_message != '' %}
-      bootstrapAlert("{% raw alert_message %}", "{{alert_type}}");
+      bootstrapAlert(decodeURIComponent("{% raw alert_message %}").replace(/\+/g,' '), "{{alert_type}}");
     {% else %}
       $('#bootstrap-alert').alert('close');
     {% end %}

--- a/qiita_pet/templates/study_ajax/sample_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_summary.html
@@ -49,7 +49,7 @@
     });
 
     {% if alert_type != 'success' and alert_message != '' %}
-      bootstrapAlert("{% raw alert_message %}", "{{alert_type}}");
+      bootstrapAlert(decodeURIComponent("{% raw alert_message %}").replace(/\+/g,' '), "{{alert_type}}");
     {% else %}
       $('#bootstrap-alert').alert('close');
     {% end %}

--- a/qiita_pet/test/test_prep_template.py
+++ b/qiita_pet/test/test_prep_template.py
@@ -26,10 +26,16 @@ class TestPrepTemplateHandler(TestHandlerBase):
         with open(self.new_prep, 'w') as f:
             f.write("sample_name\tnew_col\nSKD6.640190\tnew_value\n")
 
+        self.broken_prep = join(uploads_dp, '1', 'broke_template.txt')
+        with open(self.broken_prep, 'w') as f:
+            f.write("sample_name\tbroke \col\nSKD6.640190\tnew_value\n")
+
     def tearDown(self):
         super(TestPrepTemplateHandler, self).tearDown()
         if exists(self.new_prep):
             remove(self.new_prep)
+        if exists(self.broken_prep):
+            remove(self.broken_prep)
 
     def test_post(self):
         new_prep_id = get_count('qiita.prep_template') + 1
@@ -40,6 +46,15 @@ class TestPrepTemplateHandler(TestHandlerBase):
         self.assertEqual(response.code, 200)
         # Check that the new prep template has been created
         self.assertTrue(PrepTemplate.exists(new_prep_id))
+
+    def test_post_broken_header(self):
+        arguments = {'study_id': '1',
+                     'data-type': '16S',
+                     'prep-file': 'broke_template.txt'}
+        response = self.post('/prep_template/', arguments)
+        self.assertEqual(response.code, 200)
+        self.assertIn('sample_id varchar NOT NULL, broke \\\\col',
+                      response.body)
 
     def test_patch(self):
         # TODO: issue #1682


### PR DESCRIPTION
This fixes #1745 by escaping the text to be shown in the prep and sample metadata messages before sending into the javascript, then unescaping it before being shown. This removes all characters that could interfere with the javascript working.

See the broken /slash and broken \slash columns above that would otherwise break the system.
<img width="1514" alt="screen shot 2016-04-08 at 14 53 39" src="https://cloud.githubusercontent.com/assets/3079066/14398539/d1eb07b2-fd99-11e5-9735-fb9f7532efe2.png">
