### PR TITLE
Fixing workflow bug

### DIFF
--- a/qiita_db/test/test_processing_job.py
+++ b/qiita_db/test/test_processing_job.py
@@ -409,6 +409,7 @@ class ProcessingJobTest(TestCase):
         obs = parent._update_children(mapping)
         exp = [child]
         self.assertTrue(obs, exp)
+        self.assertEqual(child.input_artifacts, [qdb.artifact.Artifact(3)])
 
 
 class ProcessingWorkflowTestsReadOnly(TestCase):


### PR DESCRIPTION
This fixes the workflow processing. Although the jobs in the workflow where running, they're not linked with the input artifact, which made the jobs to be in a limbo stage, with no way to access them.

I deployed in the test environment and tested it there - if somebody wants to try it out, it is still deployed and running in there.

Solved the issue yesterday, but had no internet until now.

Saludos desde el Mazatlan!