### PR TITLE
Add artifact creation test handler

### DIFF
--- a/qiita_db/handlers/artifact.py
+++ b/qiita_db/handlers/artifact.py
@@ -146,7 +146,7 @@ class ArtifactAPItestHandler(OauthBaseHandler):
 
         Parameters
         ----------
-        filepahts : str
+        filepaths : str
             Json string with a list of filepaths and its types
         type : str
             The artifact type

--- a/qiita_db/handlers/oauth2.py
+++ b/qiita_db/handlers/oauth2.py
@@ -148,7 +148,11 @@ class OauthBaseHandler(RequestHandler):
                 'ERROR:\n%s\nTRACE:\n%s\nHTTP INFO:\n%s\n' %
                 (error, trace_info, request_info))
 
-        self.finish(exc_info[1].log_message)
+        message = exc_info[1].message
+        if hasattr(exc_info[1], 'log_message'):
+            message = exc_info[1].log_message
+
+        self.finish(message)
 
     def head(self):
         """Adds proper response for head requests"""

--- a/qiita_db/handlers/tests/test_artifact.py
+++ b/qiita_db/handlers/tests/test_artifact.py
@@ -153,7 +153,7 @@ class ArtifactAPItestHandlerTests(OauthTestingBase):
             if exists(f):
                 remove(f)
 
-    def test_post_root(self):
+    def test_post(self):
         fd, fp1 = mkstemp(suffix='_seqs.fastq')
         close(fd)
         self._clean_up_files.append(fp1)
@@ -185,6 +185,16 @@ class ArtifactAPItestHandlerTests(OauthTestingBase):
         a = qdb.artifact.Artifact(obs['artifact'])
         self._clean_up_files.extend([fp for _, fp, _ in a.filepaths])
         self.assertEqual(a.name, "New test artifact")
+
+    def test_post_error(self):
+        data = {'filepaths': dumps([('Do not exist', 'raw_forward_seqs')]),
+                'type': "FASTQ",
+                'name': "New test artifact",
+                'prep': 1}
+        obs = self.post('/apitest/artifact/', headers=self.header, data=data)
+        self.assertEqual(obs.code, 500)
+        self.assertIn("Prep template 1 already has an artifact associated",
+                      obs.body)
 
 
 if __name__ == '__main__':

--- a/qiita_pet/webserver.py
+++ b/qiita_pet/webserver.py
@@ -44,7 +44,7 @@ from qiita_pet.handlers.ontology import OntologyHandler
 from qiita_db.handlers.processing_job import (
     JobHandler, HeartbeatHandler, ActiveStepHandler, CompleteHandler,
     ProcessingJobAPItestHandler)
-from qiita_db.handlers.artifact import ArtifactHandler
+from qiita_db.handlers.artifact import ArtifactHandler, ArtifactAPItestHandler
 from qiita_db.handlers.prep_template import (
     PrepTemplateDataHandler, PrepTemplateAPItestHandler,
     PrepTemplateDBHandler)
@@ -168,7 +168,8 @@ class Application(tornado.web.Application):
             test_handlers = [
                 (r"/apitest/processing_job/", ProcessingJobAPItestHandler),
                 (r"/apitest/reset/", ResetAPItestHandler),
-                (r"/apitest/prep_template/", PrepTemplateAPItestHandler)
+                (r"/apitest/prep_template/", PrepTemplateAPItestHandler),
+                (r"/apitest/artifact/", ArtifactAPItestHandler)
             ]
             handlers.extend(test_handlers)
 


### PR DESCRIPTION
Depends on #1878 so review/merge that one first

This adds a new endpoint for the apitest restAPI in which plugin developers can create new artifacts