### PR TITLE
Allowing multiple SFF files per run prefix

### DIFF
--- a/qiita_pet/handlers/api_proxy/studies.py
+++ b/qiita_pet/handlers/api_proxy/studies.py
@@ -226,9 +226,9 @@ def study_files_get_req(user_id, study_id, prep_template_id, artifact_type):
     uploaded = get_files_from_uploads_folders(study_id)
     pt = PrepTemplate(prep_template_id).to_dataframe()
 
-    ftypes_it = (ft.startswith('raw_') for ft, _ in supp_file_types
+    ftypes_if = (ft.startswith('raw_') for ft, _ in supp_file_types
                  if ft != 'raw_sff')
-    if any(ftypes_it) and 'run_prefix' in pt.columns:
+    if any(ftypes_if) and 'run_prefix' in pt.columns:
         prep_prefixes = tuple(set(pt['run_prefix']))
         num_prefixes = len(prep_prefixes)
         for _, filename in uploaded:

--- a/qiita_pet/handlers/api_proxy/studies.py
+++ b/qiita_pet/handlers/api_proxy/studies.py
@@ -226,8 +226,9 @@ def study_files_get_req(user_id, study_id, prep_template_id, artifact_type):
     uploaded = get_files_from_uploads_folders(study_id)
     pt = PrepTemplate(prep_template_id).to_dataframe()
 
-    if (any(ft.startswith('raw_') for ft, _ in supp_file_types) and
-            'run_prefix' in pt.columns):
+    ftypes_it = (ft.startswith('raw_') for ft, _ in supp_file_types
+                 if ft != 'raw_sff')
+    if any(ftypes_it) and 'run_prefix' in pt.columns:
         prep_prefixes = tuple(set(pt['run_prefix']))
         num_prefixes = len(prep_prefixes)
         for _, filename in uploaded:


### PR DESCRIPTION
Right now, the value `raw_sff` is hardcoded, so the interface is fixed and those files can be processed.
We may want to discuss which is a better way of handling this in a general manner - i.e. is this case going to occur more often? If so, should we store that info in the DB? Others?