### PR TITLE
BUG: Return error message with invalid code

### DIFF
--- a/qiita_pet/test/test_auth_handlers.py
+++ b/qiita_pet/test/test_auth_handlers.py
@@ -25,7 +25,7 @@ class TestAuthVerifyHandler(TestHandlerBase):
 
     def test_get(self):
         response = self.get('/auth/verify/SOMETHINGHERE?email=test%40foo.bar')
-        self.assertEqual(response.code, 500)
+        self.assertEqual(response.code, 200)
 
         User.create('new@test.com', 'Somesortofpass')
         response = self.get('/auth/verify/SOMETHINGHERE?email=new%40test.bar')


### PR DESCRIPTION
When a user registers with an already verified code, the server will no
longer return a 500 error, instead it will return a 200 code with an
appropriate error message.

Fixes #1839