### PR TITLE
Make sure that the error message encoded is in utf8

### DIFF
--- a/qiita_ware/dispatchable.py
+++ b/qiita_ware/dispatchable.py
@@ -180,7 +180,7 @@ def create_sample_template(fp, study, is_mapping_file, data_type=None):
         status = 'danger'
         msg = str(e)
 
-    return {'status': status, 'message': msg}
+    return {'status': status, 'message': msg.decode('utf-8', 'replace')}
 
 
 def update_sample_template(study_id, fp):

--- a/qiita_ware/test/test_data/sample_info_utf8_error.txt
+++ b/qiita_ware/test/test_data/sample_info_utf8_error.txt
@@ -1,0 +1,2 @@
+Sample_name	RUN_PREFIX	TITLE	nucleic_acid	sample_type	 geo_loc_name	COLLECTION_TIME	description	dna_extracted	host_subject_id	latitude	longitude	physical_specimen_remaining	 collection_timestamp	physical_specimen_location	scientific_name	taxon_id
+sample1	341F-785R-Mineview-1-H4-A689_joined-SR	dna	bathing water	Finland:Narpio	15.6.2015	mid june dna	TRUE	Not applicable	Not applicable	Not applicable	TRUE	Not applicable	Not applicable	Not applicable	Not applicable

--- a/qiita_ware/test/test_dispatchable.py
+++ b/qiita_ware/test/test_dispatchable.py
@@ -9,7 +9,7 @@
 from unittest import TestCase, main
 from tempfile import mkstemp
 from os import close, remove
-from os.path import exists
+from os.path import exists, join, dirname, abspath
 
 from qiita_core.util import qiita_test_checker
 from qiita_ware.dispatchable import (
@@ -72,6 +72,15 @@ class TestDispatchable(TestCase):
         exp = {'status': 'danger',
                'message': "The 'SampleTemplate' object with attributes "
                           "(id: 1) already exists."}
+        self.assertEqual(obs, exp)
+
+    def test_create_sample_template_nonutf8(self):
+        fp = join(dirname(abspath(__file__)), 'test_data',
+                  'sample_info_utf8_error.txt')
+        obs = create_sample_template(fp, Study(1), False)
+        exp = {'status': 'danger',
+               'message': u"Non UTF-8 characters found in columns:"
+                          u"\n\ufffdcollection_timestamp: row(s) 1"}
         self.assertEqual(obs, exp)
 
     def test_update_sample_template(self):


### PR DESCRIPTION
While helping a user in Qiita I found that if a sample information file contained non-utf8 characters, it will break the communication between the ipython workers and the main server. This PR makes sure that the error message is a utf8 valid string, by replacing the non-utf8 characters with the official U+FFFD REPLACEMENT CHARACTER, as seen below: 

![screen shot 2016-07-20 at 2 45 37 pm](https://cloud.githubusercontent.com/assets/2501478/17004195/c98d00b2-4e88-11e6-90ce-4497bf6608f8.png)
