### PR TITLE
Make prepare-templates.rst redirect

### DIFF
--- a/qiita_pet/support_files/doc/source/tutorials/prepare-templates.rst
+++ b/qiita_pet/support_files/doc/source/tutorials/prepare-templates.rst
@@ -10,4 +10,4 @@ Templates
 The terms *Sample template* and *Prep template* have been depreciated. We now
 call these the *Sample information file* and *Preparation information files*.
 
-To lean more about these files and how to build the, please visit  :doc:`prepare-information-files`.
+To lean more about these files and how to build them, please visit  :doc:`prepare-information-files`.

--- a/qiita_pet/support_files/doc/source/tutorials/prepare-templates.rst
+++ b/qiita_pet/support_files/doc/source/tutorials/prepare-templates.rst
@@ -1,13 +1,13 @@
+:orphan:
+
+.. _prepare-templates:
+
+.. index:: prepare-templates
+
 Templates
 =========
 
 The terms *Sample template* and *Prep template* have been depreciated. We now
-call these the *Sample information file* and *Preparation information files*. 
+call these the *Sample information file* and *Preparation information files*.
 
-We will now redirected you to :doc:`prepare-information-files`.
-
-.. raw:: html
-	<meta http-equiv="refresh" content="10;url=https://qiita.ucsd.edu/static/doc/html/tutorials/prepare-information-files.html">
-	<script type="text/javascript">
-		window.location.href = "https://qiita.ucsd.edu/static/doc/html/tutorials/prepare-information-files.html"
-	</script>
+To lean more about these files and how to build the, please visit  :doc:`prepare-information-files`.

--- a/qiita_pet/support_files/doc/source/tutorials/prepare-templates.rst
+++ b/qiita_pet/support_files/doc/source/tutorials/prepare-templates.rst
@@ -1,0 +1,13 @@
+Templates
+=========
+
+The terms *Sample template* and *Prep template* have been depreciated. We now
+call these the *Sample information file* and *Preparation information files*. 
+
+We will now redirected you to :doc:`prepare-information-files`.
+
+.. raw:: html
+	<meta http-equiv="refresh" content="10;url=https://qiita.ucsd.edu/static/doc/html/tutorials/prepare-information-files.html">
+	<script type="text/javascript">
+		window.location.href = "https://qiita.ucsd.edu/static/doc/html/tutorials/prepare-information-files.html"
+	</script>


### PR DESCRIPTION
First attempt to make the old [prepare-templates.html](https://qiita.ucsd.edu/static/doc/html/tutorials/prepare-templates.html) redirect to the new [prepare-information-files.html](https://qiita.ucsd.edu/static/doc/html/tutorials/prepare-information-files.html) page. 