### PR TITLE
Do not delete jobs when the artifact is removed

### DIFF
--- a/qiita_db/artifact.py
+++ b/qiita_db/artifact.py
@@ -411,10 +411,6 @@ class Artifact(qdb.base.QiitaObject):
                          WHERE artifact_id = %s"""
                 qdb.sql_connection.TRN.add(sql, [artifact_id])
 
-                sql = """DELETE FROM qiita.processing_job
-                         WHERE processing_job_id IN %s"""
-                qdb.sql_connection.TRN.add(sql, [job_ids])
-
             # Delete the entry from the artifact_output_processing_job table
             sql = """DELETE FROM qiita.artifact_output_processing_job
                      WHERE artifact_id = %s"""

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -794,8 +794,8 @@ class ArtifactTests(TestCase):
         with self.assertRaises(qdb.exceptions.QiitaDBUnknownIDError):
             qdb.artifact.Artifact(test.id)
 
-        with self.assertRaises(qdb.exceptions.QiitaDBUnknownIDError):
-            qdb.processing_job.ProcessingJob(job.id)
+        # Check that the job still exists, so we cap keep track of system usage
+        qdb.processing_job.ProcessingJob(job.id)
 
     def test_delete_as_output_job(self):
         fd, fp = mkstemp(suffix='_table.biom')


### PR DESCRIPTION
This will prevent one of the errors appearing in the system, while at the same time we will be able to gather some information about system usage, % of jobs failed, etc.

This can be useful for multiple reasons: check which commands the users use more, which is the command that generates more errors so we need to improve docs or the command itself, or even report utilization of the system in general.