### PR TITLE
Fixing qiita client

### DIFF
--- a/qiita_plugins/qiita_client/qiita_client/qiita_client.py
+++ b/qiita_plugins/qiita_client/qiita_client/qiita_client.py
@@ -186,6 +186,7 @@ class QiitaClient(object):
                     'Oauth2 error: token has timed out':
                 # The token expired - get a new one and re-try the request
                 self._fetch_token()
+                kwargs['headers']['Authorization'] = 'Bearer %s' % self._token
                 r = req(*args, **kwargs)
         return r
 


### PR DESCRIPTION
When the OAuth2 token expires, we are requesting a new token - however, we were not changing it in the headers when retrying the request.