### PR TITLE
Storing template errors/warnings correctly in redis

### DIFF
--- a/qiita_pet/handlers/api_proxy/artifact.py
+++ b/qiita_pet/handlers/api_proxy/artifact.py
@@ -471,12 +471,13 @@ def artifact_delete_req(artifact_id, user_id):
         message: Human readable message for status
     """
     pd = Artifact(int(artifact_id))
+    pt_id = pd.prep_templates[0].id
     access_error = check_access(pd.study.id, user_id)
     if access_error:
         return access_error
 
     job_id = safe_submit(user_id, delete_artifact, artifact_id)
-    r_client.set(PREP_TEMPLATE_KEY_FORMAT % pd.prep_templates[0].id,
+    r_client.set(PREP_TEMPLATE_KEY_FORMAT % pt_id,
                  dumps({'job_id': job_id}))
 
     return {'status': 'success',

--- a/qiita_pet/handlers/api_proxy/artifact.py
+++ b/qiita_pet/handlers/api_proxy/artifact.py
@@ -7,6 +7,7 @@
 # -----------------------------------------------------------------------------
 from os.path import join, basename
 from functools import partial
+from json import dumps
 
 from future.utils import viewitems
 from moi import r_client
@@ -325,7 +326,7 @@ def artifact_post_req(user_id, filepaths, artifact_type, name,
         job_id = safe_submit(user_id, create_raw_data, artifact_type, prep,
                              cleaned_filepaths, name=name)
 
-    r_client.set(PREP_TEMPLATE_KEY_FORMAT % prep.id, job_id)
+    r_client.set(PREP_TEMPLATE_KEY_FORMAT % prep.id, dumps({'job_id': job_id}))
 
     return {'status': 'success',
             'message': ''}
@@ -475,7 +476,8 @@ def artifact_delete_req(artifact_id, user_id):
         return access_error
 
     job_id = safe_submit(user_id, delete_artifact, artifact_id)
-    r_client.set(PREP_TEMPLATE_KEY_FORMAT % pd.prep_templates[0].id, job_id)
+    r_client.set(PREP_TEMPLATE_KEY_FORMAT % pd.prep_templates[0].id,
+                 dumps({'job_id': job_id}))
 
     return {'status': 'success',
             'message': ''}

--- a/qiita_pet/handlers/api_proxy/prep_template.py
+++ b/qiita_pet/handlers/api_proxy/prep_template.py
@@ -118,9 +118,11 @@ def prep_template_ajax_get_req(user_id, prep_id):
                 alert_type = 'info'
                 alert_msg = 'This prep template is currently being updated'
             elif redis_info['status_msg'] == 'Success':
+                alert_type = redis_info['return']['status']
+                alert_msg = redis_info['return']['message']
                 payload = {'job_id': None,
-                           'status': redis_info['return']['status'],
-                           'message': redis_info['return']['message']}
+                           'status': alert_type,
+                           'message': alert_msg}
                 r_client.set(PREP_TEMPLATE_KEY_FORMAT % prep_id,
                              dumps(payload))
             else:

--- a/qiita_pet/handlers/api_proxy/prep_template.py
+++ b/qiita_pet/handlers/api_proxy/prep_template.py
@@ -9,7 +9,7 @@ from __future__ import division
 import warnings
 from os import remove
 from os.path import basename
-from json import loads
+from json import loads, dumps
 
 from natsort import natsorted
 from moi import r_client
@@ -107,16 +107,30 @@ def prep_template_ajax_get_req(user_id, prep_id):
     name = "Prep information %d" % prep_id
     pt = PrepTemplate(prep_id)
 
-    job_id = r_client.get(PREP_TEMPLATE_KEY_FORMAT % prep_id)
-    if job_id:
-        redis_info = loads(r_client.get(job_id))
-        processing = redis_info['status_msg'] == 'Running'
-        if processing:
-            alert_type = 'info'
-            alert_msg = 'This prep template is currently being updated'
+    job_info = r_client.get(PREP_TEMPLATE_KEY_FORMAT % prep_id)
+    if job_info:
+        job_info = loads(job_info)
+        job_id = job_info['job_id']
+        if job_id:
+            redis_info = loads(r_client.get(job_id))
+            processing = redis_info['status_msg'] == 'Running'
+            if processing:
+                alert_type = 'info'
+                alert_msg = 'This prep template is currently being updated'
+            elif redis_info['status_msg'] == 'Success':
+                payload = {'job_id': None,
+                           'status': redis_info['return']['status'],
+                           'message': redis_info['return']['message']}
+                r_client.set(PREP_TEMPLATE_KEY_FORMAT % prep_id,
+                             dumps(payload))
+            else:
+                alert_type = redis_info['return']['status']
+                alert_msg = redis_info['return']['message'].replace('\n',
+                                                                    '</br>')
         else:
-            alert_type = redis_info['return']['status']
-            alert_msg = redis_info['return']['message'].replace('\n', '</br>')
+            processing = False
+            alert_type = job_info['status']
+            alert_msg = job_info['message'].replace('\n', '</br>')
     else:
         processing = False
         alert_type = ''
@@ -417,7 +431,8 @@ def prep_template_patch_req(user_id, req_op, req_path, req_value=None,
                 return fp
             fp = fp['file']
             job_id = safe_submit(user_id, update_prep_template, prep_id, fp)
-            r_client.set(PREP_TEMPLATE_KEY_FORMAT % prep_id, job_id)
+            r_client.set(PREP_TEMPLATE_KEY_FORMAT % prep_id,
+                         dumps({'job_id': job_id}))
         else:
             # We don't understand the attribute so return an error
             return {'status': 'error',

--- a/qiita_pet/handlers/api_proxy/prep_template.py
+++ b/qiita_pet/handlers/api_proxy/prep_template.py
@@ -119,7 +119,8 @@ def prep_template_ajax_get_req(user_id, prep_id):
                 alert_msg = 'This prep template is currently being updated'
             elif redis_info['status_msg'] == 'Success':
                 alert_type = redis_info['return']['status']
-                alert_msg = redis_info['return']['message']
+                alert_msg = redis_info['return']['message'].replace('\n',
+                                                                    '</br>')
                 payload = {'job_id': None,
                            'status': alert_type,
                            'message': alert_msg}

--- a/qiita_pet/handlers/api_proxy/sample_template.py
+++ b/qiita_pet/handlers/api_proxy/sample_template.py
@@ -229,9 +229,11 @@ def sample_template_summary_get_req(samp_id, user_id):
                 alert_type = 'info'
                 alert_msg = 'This sample template is currently being processed'
             elif redis_info['status_msg'] == 'Success':
+                alert_type = redis_info['return']['status'],
+                alert_msg = redis_info['return']['message']
                 payload = {'job_id': None,
-                           'status': redis_info['return']['status'],
-                           'message': redis_info['return']['message']}
+                           'status': alert_type,
+                           'message': alert_msg}
                 r_client.set(SAMPLE_TEMPLATE_KEY_FORMAT % samp_id,
                              dumps(payload))
             else:

--- a/qiita_pet/handlers/api_proxy/sample_template.py
+++ b/qiita_pet/handlers/api_proxy/sample_template.py
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
 from __future__ import division
-from json import loads
+from json import loads, dumps
 
 from natsort import natsorted
 from moi import r_client
@@ -218,16 +218,30 @@ def sample_template_summary_get_req(samp_id, user_id):
     if access_error:
         return access_error
 
-    job_id = r_client.get(SAMPLE_TEMPLATE_KEY_FORMAT % samp_id)
-    if job_id:
-        redis_info = loads(r_client.get(job_id))
-        processing = redis_info['status_msg'] == 'Running'
-        if processing:
-            alert_type = 'info'
-            alert_msg = 'This sample template is currently being processed'
+    job_info = r_client.get(SAMPLE_TEMPLATE_KEY_FORMAT % samp_id)
+    if job_info:
+        job_info = loads(job_info)
+        job_id = job_info['job_id']
+        if job_id:
+            redis_info = loads(r_client.get(job_id))
+            processing = redis_info['status_msg'] == 'Running'
+            if processing:
+                alert_type = 'info'
+                alert_msg = 'This sample template is currently being processed'
+            elif redis_info['status_msg'] == 'Success':
+                payload = {'job_id': None,
+                           'status': redis_info['return']['status'],
+                           'message': redis_info['return']['message']}
+                r_client.set(SAMPLE_TEMPLATE_KEY_FORMAT % samp_id,
+                             dumps(payload))
+            else:
+                alert_type = redis_info['return']['status']
+                alert_msg = redis_info['return']['message'].replace('\n',
+                                                                    '</br>')
         else:
-            alert_type = redis_info['return']['status']
-            alert_msg = redis_info['return']['message'].replace('\n', '</br>')
+            processing = False
+            alert_type = job_info['status']
+            alert_msg = job_info['message'].replace('\n', '</br>')
     else:
         processing = False
         alert_type = ''
@@ -323,7 +337,8 @@ def sample_template_post_req(study_id, user_id, data_type,
     job_id = safe_submit(user_id, create_sample_template, fp_rsp, study,
                          is_mapping_file, data_type)
     # Store the job id attaching it to the sample template id
-    r_client.set(SAMPLE_TEMPLATE_KEY_FORMAT % study.id, job_id)
+    r_client.set(SAMPLE_TEMPLATE_KEY_FORMAT % study.id,
+                 dumps({'job_id': job_id}))
 
     return {'status': status,
             'message': msg,
@@ -374,7 +389,8 @@ def sample_template_put_req(study_id, user_id, sample_template):
     job_id = safe_submit(user_id, update_sample_template, int(study_id),
                          fp_rsp)
     # Store the job id attaching it to the sample template id
-    r_client.set(SAMPLE_TEMPLATE_KEY_FORMAT % study_id, job_id)
+    r_client.set(SAMPLE_TEMPLATE_KEY_FORMAT % study_id,
+                 dumps({'job_id': job_id}))
 
     return {'status': status,
             'message': msg,
@@ -412,7 +428,8 @@ def sample_template_delete_req(study_id, user_id):
     # Offload the deletion of the sample template to the cluster
     job_id = safe_submit(user_id, delete_sample_template, int(study_id))
     # Store the job id attaching it to the sample template id
-    r_client.set(SAMPLE_TEMPLATE_KEY_FORMAT % study_id, job_id)
+    r_client.set(SAMPLE_TEMPLATE_KEY_FORMAT % study_id,
+                 dumps({'job_id': job_id}))
 
     return {'status': 'success', 'message': ''}
 

--- a/qiita_pet/handlers/api_proxy/sample_template.py
+++ b/qiita_pet/handlers/api_proxy/sample_template.py
@@ -229,8 +229,9 @@ def sample_template_summary_get_req(samp_id, user_id):
                 alert_type = 'info'
                 alert_msg = 'This sample template is currently being processed'
             elif redis_info['status_msg'] == 'Success':
-                alert_type = redis_info['return']['status'],
-                alert_msg = redis_info['return']['message']
+                alert_type = redis_info['return']['status']
+                alert_msg = redis_info['return']['message'].replace('\n',
+                                                                    '</br>')
                 payload = {'job_id': None,
                            'status': alert_type,
                            'message': alert_msg}

--- a/qiita_pet/handlers/api_proxy/tests/test_artifact.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_artifact.py
@@ -333,10 +333,10 @@ class TestArtifactAPI(TestCase):
         # the test database
         obs = r_client.get('prep_template_1')
         self.assertIsNotNone(obs)
-        redis_info = loads(r_client.get(obs))
+        redis_info = loads(r_client.get(loads(obs)['job_id']))
         while redis_info['status_msg'] == 'Running':
             sleep(0.05)
-            redis_info = loads(r_client.get(obs))
+            redis_info = loads(r_client.get(loads(obs)['job_id']))
 
     def test_artifact_delete_req_no_access(self):
         obs = artifact_delete_req(3, 'demo@microbio.me')
@@ -362,10 +362,10 @@ class TestArtifactAPI(TestCase):
 
         obs = r_client.get('prep_template_%d' % pt.id)
         self.assertIsNotNone(obs)
-        redis_info = loads(r_client.get(obs))
+        redis_info = loads(r_client.get(loads(obs)['job_id']))
         while redis_info['status_msg'] == 'Running':
             sleep(0.05)
-            redis_info = loads(r_client.get(obs))
+            redis_info = loads(r_client.get(loads(obs)['job_id']))
 
         # Instantiate the artifact to make sure it was made and
         # to clean the environment
@@ -389,10 +389,10 @@ class TestArtifactAPI(TestCase):
 
         obs = r_client.get('prep_template_%d' % pt.id)
         self.assertIsNotNone(obs)
-        redis_info = loads(r_client.get(obs))
+        redis_info = loads(r_client.get(loads(obs)['job_id']))
         while redis_info['status_msg'] == 'Running':
             sleep(0.05)
-            redis_info = loads(r_client.get(obs))
+            redis_info = loads(r_client.get(loads(obs)['job_id']))
         # Instantiate the artifact to make sure it was made and
         # to clean the environment
         a = Artifact(new_artifact_id_2)

--- a/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
@@ -406,10 +406,10 @@ class TestPrepAPI(TestCase):
         # This is needed so the clean up works - this is a distributed system
         # so we need to make sure that all processes are done before we reset
         # the test database
-        redis_info = loads(r_client.get(obs))
+        redis_info = loads(r_client.get(loads(obs)['job_id']))
         while redis_info['status_msg'] == 'Running':
             sleep(0.05)
-            redis_info = loads(r_client.get(obs))
+            redis_info = loads(r_client.get(loads(obs)['job_id']))
 
     def test_prep_template_patch_req_errors(self):
         # Operation not supported

--- a/qiita_pet/handlers/api_proxy/tests/test_sample_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_sample_template.py
@@ -322,10 +322,10 @@ class TestSampleAPI(TestCase):
         # This is needed so the clean up works - this is a distributed system
         # so we need to make sure that all processes are done before we reset
         # the test database
-        redis_info = loads(r_client.get(obs))
+        redis_info = loads(r_client.get(loads(obs)['job_id']))
         while redis_info['status_msg'] == 'Running':
             sleep(0.05)
-            redis_info = loads(r_client.get(obs))
+            redis_info = loads(r_client.get(loads(obs)['job_id']))
 
     def test_sample_template_post_req_no_access(self):
         obs = sample_template_post_req(1, 'demo@microbio.me', '16S',
@@ -348,10 +348,10 @@ class TestSampleAPI(TestCase):
         # This is needed so the clean up works - this is a distributed system
         # so we need to make sure that all processes are done before we reset
         # the test database
-        redis_info = loads(r_client.get(obs))
+        redis_info = loads(r_client.get(loads(obs)['job_id']))
         while redis_info['status_msg'] == 'Running':
             sleep(0.05)
-            redis_info = loads(r_client.get(obs))
+            redis_info = loads(r_client.get(loads(obs)['job_id']))
 
     def test_sample_template_put_req_no_access(self):
         obs = sample_template_put_req(1, 'demo@microbio.me', 'filepath')
@@ -378,10 +378,10 @@ class TestSampleAPI(TestCase):
         # This is needed so the clean up works - this is a distributed system
         # so we need to make sure that all processes are done before we reset
         # the test database
-        redis_info = loads(r_client.get(obs))
+        redis_info = loads(r_client.get(loads(obs)['job_id']))
         while redis_info['status_msg'] == 'Running':
             sleep(0.05)
-            redis_info = loads(r_client.get(obs))
+            redis_info = loads(r_client.get(loads(obs)['job_id']))
 
     def test_sample_template_delete_req_no_access(self):
         obs = sample_template_delete_req(1, 'demo@microbio.me')

--- a/qiita_pet/handlers/study_handlers/tests/test_artifact.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_artifact.py
@@ -129,10 +129,10 @@ class NewArtifactHandlerTests(TestHandlerBase):
         # make sure new artifact created
         obs = r_client.get('prep_template_%s' % self.prep.id)
         self.assertIsNotNone(obs)
-        redis_info = loads(r_client.get(obs))
+        redis_info = loads(r_client.get(loads(obs)['job_id']))
         while redis_info['status_msg'] == 'Running':
             sleep(0.05)
-            redis_info = loads(r_client.get(obs))
+            redis_info = loads(r_client.get(loads(obs)['job_id']))
         new_artifact_id = get_count('qiita.artifact')
         artifact = Artifact(new_artifact_id)
         self.assertEqual(artifact.name, 'New Artifact Handler test')


### PR DESCRIPTION
Before we where "trusting" moi to store these error messages. However, moi sets an expiration time in the keys, which makes the interface to break once the key expires. This changes the way the keys are stored to actually store the information in new keys, which do not expire.