### PR TITLE
Fix 1512: phred_offset

### DIFF
--- a/qiita_db/handlers/tests/test_processing_job.py
+++ b/qiita_db/handlers/tests/test_processing_job.py
@@ -52,7 +52,8 @@ class JobHandlerTests(OauthTestingBase):
                   "rev_comp_barcode": False,
                   "rev_comp_mapping_barcodes": False, "rev_comp": False,
                   "phred_quality_threshold": 3, "barcode_type": "golay_12",
-                  "max_barcode_errors": 1.5, "input_data": 1}
+                  "max_barcode_errors": 1.5, "input_data": 1,
+                  'phred_offset': ''}
         exp = {'success': True, 'error': '', 'command': cmd,
                'parameters': params, 'status': 'success'}
         self.assertEqual(loads(obs.body), exp)

--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -736,6 +736,13 @@ class DefaultParameters(qdb.base.QiitaObject):
             - If the parameter set already exists
         """
         with qdb.sql_connection.TRN:
+            # setting to default values all parameters not in the user_params
+            cmd_params = command.optional_parameters
+            missing_in_user = {k: cmd_params[k][1]
+                               for k in (set(cmd_params) - set(kwargs))}
+            if missing_in_user:
+                kwargs.update(missing_in_user)
+
             # If the columns in kwargs and command do not match, cls.exists
             # will raise the error for us
             if cls.exists(command, **kwargs):
@@ -868,6 +875,13 @@ class Parameters(object):
             parameters = deepcopy(values_dict)
             error_msg = ("The provided values dictionary doesn't encode a "
                          "parameter set for command %s" % command.id)
+
+        # setting to default values all parameters not in the user_params
+        cmd_params = command.optional_parameters
+        missing_in_user = {k: cmd_params[k][1]
+                           for k in (set(cmd_params) - set(parameters))}
+        if missing_in_user:
+            parameters.update(missing_in_user)
 
         with qdb.sql_connection.TRN:
             cmd_reqd_params = command.required_parameters

--- a/qiita_db/support_files/patches/37.sql
+++ b/qiita_db/support_files/patches/37.sql
@@ -17,9 +17,9 @@ BEGIN
         SET command_parameters = (
             substring(command_parameters::text FROM 0 FOR char_length(command_parameters::text)) || ',"phred_offset":""}'
         )::json
-        WHERE artifact_id=2;
+        WHERE command_id=cmd_id;;
 
-    -- updating the per sample FASTQ defaults
+    -- updating the default_parameter_set
     UPDATE qiita.default_parameter_set
         SET parameter_set = (
             substring(parameter_set::text FROM 0 FOR char_length(parameter_set::text)) || ',"phred_offset":""}'

--- a/qiita_db/support_files/patches/37.sql
+++ b/qiita_db/support_files/patches/37.sql
@@ -17,7 +17,7 @@ BEGIN
         SET command_parameters = (
             substring(command_parameters::text FROM 0 FOR char_length(command_parameters::text)) || ',"phred_offset":""}'
         )::json
-        WHERE command_id=cmd_id;;
+        WHERE command_id=cmd_id;
 
     -- updating the default_parameter_set
     UPDATE qiita.default_parameter_set

--- a/qiita_db/support_files/patches/37.sql
+++ b/qiita_db/support_files/patches/37.sql
@@ -25,4 +25,12 @@ BEGIN
             substring(parameter_set::text FROM 0 FOR char_length(parameter_set::text)) || ',"phred_offset":""}'
         )::json
         WHERE command_id=cmd_id;
+
+    -- inserting new possible default_parameter_sets
+    INSERT INTO qiita.default_parameter_set (command_id, parameter_set_name, parameter_set)
+        VALUES (cmd_id, 'per sample FASTQ defaults, phred_offset 33',
+                '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":false,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"not-barcoded","max_barcode_errors":1.5,"phred_offset":"33"}'::json);
+    INSERT INTO qiita.default_parameter_set (command_id, parameter_set_name, parameter_set)
+        VALUES (cmd_id, 'per sample FASTQ defaults, phred_offset 64',
+                '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":false,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"not-barcoded","max_barcode_errors":1.5,"phred_offset":"64"}'::json);
 END $do$;

--- a/qiita_db/support_files/patches/37.sql
+++ b/qiita_db/support_files/patches/37.sql
@@ -1,0 +1,28 @@
+-- Apr 18, 2016
+-- Adding phred_offset to split libraries
+
+DO $do$
+DECLARE
+    cmd_id            bigint;
+BEGIN
+    -- selecting command_id of interest
+    SELECT command_id FROM qiita.software_command WHERE name = 'Split libraries FASTQ' INTO cmd_id;
+
+    -- adding new parameter
+    INSERT INTO qiita.command_parameter (command_id, parameter_name, parameter_type, required, default_value)
+        VALUES (cmd_id, 'phred_offset', 'string', False, '');
+
+    -- updating all current artifacts that were generated with this command
+    UPDATE qiita.artifact
+        SET command_parameters = (
+            substring(command_parameters::text FROM 0 FOR char_length(command_parameters::text)) || ',"phred_offset":""}'
+        )::json
+        WHERE artifact_id=2;
+
+    -- updating the per sample FASTQ defaults
+    UPDATE qiita.default_parameter_set
+        SET parameter_set = (
+            substring(parameter_set::text FROM 0 FOR char_length(parameter_set::text)) || ',"phred_offset":""}'
+        )::json
+        WHERE command_id=cmd_id;
+END $do$;

--- a/qiita_db/support_files/populate_test_db.sql
+++ b/qiita_db/support_files/populate_test_db.sql
@@ -321,9 +321,9 @@ INSERT INTO qiita.study_prep_template (study_id, prep_template_id) VALUES (1, 1)
 INSERT INTO qiita.artifact (name, generated_timestamp, command_id, command_parameters,
                             visibility_id, artifact_type_id, data_type_id)
     VALUES ('Raw data 1', 'Mon Oct 1 09:30:27 2012', NULL, NULL, 3, 3, 2),
-           ('Demultiplexed 1', 'Mon Oct 1 10:30:27 2012', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":false,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1}'::json,
+           ('Demultiplexed 1', 'Mon Oct 1 10:30:27 2012', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":false,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1,"phred_offset":""}'::json,
             3, 6, 2),
-           ('Demultiplexed 2', 'Mon Oct 1 11:30:27 2012', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":true,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1}'::json,
+           ('Demultiplexed 2', 'Mon Oct 1 11:30:27 2012', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":true,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1,"phred_offset":""}'::json,
             3, 6, 2),
            ('BIOM', 'Tue Oct 2 17:30:00 2012', 3, '{"reference":1,"sortmerna_e_value":1,"sortmerna_max_pos":10000,"similarity":0.97,"sortmerna_coverage":0.97,"threads":1,"input_data":2}'::json,
             3, 7, 2),
@@ -339,8 +339,8 @@ INSERT INTO qiita.parent_artifact (parent_id, artifact_id)
 
 -- Insert the jobs that processed the previous artifacts
 INSERT INTO qiita.processing_job (processing_job_id, email, command_id, command_parameters, processing_job_status_id)
-    VALUES ('6d368e16-2242-4cf8-87b4-a5dc40bb890b', 'test@foo.bar', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":false,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1}'::json, 3),
-           ('4c7115e8-4c8e-424c-bf25-96c292ca1931', 'test@foo.bar', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":true,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1}'::json, 3),
+    VALUES ('6d368e16-2242-4cf8-87b4-a5dc40bb890b', 'test@foo.bar', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":false,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1,"phred_offset":""}'::json, 3),
+           ('4c7115e8-4c8e-424c-bf25-96c292ca1931', 'test@foo.bar', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":true,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1,"phred_offset":""}'::json, 3),
            ('3c9991ab-6c14-4368-a48c-841e8837a79c', 'test@foo.bar', 3, '{"reference":1,"sortmerna_e_value":1,"sortmerna_max_pos":10000,"similarity":0.97,"sortmerna_coverage":0.97,"threads":1,"input_data":2}'::json, 3);
 
 -- Relate the above jobs with the artifacts
@@ -512,9 +512,9 @@ INSERT INTO qiita.logging (time, severity_id, msg, information)
 INSERT INTO qiita.processing_job
         (processing_job_id, email, command_id, command_parameters,
          processing_job_status_id, logging_id, heartbeat, step)
-    VALUES ('063e553b-327c-4818-ab4a-adfe58e49860', 'test@foo.bar', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":false,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1}'::json, 1, NULL, NULL, NULL),
+    VALUES ('063e553b-327c-4818-ab4a-adfe58e49860', 'test@foo.bar', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":false,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1,"phred_offset":""}'::json, 1, NULL, NULL, NULL),
            ('bcc7ebcd-39c1-43e4-af2d-822e3589f14d', 'test@foo.bar', 2, '{"min_seq_len":100,"max_seq_len":1000,"trim_seq_length":false,"min_qual_score":25,"max_ambig":6,"max_homopolymer":6,"max_primer_mismatch":0,"barcode_type":"golay_12","max_barcode_errors":1.5,"disable_bc_correction":false,"qual_score_window":0,"disable_primers":false,"reverse_primers":"disable","reverse_primer_mismatches":0,"truncate_ambi_bases":false,"input_data":1}'::json, 2, NULL, 'Sun Nov 22 21:00:00 2015', 'demultiplexing'),
-           ('b72369f9-a886-4193-8d3d-f7b504168e75', 'shared@foo.bar', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":true,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1}'::json, 3, NULL, 'Sun Nov 22 21:15:00 2015', NULL),
+           ('b72369f9-a886-4193-8d3d-f7b504168e75', 'shared@foo.bar', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":true,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1,"phred_offset":""}'::json, 3, NULL, 'Sun Nov 22 21:15:00 2015', NULL),
            ('d19f76ee-274e-4c1b-b3a2-a12d73507c55', 'shared@foo.bar', 3, '{"reference":1,"sortmerna_e_value":1,"sortmerna_max_pos":10000,"similarity":0.97,"sortmerna_coverage":0.97,"threads":1,"input_data":2}'::json, 4, 1, 'Sun Nov 22 21:30:00 2015', 'generating demux file'),
            ('ac653cb5-76a6-4a45-929e-eb9b2dee6b63', 'test@foo.bar', 1, '{"max_bad_run_length":3,"min_per_read_length_fraction":0.75,"sequence_max_n":0,"rev_comp_barcode":false,"rev_comp_mapping_barcodes":false,"rev_comp":false,"phred_quality_threshold":3,"barcode_type":"golay_12","max_barcode_errors":1.5,"input_data":1}'::json, 5, NULL, NULL, NULL);
 

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -76,7 +76,8 @@ class ArtifactTestsReadOnly(TestCase):
                          'rev_comp_barcode': False,
                          'rev_comp_mapping_barcodes': False,
                          'min_per_read_length_fraction': 0.75,
-                         'barcode_type': 'golay_12'})
+                         'barcode_type': 'golay_12',
+                         'phred_offset': ''})
         self.assertEqual(obs, exp)
         obs = qdb.artifact.Artifact(3).processing_parameters
         exp = qdb.software.Parameters.load(
@@ -87,7 +88,8 @@ class ArtifactTestsReadOnly(TestCase):
                          'rev_comp_barcode': False,
                          'rev_comp_mapping_barcodes': True,
                          'min_per_read_length_fraction': 0.75,
-                         'barcode_type': 'golay_12'})
+                         'barcode_type': 'golay_12',
+                         'phred_offset': ''})
         self.assertEqual(obs, exp)
 
     def test_visibility(self):
@@ -702,8 +704,8 @@ class ArtifactTests(TestCase):
             '"barcode_type": "golay_12", "max_bad_run_length": 3, '
             '"rev_comp": false, "phred_quality_threshold": 3, '
             '"rev_comp_barcode": false, "rev_comp_mapping_barcodes": false, '
-            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0}'
-            % test.id)
+            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0, '
+            '"phred_offset": ""}' % test.id)
         qdb.processing_job.ProcessingJob.create(
             qdb.user.User('test@foo.bar'),
             qdb.software.Parameters.load(qdb.software.Command(1),
@@ -720,8 +722,8 @@ class ArtifactTests(TestCase):
             '"barcode_type": "golay_12", "max_bad_run_length": 3, '
             '"rev_comp": false, "phred_quality_threshold": 3, '
             '"rev_comp_barcode": false, "rev_comp_mapping_barcodes": false, '
-            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0}'
-            % test.id)
+            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0, '
+            '"phred_offset": ""}' % test.id)
         job = qdb.processing_job.ProcessingJob.create(
             qdb.user.User('test@foo.bar'),
             qdb.software.Parameters.load(qdb.software.Command(1),
@@ -779,8 +781,8 @@ class ArtifactTests(TestCase):
             '"barcode_type": "golay_12", "max_bad_run_length": 3, '
             '"rev_comp": false, "phred_quality_threshold": 3, '
             '"rev_comp_barcode": false, "rev_comp_mapping_barcodes": false, '
-            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0}'
-            % test.id)
+            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0, '
+            '"phred_offset": ""}' % test.id)
         job = qdb.processing_job.ProcessingJob.create(
             qdb.user.User('test@foo.bar'),
             qdb.software.Parameters.load(qdb.software.Command(1),

--- a/qiita_db/test/test_commands.py
+++ b/qiita_db/test/test_commands.py
@@ -226,7 +226,7 @@ class TestLoadParametersFromCmd(TestCase):
             "test", self.fp, 1)
         obs = new.values
         exp = {"barcode_type": "hamming_8", "max_bad_run_length": "3",
-               "max_barcode_errors": "1.5",
+               "phred_offset": "", "max_barcode_errors": "1.5",
                "min_per_read_length_fraction": "0.75",
                "phred_quality_threshold": "3", "sequence_max_n": "0",
                "rev_comp": "False", "rev_comp_barcode": "False",

--- a/qiita_db/test/test_processing_job.py
+++ b/qiita_db/test/test_processing_job.py
@@ -112,7 +112,7 @@ class ProcessingJobTestReadOnly(TestCase):
             '"sequence_max_n":0,"rev_comp_barcode":false,'
             '"rev_comp_mapping_barcodes":false,"rev_comp":false,'
             '"phred_quality_threshold":3,"barcode_type":"golay_12",'
-            '"max_barcode_errors":1.5,"input_data":1}')
+            '"max_barcode_errors":1.5,"input_data":1,"phred_offset":""}')
         exp_params = qdb.software.Parameters.load(qdb.software.Command(1),
                                                   json_str=json_str)
         self.assertEqual(self.tester1.parameters, exp_params)
@@ -134,7 +134,7 @@ class ProcessingJobTestReadOnly(TestCase):
             '"sequence_max_n":0,"rev_comp_barcode":false,'
             '"rev_comp_mapping_barcodes":true,"rev_comp":false,'
             '"phred_quality_threshold":3,"barcode_type":"golay_12",'
-            '"max_barcode_errors":1.5,"input_data":1}')
+            '"max_barcode_errors":1.5,"input_data":1,"phred_offset":""}')
         exp_params = qdb.software.Parameters.load(qdb.software.Command(1),
                                                   json_str=json_str)
         self.assertEqual(self.tester3.parameters, exp_params)
@@ -232,7 +232,8 @@ class ProcessingJobTest(TestCase):
             '"barcode_type": "golay_12", "max_bad_run_length": 3, '
             '"rev_comp": false, "phred_quality_threshold": 3, '
             '"rev_comp_barcode": false, "rev_comp_mapping_barcodes": false, '
-            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0}')
+            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0, '
+            '"phred_offset": ""}')
         exp_params = qdb.software.Parameters.load(exp_command,
                                                   json_str=json_str)
         exp_user = qdb.user.User('test@foo.bar')
@@ -387,7 +388,8 @@ class ProcessingJobTest(TestCase):
             '"barcode_type": "golay_12", "max_bad_run_length": 3, '
             '"rev_comp": false, "phred_quality_threshold": 3, '
             '"rev_comp_barcode": false, "rev_comp_mapping_barcodes": false, '
-            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0}')
+            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0, '
+            '"phred_offset": ""}')
         exp_params = qdb.software.Parameters.load(exp_command,
                                                   json_str=json_str)
         exp_user = qdb.user.User('test@foo.bar')
@@ -519,7 +521,8 @@ class ProcessingWorkflowTests(TestCase):
             '"barcode_type": "golay_12", "max_bad_run_length": 3, '
             '"rev_comp": false, "phred_quality_threshold": 3, '
             '"rev_comp_barcode": false, "rev_comp_mapping_barcodes": false, '
-            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0}')
+            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0, '
+            '"phred_offset": ""}')
         exp_params = qdb.software.Parameters.load(exp_command,
                                                   json_str=json_str)
         exp_user = qdb.user.User('test@foo.bar')
@@ -543,7 +546,8 @@ class ProcessingWorkflowTests(TestCase):
             '"barcode_type": "golay_12", "max_bad_run_length": 3, '
             '"rev_comp": false, "phred_quality_threshold": 3, '
             '"rev_comp_barcode": false, "rev_comp_mapping_barcodes": false, '
-            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0}')
+            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0, '
+            '"phred_offset": ""}')
         exp_params = qdb.software.Parameters.load(exp_command,
                                                   json_str=json_str)
         exp_user = qdb.user.User('test@foo.bar')
@@ -602,7 +606,8 @@ class ProcessingWorkflowTests(TestCase):
                       'rev_comp': False,
                       'rev_comp_barcode': False,
                       'rev_comp_mapping_barcodes': False,
-                      'sequence_max_n': 0}
+                      'sequence_max_n': 0,
+                      'phred_offset': ''}
         self.assertEqual(obs_job.parameters.values, exp_params)
 
     def test_add_error(self):
@@ -617,7 +622,8 @@ class ProcessingWorkflowTests(TestCase):
             '"barcode_type": "golay_12", "max_bad_run_length": 3, '
             '"rev_comp": false, "phred_quality_threshold": 3, '
             '"rev_comp_barcode": false, "rev_comp_mapping_barcodes": false, '
-            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0}')
+            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0,'
+            '"phred_offset": ""}')
         exp_params = qdb.software.Parameters.load(exp_command,
                                                   json_str=json_str)
         exp_user = qdb.user.User('test@foo.bar')

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -168,7 +168,9 @@ class CommandTestsReadOnly(TestCase):
                qdb.software.DefaultParameters(4),
                qdb.software.DefaultParameters(5),
                qdb.software.DefaultParameters(6),
-               qdb.software.DefaultParameters(7)]
+               qdb.software.DefaultParameters(7),
+               qdb.software.DefaultParameters(11),
+               qdb.software.DefaultParameters(12)]
         self.assertEqual(obs, exp)
 
         obs = list(qdb.software.Command(2).default_parameter_sets)
@@ -463,16 +465,18 @@ class ParametersTests(TestCase):
         with self.assertRaises(qdb.exceptions.QiitaDBError):
             qdb.software.Parameters.load(cmd, json_str=json_str)
 
-    def test_load_error_missing_optional(self):
-        json_str = ('{"barcode_type": "golay_12", "input_data": 1, '
-                    '"max_bad_run_length": 3, "max_barcode_errors": 1.5, '
-                    '"min_per_read_length_fraction": 0.75, '
-                    '"rev_comp": false, '
-                    '"rev_comp_barcode": false, '
-                    '"rev_comp_mapping_barcodes": false, "sequence_max_n": 0}')
+    def test_load_loads_defaults(self):
+        values = {
+            "barcode_type": "golay_12", "input_data": 1,
+            "phred_quality_threshold": 3, "rev_comp": False,
+            "rev_comp_barcode": False, "rev_comp_mapping_barcodes": False,
+            "sequence_max_n": 0, "phred_offset": ""}
         cmd = qdb.software.Command(1)
-        with self.assertRaises(qdb.exceptions.QiitaDBError):
-            qdb.software.Parameters.load(cmd, json_str=json_str)
+        obs = qdb.software.Parameters.load(cmd, values_dict=values)
+        values.update({
+            "max_bad_run_length": '3', "max_barcode_errors": '1.5',
+            "min_per_read_length_fraction": '0.75'})
+        self.assertEqual(obs.values, values)
 
     def test_load_error_extra_parameters(self):
         json_str = ('{"barcode_type": "golay_12", "input_data": 1, '

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -85,7 +85,8 @@ class CommandTestsReadOnly(TestCase):
                       'rev_comp': ['bool', 'False'],
                       'rev_comp_barcode': ['bool', 'False'],
                       'rev_comp_mapping_barcodes': ['bool', 'False'],
-                      'sequence_max_n': ['integer', '0']}
+                      'sequence_max_n': ['integer', '0'],
+                      'phred_offset': ['string', '']}
         self.assertEqual(qdb.software.Command(1).parameters, exp_params)
         exp_params = {
             'barcode_type': ['string', 'golay_12'],
@@ -134,7 +135,8 @@ class CommandTestsReadOnly(TestCase):
                       'rev_comp': ['bool', 'False'],
                       'rev_comp_barcode': ['bool', 'False'],
                       'rev_comp_mapping_barcodes': ['bool', 'False'],
-                      'sequence_max_n': ['integer', '0']}
+                      'sequence_max_n': ['integer', '0'],
+                      'phred_offset': ['string', '']}
         self.assertEqual(qdb.software.Command(1).optional_parameters,
                          exp_params)
         exp_params = exp_params = {
@@ -344,7 +346,7 @@ class DefaultParametersTestsReadOnly(TestCase):
             sequence_max_n=0, rev_comp_barcode=False,
             rev_comp_mapping_barcodes=False, rev_comp=False,
             phred_quality_threshold=3, barcode_type="golay_12",
-            max_barcode_errors=1.5)
+            max_barcode_errors=1.5, phred_offset='')
         self.assertTrue(obs)
 
         obs = qdb.software.DefaultParameters.exists(
@@ -352,7 +354,7 @@ class DefaultParametersTestsReadOnly(TestCase):
             sequence_max_n=0, rev_comp_barcode=False,
             rev_comp_mapping_barcodes=False, rev_comp=False,
             phred_quality_threshold=3, barcode_type="hamming_8",
-            max_barcode_errors=1.5)
+            max_barcode_errors=1.5, phred_offset='')
         self.assertFalse(obs)
 
     def test_name(self):
@@ -363,7 +365,8 @@ class DefaultParametersTestsReadOnly(TestCase):
                'max_barcode_errors': 1.5, 'max_bad_run_length': 3,
                'rev_comp': False, 'phred_quality_threshold': 3,
                'rev_comp_barcode': False, 'sequence_max_n': 0,
-               'barcode_type': 'golay_12', 'rev_comp_mapping_barcodes': False}
+               'barcode_type': 'golay_12', 'rev_comp_mapping_barcodes': False,
+               'phred_offset': ''}
         self.assertEqual(qdb.software.DefaultParameters(1).values, exp)
 
     def test_command(self):
@@ -380,14 +383,15 @@ class DefaultParametersTests(TestCase):
             min_per_read_length_fraction=0.75, sequence_max_n=0,
             rev_comp_barcode=False, rev_comp_mapping_barcodes=False,
             rev_comp=False, phred_quality_threshold=3,
-            barcode_type="hamming_8", max_barcode_errors=1.5)
+            barcode_type="hamming_8", max_barcode_errors=1.5,
+            phred_offset='')
         self.assertEqual(obs.name, "test_create")
 
         exp = {'max_bad_run_length': 3, 'min_per_read_length_fraction': 0.75,
                'sequence_max_n': 0, 'rev_comp_barcode': False,
                'rev_comp_mapping_barcodes': False, 'rev_comp': False,
                'phred_quality_threshold': 3, 'barcode_type': "hamming_8",
-               'max_barcode_errors': 1.5}
+               'max_barcode_errors': 1.5, 'phred_offset': ''}
         self.assertEqual(obs.values, exp)
         self.assertEqual(obs.command, cmd)
 
@@ -423,7 +427,7 @@ class ParametersTests(TestCase):
                     '"max_bad_run_length": 3, "max_barcode_errors": 1.5, '
                     '"min_per_read_length_fraction": 0.75, '
                     '"phred_quality_threshold": 3, "rev_comp": false, '
-                    '"rev_comp_barcode": false, '
+                    '"rev_comp_barcode": false, "phred_offset": "", '
                     '"rev_comp_mapping_barcodes": false, "sequence_max_n": 0}')
         cmd = qdb.software.Command(1)
         obs = qdb.software.Parameters.load(cmd, json_str=json_str)
@@ -433,7 +437,7 @@ class ParametersTests(TestCase):
             "min_per_read_length_fraction": 0.75,
             "phred_quality_threshold": 3, "rev_comp": False,
             "rev_comp_barcode": False, "rev_comp_mapping_barcodes": False,
-            "sequence_max_n": 0}
+            "sequence_max_n": 0, "phred_offset": ""}
         self.assertEqual(obs.values, exp_values)
 
     def test_load_dictionary(self):
@@ -443,7 +447,7 @@ class ParametersTests(TestCase):
             "min_per_read_length_fraction": 0.75,
             "phred_quality_threshold": 3, "rev_comp": False,
             "rev_comp_barcode": False, "rev_comp_mapping_barcodes": False,
-            "sequence_max_n": 0}
+            "sequence_max_n": 0, "phred_offset": ""}
         cmd = qdb.software.Command(1)
         obs = qdb.software.Parameters.load(cmd, values_dict=exp_values)
         self.assertEqual(obs.values, exp_values)
@@ -453,7 +457,7 @@ class ParametersTests(TestCase):
                     '"max_bad_run_length": 3, "max_barcode_errors": 1.5, '
                     '"min_per_read_length_fraction": 0.75, '
                     '"phred_quality_threshold": 3, "rev_comp": false, '
-                    '"rev_comp_barcode": false, '
+                    '"rev_comp_barcode": false, "phred_offset": "", '
                     '"rev_comp_mapping_barcodes": false, "sequence_max_n": 0}')
         cmd = qdb.software.Command(1)
         with self.assertRaises(qdb.exceptions.QiitaDBError):
@@ -475,7 +479,7 @@ class ParametersTests(TestCase):
                     '"max_bad_run_length": 3, "max_barcode_errors": 1.5, '
                     '"min_per_read_length_fraction": 0.75, '
                     '"phred_quality_threshold": 3, "rev_comp": false, '
-                    '"rev_comp_barcode": false, '
+                    '"rev_comp_barcode": false, "phred_offset": "",'
                     '"rev_comp_mapping_barcodes": false, "sequence_max_n": 0,'
                     '"extra_param": 1}')
         cmd = qdb.software.Command(1)
@@ -491,7 +495,7 @@ class ParametersTests(TestCase):
                'rev_comp': False, 'phred_quality_threshold': 3,
                'rev_comp_barcode': False, 'sequence_max_n': 0,
                'barcode_type': 'golay_12', 'rev_comp_mapping_barcodes': False,
-               'input_data': 1}
+               'input_data': 1, 'phred_offset': ''}
         self.assertEqual(obs._values, exp)
 
         obs = qdb.software.Parameters.from_default_params(
@@ -503,7 +507,7 @@ class ParametersTests(TestCase):
                'rev_comp': False, 'phred_quality_threshold': 3,
                'rev_comp_barcode': False, 'sequence_max_n': 0,
                'barcode_type': 'golay_12', 'rev_comp_mapping_barcodes': False,
-               'input_data': 1}
+               'input_data': 1, 'phred_offset': ''}
         self.assertEqual(obs._values, exp)
 
     def test_from_default_params_error_missing_reqd(self):
@@ -536,7 +540,7 @@ class ParametersTests(TestCase):
                'rev_comp': False, 'phred_quality_threshold': 3,
                'rev_comp_barcode': False, 'sequence_max_n': 0,
                'barcode_type': 'golay_12', 'rev_comp_mapping_barcodes': False,
-               'input_data': 1}
+               'phred_offset': '', 'input_data': 1}
         self.assertEqual(obs, exp)
 
     def test_dumps(self):
@@ -544,7 +548,7 @@ class ParametersTests(TestCase):
             qdb.software.DefaultParameters(1), {'input_data': 1}).dump()
         exp = ('{"barcode_type": "golay_12", "input_data": 1, '
                '"max_bad_run_length": 3, "max_barcode_errors": 1.5, '
-               '"min_per_read_length_fraction": 0.75, '
+               '"min_per_read_length_fraction": 0.75, "phred_offset": "", '
                '"phred_quality_threshold": 3, "rev_comp": false, '
                '"rev_comp_barcode": false, '
                '"rev_comp_mapping_barcodes": false, "sequence_max_n": 0}')

--- a/qiita_pet/handlers/api_proxy/tests/test_processing.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_processing.py
@@ -86,7 +86,8 @@ class TestProcessingAPIReadOnly(TestCase):
                                   'rev_comp': False,
                                   'rev_comp_barcode': False,
                                   'rev_comp_mapping_barcodes': False,
-                                  'sequence_max_n': 0}}
+                                  'sequence_max_n': 0,
+                                  'phred_offset': ''}}
         self.assertEqual(obs, exp)
 
 

--- a/qiita_plugins/target_gene/tgp/split_libraries/split_libraries_fastq.py
+++ b/qiita_plugins/target_gene/tgp/split_libraries/split_libraries_fastq.py
@@ -35,7 +35,7 @@ def generate_parameters_string(parameters):
                   'sequence_max_n', 'phred_quality_threshold', 'barcode_type',
                   'max_barcode_errors', 'phred_offset']
     result = ["--%s %s" % (sp, parameters[sp]) for sp in str_params
-              if parameters[sp]]
+              if parameters[sp] != ""]
     for fp in flag_params:
         if parameters[fp]:
             result.append("--%s" % fp)

--- a/qiita_plugins/target_gene/tgp/split_libraries/split_libraries_fastq.py
+++ b/qiita_plugins/target_gene/tgp/split_libraries/split_libraries_fastq.py
@@ -33,8 +33,9 @@ def generate_parameters_string(parameters):
     flag_params = ['rev_comp_barcode', 'rev_comp_mapping_barcodes', 'rev_comp']
     str_params = ['max_bad_run_length', 'min_per_read_length_fraction',
                   'sequence_max_n', 'phred_quality_threshold', 'barcode_type',
-                  'max_barcode_errors']
-    result = ["--%s %s" % (sp, parameters[sp]) for sp in str_params]
+                  'max_barcode_errors', 'phred_offset']
+    result = ["--%s %s" % (sp, parameters[sp]) for sp in str_params
+              if parameters[sp]]
     for fp in flag_params:
         if parameters[fp]:
             result.append("--%s" % fp)

--- a/qiita_plugins/target_gene/tgp/split_libraries/tests/test_split_libraries_fastq.py
+++ b/qiita_plugins/target_gene/tgp/split_libraries/tests/test_split_libraries_fastq.py
@@ -35,13 +35,12 @@ class SplitLibrariesFastqTests(TestCase):
             "sequence_max_n": 0, "rev_comp_barcode": False,
             "rev_comp_mapping_barcodes": True, "rev_comp": False,
             "phred_quality_threshold": 3, "barcode_type": "golay_12",
-            "max_barcode_errors": 1.5, "input_data": 1}
+            "max_barcode_errors": 1.5, "input_data": 1, "phred_offset": ""}
 
         obs = generate_parameters_string(parameters)
-        exp = ("--max_bad_run_length 3 --min_per_read_length_fraction 0.75 "
-               "--sequence_max_n 0 --phred_quality_threshold 3 "
-               "--barcode_type golay_12 --max_barcode_errors 1.5 "
-               "--rev_comp_mapping_barcodes")
+        exp = ('--max_bad_run_length 3 --min_per_read_length_fraction 0.75 '
+               '--phred_quality_threshold 3 --barcode_type golay_12 '
+               '--max_barcode_errors 1.5 --rev_comp_mapping_barcodes')
         self.assertEqual(obs, exp)
 
     def test_get_sample_names_by_run_prefix(self):
@@ -187,17 +186,16 @@ class SplitLibrariesFastqTests(TestCase):
             "sequence_max_n": 0, "rev_comp_barcode": False,
             "rev_comp_mapping_barcodes": True, "rev_comp": False,
             "phred_quality_threshold": 3, "barcode_type": "golay_12",
-            "max_barcode_errors": 1.5, "input_data": 1}
+            "max_barcode_errors": 1.5, "input_data": 1, "phred_offset": ""}
         obs_cmd, obs_outdir = generate_split_libraries_fastq_cmd(
             fps, mapping_file, atype, out_dir, parameters)
         exp_cmd = (
-            "split_libraries_fastq.py --store_demultiplexed_fastq -i "
-            "s1.fastq.gz,s2.fastq.gz,s3.fastq.gz --sample_ids "
-            "SKB8.640193,SKD8.640184,SKB7.640196 -o /output/dir/sl_out "
-            "--max_bad_run_length 3 --min_per_read_length_fraction 0.75 "
-            "--sequence_max_n 0 --phred_quality_threshold 3 "
-            "--barcode_type golay_12 --max_barcode_errors 1.5 "
-            "--rev_comp_mapping_barcodes")
+            'split_libraries_fastq.py --store_demultiplexed_fastq -i '
+            's1.fastq.gz,s2.fastq.gz,s3.fastq.gz --sample_ids '
+            'SKB8.640193,SKD8.640184,SKB7.640196 -o /output/dir/sl_out '
+            '--max_bad_run_length 3 --min_per_read_length_fraction 0.75 '
+            '--phred_quality_threshold 3 --barcode_type golay_12 '
+            '--max_barcode_errors 1.5 --rev_comp_mapping_barcodes')
         self.assertEqual(obs_cmd, exp_cmd)
         self.assertEqual(obs_outdir, "/output/dir/sl_out")
 
@@ -225,21 +223,19 @@ class SplitLibrariesFastqTests(TestCase):
             "sequence_max_n": 0, "rev_comp_barcode": False,
             "rev_comp_mapping_barcodes": True, "rev_comp": False,
             "phred_quality_threshold": 3, "barcode_type": "golay_12",
-            "max_barcode_errors": 1.5, "input_data": 1}
+            "max_barcode_errors": 1.5, "input_data": 1, "phred_offset": ""}
         obs_cmd, obs_outdir = generate_split_libraries_fastq_cmd(
             fps, mapping_file, atype, out_dir, parameters)
         exp_cmd = (
-            "split_libraries_fastq.py --store_demultiplexed_fastq -i "
-            "s1.fastq.gz,s2.fastq.gz,s3.fastq.gz -b "
-            "s1_barcodes.fastq.gz,s2_barcodes.fastq.gz,s3_barcodes.fastq.gz "
-            "-m {0}/mappings/s1_mapping_file.txt,"
-            "{0}/mappings/s2_mapping_file.txt,"
-            "{0}/mappings/s3_mapping_file.txt "
-            "-o {0}/sl_out --max_bad_run_length 3 "
-            "--min_per_read_length_fraction 0.75 --sequence_max_n 0 "
-            "--phred_quality_threshold 3 --barcode_type golay_12 "
-            "--max_barcode_errors 1.5 "
-            "--rev_comp_mapping_barcodes".format(out_dir))
+            'split_libraries_fastq.py --store_demultiplexed_fastq -i '
+            's1.fastq.gz,s2.fastq.gz,s3.fastq.gz -b '
+            's1_barcodes.fastq.gz,s2_barcodes.fastq.gz,s3_barcodes.fastq.gz '
+            '-m {0}/mappings/s1_mapping_file.txt,'
+            '{0}/mappings/s2_mapping_file.txt,{0}/mappings/s3_mapping_file.txt'
+            ' -o {0}/sl_out --max_bad_run_length 3 '
+            '--min_per_read_length_fraction 0.75 --phred_quality_threshold 3 '
+            '--barcode_type golay_12 --max_barcode_errors 1.5 '
+            '--rev_comp_mapping_barcodes'.format(out_dir))
         self.assertEqual(obs_cmd, exp_cmd)
         self.assertEqual(obs_outdir, join(out_dir, "sl_out"))
 
@@ -273,7 +269,7 @@ class SplitLibrariesFastqTests(TestCase):
             "sequence_max_n": 0, "rev_comp_barcode": False,
             "rev_comp_mapping_barcodes": True, "rev_comp": False,
             "phred_quality_threshold": 3, "barcode_type": "golay_12",
-            "max_barcode_errors": 1.5, "input_data": 1}
+            "max_barcode_errors": 1.5, "input_data": 1, "phred_offset": ""}
         with self.assertRaises(ValueError):
             generate_split_libraries_fastq_cmd(
                 fps, mapping_file, atype, out_dir, parameters)

--- a/qiita_plugins/target_gene/tgp/split_libraries/tests/test_split_libraries_fastq.py
+++ b/qiita_plugins/target_gene/tgp/split_libraries/tests/test_split_libraries_fastq.py
@@ -38,9 +38,10 @@ class SplitLibrariesFastqTests(TestCase):
             "max_barcode_errors": 1.5, "input_data": 1, "phred_offset": ""}
 
         obs = generate_parameters_string(parameters)
-        exp = ('--max_bad_run_length 3 --min_per_read_length_fraction 0.75 '
-               '--phred_quality_threshold 3 --barcode_type golay_12 '
-               '--max_barcode_errors 1.5 --rev_comp_mapping_barcodes')
+        exp = ("--max_bad_run_length 3 --min_per_read_length_fraction 0.75 "
+               "--sequence_max_n 0 --phred_quality_threshold 3 "
+               "--barcode_type golay_12 --max_barcode_errors 1.5 "
+               "--rev_comp_mapping_barcodes")
         self.assertEqual(obs, exp)
 
     def test_get_sample_names_by_run_prefix(self):
@@ -189,13 +190,15 @@ class SplitLibrariesFastqTests(TestCase):
             "max_barcode_errors": 1.5, "input_data": 1, "phred_offset": ""}
         obs_cmd, obs_outdir = generate_split_libraries_fastq_cmd(
             fps, mapping_file, atype, out_dir, parameters)
+
         exp_cmd = (
-            'split_libraries_fastq.py --store_demultiplexed_fastq -i '
-            's1.fastq.gz,s2.fastq.gz,s3.fastq.gz --sample_ids '
-            'SKB8.640193,SKD8.640184,SKB7.640196 -o /output/dir/sl_out '
-            '--max_bad_run_length 3 --min_per_read_length_fraction 0.75 '
-            '--phred_quality_threshold 3 --barcode_type golay_12 '
-            '--max_barcode_errors 1.5 --rev_comp_mapping_barcodes')
+            "split_libraries_fastq.py --store_demultiplexed_fastq -i "
+            "s1.fastq.gz,s2.fastq.gz,s3.fastq.gz --sample_ids "
+            "SKB8.640193,SKD8.640184,SKB7.640196 -o /output/dir/sl_out "
+            "--max_bad_run_length 3 --min_per_read_length_fraction 0.75 "
+            "--sequence_max_n 0 --phred_quality_threshold 3 "
+            "--barcode_type golay_12 --max_barcode_errors 1.5 "
+            "--rev_comp_mapping_barcodes")
         self.assertEqual(obs_cmd, exp_cmd)
         self.assertEqual(obs_outdir, "/output/dir/sl_out")
 
@@ -227,15 +230,17 @@ class SplitLibrariesFastqTests(TestCase):
         obs_cmd, obs_outdir = generate_split_libraries_fastq_cmd(
             fps, mapping_file, atype, out_dir, parameters)
         exp_cmd = (
-            'split_libraries_fastq.py --store_demultiplexed_fastq -i '
-            's1.fastq.gz,s2.fastq.gz,s3.fastq.gz -b '
-            's1_barcodes.fastq.gz,s2_barcodes.fastq.gz,s3_barcodes.fastq.gz '
-            '-m {0}/mappings/s1_mapping_file.txt,'
-            '{0}/mappings/s2_mapping_file.txt,{0}/mappings/s3_mapping_file.txt'
-            ' -o {0}/sl_out --max_bad_run_length 3 '
-            '--min_per_read_length_fraction 0.75 --phred_quality_threshold 3 '
-            '--barcode_type golay_12 --max_barcode_errors 1.5 '
-            '--rev_comp_mapping_barcodes'.format(out_dir))
+            "split_libraries_fastq.py --store_demultiplexed_fastq -i "
+            "s1.fastq.gz,s2.fastq.gz,s3.fastq.gz -b "
+            "s1_barcodes.fastq.gz,s2_barcodes.fastq.gz,s3_barcodes.fastq.gz "
+            "-m {0}/mappings/s1_mapping_file.txt,"
+            "{0}/mappings/s2_mapping_file.txt,"
+            "{0}/mappings/s3_mapping_file.txt "
+            "-o {0}/sl_out --max_bad_run_length 3 "
+            "--min_per_read_length_fraction 0.75 --sequence_max_n 0 "
+            "--phred_quality_threshold 3 --barcode_type golay_12 "
+            "--max_barcode_errors 1.5 "
+            "--rev_comp_mapping_barcodes".format(out_dir))
         self.assertEqual(obs_cmd, exp_cmd)
         self.assertEqual(obs_outdir, join(out_dir, "sl_out"))
 


### PR DESCRIPTION
This add phred_offset to the current split libraries command and the new 2 options for per_sample_FASTQ of 33/64. 