### PR TITLE
Add delete buttons to GUI

### DIFF
--- a/qiita_db/metadata_template/prep_template.py
+++ b/qiita_db/metadata_template/prep_template.py
@@ -664,9 +664,9 @@ class PrepTemplate(MetadataTemplate):
         QiitaDBColumnError
             If the prep info file has been processed
         """
-        if self.artifact.children:
+        if self.artifact:
             raise qdb.exceptions.QiitaDBOperationNotPermittedError(
-                "Prep info file '%d' has been processed, you cannot delete "
+                "Prep info file '%d' has files attached, you cannot delete "
                 "samples." % (self._id))
 
         self._common_delete_sample_steps(sample_name)

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -1478,15 +1478,18 @@ class TestPrepTemplateReadWrite(BaseTestPrepTemplate):
 
     def test_delete_sample(self):
         QE = qdb.exceptions
-        pt = qdb.metadata_template.prep_template.PrepTemplate(2)
-        pt.delete_sample('1.SKM5.640177')
-        self.assertNotIn('1.SKM5.640177', pt.keys())
+
+        pt = qdb.metadata_template.prep_template.PrepTemplate.create(
+            self.metadata, self.test_study, self.data_type)
+        sample_id = '%s.SKB8.640193' % self.test_study.id
+        pt.delete_sample(sample_id)
+        self.assertNotIn(sample_id, pt.keys())
 
         # testing errors
         with self.assertRaises(QE.QiitaDBUnknownIDError):
             pt.delete_sample('not.existing.sample')
 
-        pt = qdb.metadata_template.prep_template.PrepTemplate(1)
+        pt = qdb.metadata_template.prep_template.PrepTemplate(2)
         with self.assertRaises(QE.QiitaDBOperationNotPermittedError):
             pt.delete_sample('1.SKM5.640177')
 

--- a/qiita_pet/handlers/api_proxy/__init__.py
+++ b/qiita_pet/handlers/api_proxy/__init__.py
@@ -15,7 +15,8 @@ from .sample_template import (
     sample_template_summary_get_req, sample_template_delete_req,
     sample_template_filepaths_get_req, sample_template_get_req,
     sample_template_meta_cats_get_req, sample_template_samples_get_req,
-    sample_template_category_get_req, sample_template_patch_request)
+    sample_template_category_get_req, sample_template_patch_request,
+    get_sample_template_processing_status)
 from .prep_template import (
     prep_template_summary_get_req, prep_template_post_req,
     prep_template_delete_req, prep_template_get_req,
@@ -62,4 +63,5 @@ __all__ = ['prep_template_summary_get_req', 'sample_template_post_req',
            'list_options_handler_get_req', 'workflow_handler_post_req',
            'workflow_handler_patch_req', 'workflow_run_post_req',
            'job_ajax_get_req', 'artifact_patch_request',
-           'sample_template_patch_request']
+           'sample_template_patch_request',
+           'get_sample_template_processing_status']

--- a/qiita_pet/handlers/api_proxy/__init__.py
+++ b/qiita_pet/handlers/api_proxy/__init__.py
@@ -15,7 +15,7 @@ from .sample_template import (
     sample_template_summary_get_req, sample_template_delete_req,
     sample_template_filepaths_get_req, sample_template_get_req,
     sample_template_meta_cats_get_req, sample_template_samples_get_req,
-    sample_template_category_get_req)
+    sample_template_category_get_req, sample_template_patch_request)
 from .prep_template import (
     prep_template_summary_get_req, prep_template_post_req,
     prep_template_delete_req, prep_template_get_req,
@@ -61,4 +61,5 @@ __all__ = ['prep_template_summary_get_req', 'sample_template_post_req',
            'list_commands_handler_get_req', 'process_artifact_handler_get_req',
            'list_options_handler_get_req', 'workflow_handler_post_req',
            'workflow_handler_patch_req', 'workflow_run_post_req',
-           'job_ajax_get_req', 'artifact_patch_request']
+           'job_ajax_get_req', 'artifact_patch_request',
+           'sample_template_patch_request']

--- a/qiita_pet/handlers/api_proxy/prep_template.py
+++ b/qiita_pet/handlers/api_proxy/prep_template.py
@@ -17,7 +17,8 @@ from moi import r_client
 from qiita_core.util import execute_as_transaction
 from qiita_pet.handlers.api_proxy.util import check_access, check_fp
 from qiita_ware.context import safe_submit
-from qiita_ware.dispatchable import update_prep_template
+from qiita_ware.dispatchable import (
+    update_prep_template, delete_sample_or_column)
 from qiita_db.metadata_template.util import load_template_to_dataframe
 from qiita_db.util import convert_to_id, get_files_from_uploads_folders
 from qiita_db.study import Study
@@ -409,8 +410,8 @@ def prep_template_patch_req(user_id, req_op, req_path, req_value=None,
         - status: str, whether if the request is successful or not
         - message: str, if the request is unsuccessful, a human readable error
     """
+    req_path = [v for v in req_path.split('/') if v]
     if req_op == 'replace':
-        req_path = [v for v in req_path.split('/') if v]
         # The structure of the path should be /prep_id/attribute_to_modify/
         # so if we don't have those 2 elements, we should return an error
         if len(req_path) != 2:
@@ -444,10 +445,33 @@ def prep_template_patch_req(user_id, req_op, req_path, req_value=None,
                                'Please, check the path parameter' % attribute}
 
         return {'status': status, 'message': msg}
+    elif req_op == 'delete':
+        # The structure of the path should be /prep_id/{columns|samples}/name
+        if len(req_path) != 3:
+            return {'status': 'error',
+                    'message': 'Incorrect path parameter'}
+        prep_id = int(req_path[0])
+        attribute = req_path[1]
+        attr_id = req_path[2]
+
+        # Check if the user actually has access to the study
+        pt = PrepTemplate(prep_id)
+        access_error = check_access(pt.study_id, user_id)
+        if access_error:
+            return access_error
+
+        # Offload the deletion of the column to the cluster
+        job_id = safe_submit(user_id, delete_sample_or_column, PrepTemplate,
+                             prep_id, attribute, attr_id)
+        # Store the job id attaching it to the sample template id
+        r_client.set(PREP_TEMPLATE_KEY_FORMAT % prep_id,
+                     dumps({'job_id': job_id}))
+        return {'status': 'success', 'message': ''}
     else:
         return {'status': 'error',
                 'message': 'Operation "%s" not supported. '
-                           'Current supported operations: replace' % req_op}
+                           'Current supported operations: replace, delete'
+                           % req_op}
 
 
 def prep_template_samples_get_req(prep_id, user_id):

--- a/qiita_pet/handlers/api_proxy/prep_template.py
+++ b/qiita_pet/handlers/api_proxy/prep_template.py
@@ -159,8 +159,8 @@ def prep_template_ajax_get_req(user_id, prep_id):
             download_qiime.append(fp_id)
         else:
             download_prep.append(fp_id)
-    download_prep = download_prep[0] if download_prep else None
-    download_qiime = download_qiime[0] if download_qiime else None
+    download_prep = download_prep[0]
+    download_qiime = download_qiime[0]
 
     ontology = _get_ENA_ontology()
 

--- a/qiita_pet/handlers/api_proxy/prep_template.py
+++ b/qiita_pet/handlers/api_proxy/prep_template.py
@@ -158,8 +158,8 @@ def prep_template_ajax_get_req(user_id, prep_id):
             download_qiime.append(fp_id)
         else:
             download_prep.append(fp_id)
-    download_prep = download_prep[0]
-    download_qiime = download_qiime[0]
+    download_prep = download_prep[0] if download_prep else None
+    download_qiime = download_qiime[0] if download_qiime else None
 
     ontology = _get_ENA_ontology()
 

--- a/qiita_pet/handlers/api_proxy/prep_template.py
+++ b/qiita_pet/handlers/api_proxy/prep_template.py
@@ -445,7 +445,7 @@ def prep_template_patch_req(user_id, req_op, req_path, req_value=None,
                                'Please, check the path parameter' % attribute}
 
         return {'status': status, 'message': msg}
-    elif req_op == 'delete':
+    elif req_op == 'remove':
         # The structure of the path should be /prep_id/{columns|samples}/name
         if len(req_path) != 3:
             return {'status': 'error',
@@ -470,7 +470,7 @@ def prep_template_patch_req(user_id, req_op, req_path, req_value=None,
     else:
         return {'status': 'error',
                 'message': 'Operation "%s" not supported. '
-                           'Current supported operations: replace, delete'
+                           'Current supported operations: replace, remove'
                            % req_op}
 
 

--- a/qiita_pet/handlers/api_proxy/sample_template.py
+++ b/qiita_pet/handlers/api_proxy/sample_template.py
@@ -522,7 +522,7 @@ def sample_template_patch_request(user_id, req_op, req_path, req_value=None,
         attribute = req_path[1]
         attr_id = req_path[2]
 
-        # Check if the user actually has access to the artifact
+        # Check if the user actually has access to the template
         st = SampleTemplate(st_id)
         access_error = check_access(st.study_id, user_id)
         if access_error:

--- a/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
@@ -423,7 +423,7 @@ class TestPrepAPI(TestCase):
 
         # Delete a prep template column
         obs = prep_template_patch_req(
-            'test@foo.bar', 'delete', '/1/columns/target_subfragment/')
+            'test@foo.bar', 'remove', '/1/columns/target_subfragment/')
         exp = {'status': 'success', 'message': ''}
         self.assertEqual(obs, exp)
         self._wait_for_parallel_job('prep_template_1')

--- a/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
@@ -436,7 +436,7 @@ class TestPrepAPI(TestCase):
             'Cancer Genomics')
         exp = {'status': 'error',
                'message': 'Operation "add" not supported. '
-                          'Current supported operations: replace, delete'}
+                          'Current supported operations: replace, remove'}
         self.assertEqual(obs, exp)
         # Incorrect path parameter
         obs = prep_template_patch_req(

--- a/qiita_pet/handlers/study_handlers/prep_template.py
+++ b/qiita_pet/handlers/study_handlers/prep_template.py
@@ -45,7 +45,7 @@ class PrepTemplateSummaryAJAX(BaseHandler):
     def get(self):
         prep_id = to_int(self.get_argument('prep_id'))
         res = prep_template_summary_get_req(prep_id, self.current_user.id)
-        self.render('study_ajax/prep_summary_table.html',
+        self.render('study_ajax/prep_summary_table.html', pid=prep_id, 
                     stats=res['summary'])
 
 

--- a/qiita_pet/handlers/study_handlers/prep_template.py
+++ b/qiita_pet/handlers/study_handlers/prep_template.py
@@ -45,7 +45,7 @@ class PrepTemplateSummaryAJAX(BaseHandler):
     def get(self):
         prep_id = to_int(self.get_argument('prep_id'))
         res = prep_template_summary_get_req(prep_id, self.current_user.id)
-        self.render('study_ajax/prep_summary_table.html', pid=prep_id, 
+        self.render('study_ajax/prep_summary_table.html', pid=prep_id,
                     stats=res['summary'])
 
 

--- a/qiita_pet/handlers/study_handlers/sample_template.py
+++ b/qiita_pet/handlers/study_handlers/sample_template.py
@@ -17,7 +17,8 @@ from qiita_pet.handlers.api_proxy import (
     sample_template_delete_req, sample_template_filepaths_get_req,
     data_types_get_req, sample_template_samples_get_req,
     prep_template_samples_get_req, study_prep_get_req,
-    sample_template_meta_cats_get_req, sample_template_category_get_req)
+    sample_template_meta_cats_get_req, sample_template_category_get_req,
+    sample_template_patch_request)
 
 
 def _build_sample_summary(study_id, user_id):
@@ -118,6 +119,23 @@ class SampleTemplateAJAX(BaseHandler):
             raise HTTPError(400, 'Unknown sample information action: %s'
                             % action)
         self.write(result)
+
+    @authenticated
+    def patch(self):
+        """Patches a sample template in the system
+
+        Follows the JSON PATCH specification:
+        https://tools.ietf.org/html/rfc6902
+        """
+        req_op = self.get_argument('op')
+        req_path = self.get_argument('path')
+        req_value = self.get_argument('value', None)
+        req_from = self.get_argument('from', None)
+
+        response = sample_template_patch_request(
+            self.current_user.id, req_op, req_path, req_value, req_from)
+
+        self.write(response)
 
 
 class SampleAJAX(BaseHandler):

--- a/qiita_pet/handlers/study_handlers/sample_template.py
+++ b/qiita_pet/handlers/study_handlers/sample_template.py
@@ -64,6 +64,7 @@ def _build_sample_summary(study_id, user_id):
             # X in cell for samples in the prep template
             for s in all_samps.intersection(prep_samples):
                 samps_table[s][col_field] = "X"
+
     return columns, samps_table.values()
 
 

--- a/qiita_pet/handlers/study_handlers/sample_template.py
+++ b/qiita_pet/handlers/study_handlers/sample_template.py
@@ -18,7 +18,7 @@ from qiita_pet.handlers.api_proxy import (
     data_types_get_req, sample_template_samples_get_req,
     prep_template_samples_get_req, study_prep_get_req,
     sample_template_meta_cats_get_req, sample_template_category_get_req,
-    sample_template_patch_request)
+    sample_template_patch_request, get_sample_template_processing_status)
 
 
 def _build_sample_summary(study_id, user_id):
@@ -158,9 +158,12 @@ class SampleAJAX(BaseHandler):
         meta_cats = res['categories']
         cols, samps_table = _build_sample_summary(study_id,
                                                   self.current_user.id)
+        _, alert_type, alert_msg = get_sample_template_processing_status(
+            study_id)
         self.render('study_ajax/sample_prep_summary.html',
                     table=samps_table, cols=cols, meta_available=meta_cats,
-                    study_id=study_id)
+                    study_id=study_id, alert_type=alert_type,
+                    alert_message=alert_msg)
 
     @authenticated
     def post(self):

--- a/qiita_pet/templates/study_ajax/prep_summary.html
+++ b/qiita_pet/templates/study_ajax/prep_summary.html
@@ -135,6 +135,35 @@
   }
 
   /*
+   *
+   * Deletes a column from the prep template
+   *
+   * @param prep_id the prep template id
+   * @param column_name string the the column to be removed
+   *
+   * This function executes an AJAX call to remove the given column from the
+   * prep information
+   *
+   */
+  function delete_prep_column(prep_id, column_name) {
+    if(confirm("Are you sure you want to delete '" + column_name + "' information?")) {
+      $.ajax({
+        url: '{% raw qiita_config.portal_dir %}/prep_template/',
+        type: 'PATCH',
+        data: {'op': 'remove', 'path': '/' + prep_id + '/columns/' + column_name},
+        success: function(data) {
+          if(data.status == 'error') {
+            bootstrapAlert(data.message, "danger");
+          }
+          else {
+            populate_main_div('/study/description/prep_template/', { prep_id: prep_id, study_id: {{study_id}} });
+          }
+        }
+      });
+    }
+  }
+
+  /*
    * Toggle the graph view
    *
    * Show/hide the graph div and update GUI accordingly
@@ -257,13 +286,6 @@
           }
         }
       });
-    }
-  }
-
-
-  function delete_prep_column(prep_id, column_name) {
-    if(confirm("Are you sure you want to delete '" + column_name + "' information?")) {
-      console.log({{study_id}}, prep_id, column_name)
     }
   }
 

--- a/qiita_pet/templates/study_ajax/prep_summary.html
+++ b/qiita_pet/templates/study_ajax/prep_summary.html
@@ -139,7 +139,7 @@
    * Deletes a column from the prep template
    *
    * @param prep_id the prep template id
-   * @param column_name string the the column to be removed
+   * @param column_name string with the column to be removed
    *
    * This function executes an AJAX call to remove the given column from the
    * prep information

--- a/qiita_pet/templates/study_ajax/prep_summary.html
+++ b/qiita_pet/templates/study_ajax/prep_summary.html
@@ -260,6 +260,13 @@
     }
   }
 
+
+  function delete_prep_column(prep_id, column_name) {
+    if(confirm("Are you sure you want to delete '" + column_name + "' information?")) {
+      console.log({{study_id}}, prep_id, column_name)
+    }
+  }
+
   $(document).ready(function () {
     if("{{investigation_type}}" !== "None") {
       // The prep information already has an investigation type

--- a/qiita_pet/templates/study_ajax/prep_summary_table.html
+++ b/qiita_pet/templates/study_ajax/prep_summary_table.html
@@ -6,31 +6,20 @@
   <div id="summary-table-div">
     <table class="table">
       {% for category, summary in viewitems(stats) %}
+        <tr>
+          <td>
+            <a class="btn btn-danger" onclick="delete_prep_column({{pid}}, '{{category}}');"><span class="glyphicon glyphicon-trash"></span></a>
+          </td>
         {% if len(summary) == 1 %}
-          <tr>
-            <td>
-              <a class="btn btn-danger" onclick="delete_prep_column({{pid}}, '{{category}}');"><span class="glyphicon glyphicon-trash"></span></a>
-            </td>
-            <td colspan="2">
-              <b>{{category}}</b>: <tt>{{summary[0][0]}}</tt> is repeated in all rows.
-            </td>
-          </tr>
+          <td colspan="2">
+            <b>{{category}}</b>: <tt>{{summary[0][0]}}</tt> is repeated in all rows.
+          </td>
         {% elif len(set([row[1] for row in summary])) == 1 %}
-          <tr>
-            <td>
-              <a class="btn btn-danger" onclick="delete_prep_column({{pid}}, '{{category}}');"><span class="glyphicon glyphicon-trash"></span></a>
-            </td>
-            <td colspan="2">
-              <b>{{category}}</b>: All the values in this category are different.
-            </td>
-          </tr>
+          <td colspan="2">
+            <b>{{category}}</b>: All the values in this category are different.
+          </td>
         {% else %}
-          <tr>
-            <td>
-              <a class="btn btn-danger" onclick="delete_prep_column({{pid}}, '{{category}}');"><span class="glyphicon glyphicon-trash"></span></a>
-            </td>
-            <th colspan="2" align="center">{{category}}</th>
-          </tr>
+          <th colspan="2" align="center">{{category}}</th>
           {% for row in summary %}
             <tr>
               <td width="5px">&nbsp;</td>
@@ -39,6 +28,7 @@
             </tr>
           {% end %}
         {% end %}
+        </tr>
       {% end %}
     </table>
   </div>

--- a/qiita_pet/templates/study_ajax/prep_summary_table.html
+++ b/qiita_pet/templates/study_ajax/prep_summary_table.html
@@ -8,22 +8,32 @@
       {% for category, summary in viewitems(stats) %}
         {% if len(summary) == 1 %}
           <tr>
+            <td>
+              <a class="btn btn-danger" onclick="delete_prep_column({{pid}}, '{{category}}');"><span class="glyphicon glyphicon-trash"></span></a>
+            </td>
             <td colspan="2">
               <b>{{category}}</b>: <tt>{{summary[0][0]}}</tt> is repeated in all rows.
             </td>
           </tr>
         {% elif len(set([row[1] for row in summary])) == 1 %}
           <tr>
+            <td>
+              <a class="btn btn-danger" onclick="delete_prep_column({{pid}}, '{{category}}');"><span class="glyphicon glyphicon-trash"></span></a>
+            </td>
             <td colspan="2">
               <b>{{category}}</b>: All the values in this category are different.
             </td>
           </tr>
         {% else %}
           <tr>
+            <td>
+              <a class="btn btn-danger" onclick="delete_prep_column({{pid}}, '{{category}}');"><span class="glyphicon glyphicon-trash"></span></a>
+            </td>
             <th colspan="2" align="center">{{category}}</th>
           </tr>
           {% for row in summary %}
             <tr>
+              <td width="5px">&nbsp;</td>
               <td>{{row[0]}}</td>
               <td>{{row[1]}}</td>
             </tr>

--- a/qiita_pet/templates/study_ajax/sample_prep_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_prep_summary.html
@@ -51,6 +51,15 @@
     grid.render();
   }
 
+  /*
+   * Deletes a sample from the sample template
+   *
+   * @param sample_name string with the sample to be removed
+   *
+   * This function executes an AJAX call to remove the given sample from the
+   * current sample template
+   *
+   */
   function delete_sample(sample_name) {
     if(confirm("Are you sure you want to delete '" + sample_name + "'?")) {
       $.ajax({

--- a/qiita_pet/templates/study_ajax/sample_prep_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_prep_summary.html
@@ -80,7 +80,7 @@
 
   $(document).ready(function() {
     {% if alert_type != 'success' and alert_message != '' %}
-      bootstrapAlert(decodeURIComponent("{% raw alert_message %}").replace(/\+/g,' '), "{{alert_type}}");
+      bootstrapAlert('{% raw alert_message %}', "{{alert_type}}");
     {% else %}
       $('#bootstrap-alert').alert('close');
     {% end %}

--- a/qiita_pet/templates/study_ajax/sample_prep_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_prep_summary.html
@@ -7,8 +7,20 @@
   var False = false;
   var table = {% raw table %};
   var cols = {% raw cols %};
-  var options = { enableCellNavigation: false };
+  var options = { enableCellNavigation: false, rowHeight: 40 };
   var currentSortCol = 'sample';
+
+  // ==> adding the delete column to the grid
+  // adding new column to the table - using sample name as value
+  for(var i=0;i<table.length;i++) {
+    table[i]['slick-grid-sample-delete'] = table[i]['sample'];
+  }
+  // adding new column to cols, we need to add a Formatter
+  function linkFormatter(row, cell, value, columnDef, dataContext) {
+    return "<a class=\"btn btn-danger\" onclick=\"delete_sample('" + value +
+           "');\"><span class=\"glyphicon glyphicon-trash\"></span></a>";
+  }
+  cols.unshift({ name: "", field: "slick-grid-sample-delete", width: 60, formatter: linkFormatter })
   var grid = new Slick.Grid("#samples-div", table, cols, options);
 
   function add_meta() {
@@ -38,6 +50,7 @@
     grid.invalidateAllRows();
     grid.render();
   }
+
 </script>
 
 <style>

--- a/qiita_pet/templates/study_ajax/sample_prep_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_prep_summary.html
@@ -51,6 +51,32 @@
     grid.render();
   }
 
+  function delete_sample(sample_name) {
+    if(confirm("Are you sure you want to delete '" + sample_name + "'?")) {
+      $.ajax({
+        url: '{% raw qiita_config.portal_dir %}/study/description/sample_template/',
+        type: 'PATCH',
+        data: {'op': 'remove', 'path': '/{{study_id}}/samples/' + sample_name},
+        success: function(data) {
+          if(data.status == 'error') {
+            bootstrapAlert(data.message, "danger");
+          }
+          else {
+            populate_main_div('{% raw qiita_config.portal_dir %}/study/description/sample_summary/', { study_id: {{study_id}} });
+          }
+        }
+      });
+    }
+  }
+
+  $(document).ready(function() {
+    {% if alert_type != 'success' and alert_message != '' %}
+      bootstrapAlert(decodeURIComponent("{% raw alert_message %}").replace(/\+/g,' '), "{{alert_type}}");
+    {% else %}
+      $('#bootstrap-alert').alert('close');
+    {% end %}
+  });
+
 </script>
 
 <style>

--- a/qiita_pet/templates/study_ajax/sample_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_summary.html
@@ -10,13 +10,19 @@
 
   function delete_column(column_name) {
     if(confirm("Are you sure you want to delete '" + column_name + "' information?")) {
-      console.log({{study_id}}, column_name)
-    }
-  }
-
-  function delete_sample(sample_name) {
-    if(confirm("Are you sure you want to delete '" + sample_name + "'?")) {
-      console.log({{study_id}}, sample_name)
+      $.ajax({
+        url: '{% raw qiita_config.portal_dir %}/study/description/sample_template/',
+        type: 'PATCH',
+        data: {'op': 'remove', 'path': '/{{study_id}}/columns/' + column_name},
+        success: function(data) {
+          if(data.status == 'error') {
+            bootstrapAlert(data.message, "danger");
+          }
+          else {
+            populate_main_div('{% raw qiita_config.portal_dir %}/study/description/sample_template/', { study_id: {{study_id}} });
+          }
+        }
+      });
     }
   }
 

--- a/qiita_pet/templates/study_ajax/sample_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_summary.html
@@ -146,45 +146,31 @@
 
     <table class="table">
       {% for category, summary in viewitems(stats) %}
-        {% if len(summary) == 1 %}
-          <tr>
-            {% if editable %}
-              <td>
-                <a class="btn btn-danger" onclick="delete_column('{{category}}');"><span class="glyphicon glyphicon-trash"></span></a>
-              </td>
-            {% end %}
+        <tr>
+          {% if editable %}
+            <td>
+              <a class="btn btn-danger" onclick="delete_column('{{category}}');"><span class="glyphicon glyphicon-trash"></span></a>
+            </td>
+          {% end %}
+          {% if len(summary) == 1 %}
             <td colspan="2">
               <b>{{category}}</b>: <tt>{{summary[0][0]}}</tt> is repeated in all rows.
             </td>
-          </tr>
-        {% elif len(set([row[1] for row in summary])) == 1 %}
-          <tr>
-            {% if editable %}
-              <td>
-                <a class="btn btn-danger" onclick="delete_column('{{category}}');"><span class="glyphicon glyphicon-trash"></span></a>
-              </td>
-            {% end %}
+          {% elif len(set([row[1] for row in summary])) == 1 %}
             <td colspan="2">
               <b>{{category}}</b>: All the values in this category are different.
             </td>
-          </tr>
-        {% else %}
-          <tr>
-            {% if editable %}
-              <td>
-                <a class="btn btn-danger" onclick="delete_column('{{category}}');"><span class="glyphicon glyphicon-trash"></span></a>
-              </td>
-            {% end %}
+          {% else %}
             <th colspan="2" align="center">{{category}}</th>
-          </tr>
-          {% for row in summary %}
+            {% for row in summary %}
             <tr>
               <td width="5px">&nbsp;</td>
               <td>{{row[0]}}</td>
               <td>{{row[1]}}</td>
             </tr>
+            {% end %}
           {% end %}
-        {% end %}
+        </tr>
       {% end %}
     </table>
   </div>

--- a/qiita_pet/templates/study_ajax/sample_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_summary.html
@@ -8,6 +8,18 @@
     }
   }
 
+  function delete_column(column_name) {
+    if(confirm("Are you sure you want to delete '" + column_name + "' information?")) {
+      console.log({{study_id}}, column_name)
+    }
+  }
+
+  function delete_sample(sample_name) {
+    if(confirm("Are you sure you want to delete '" + sample_name + "'?")) {
+      console.log({{study_id}}, sample_name)
+    }
+  }
+
   function sample_action(act) {
     $.post('{% raw qiita_config.portal_dir %}/study/description/sample_template/', { study_id: {{study_id}}, action: act, filepath: $("#file-selector").val(), data_type: $("#data_types").val() })
       .done(function ( data ) {
@@ -120,22 +132,38 @@
       {% for category, summary in viewitems(stats) %}
         {% if len(summary) == 1 %}
           <tr>
+            {% if editable %}
+              <td>
+                <a class="btn btn-danger" onclick="delete_column('{{category}}');"><span class="glyphicon glyphicon-trash"></span></a>
+              </td>
+            {% end %}
             <td colspan="2">
               <b>{{category}}</b>: <tt>{{summary[0][0]}}</tt> is repeated in all rows.
             </td>
           </tr>
         {% elif len(set([row[1] for row in summary])) == 1 %}
           <tr>
+            {% if editable %}
+              <td>
+                <a class="btn btn-danger" onclick="delete_column('{{category}}');"><span class="glyphicon glyphicon-trash"></span></a>
+              </td>
+            {% end %}
             <td colspan="2">
               <b>{{category}}</b>: All the values in this category are different.
             </td>
           </tr>
         {% else %}
           <tr>
+            {% if editable %}
+              <td>
+                <a class="btn btn-danger" onclick="delete_column('{{category}}');"><span class="glyphicon glyphicon-trash"></span></a>
+              </td>
+            {% end %}
             <th colspan="2" align="center">{{category}}</th>
           </tr>
           {% for row in summary %}
             <tr>
+              <td width="5px">&nbsp;</td>
               <td>{{row[0]}}</td>
               <td>{{row[1]}}</td>
             </tr>

--- a/qiita_pet/templates/study_ajax/sample_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_summary.html
@@ -8,6 +8,16 @@
     }
   }
 
+  /*
+   *
+   * Deletes a column from the sample template
+   *
+   * @param column_name string with the column to be removed
+   *
+   * This function executes an AJAX call to remove the given column from the
+   * sample information
+   *
+   */
   function delete_column(column_name) {
     if(confirm("Are you sure you want to delete '" + column_name + "' information?")) {
       $.ajax({

--- a/qiita_ware/dispatchable.py
+++ b/qiita_ware/dispatchable.py
@@ -293,3 +293,45 @@ def update_prep_template(prep_id, fp):
             msg = str(e)
 
     return {'status': status, 'message': msg}
+
+
+def delete_sample_or_column(obj_class, obj_id, sample_or_col, name):
+    """Deletes a sample or a column from the metadata
+
+    Parameters
+    ----------
+    obj_class : {SampleTemplate, PrepTemplate}
+        The metadata template subclass
+    obj_id : int
+        The template id
+    sample_or_col : {"samples", "columns"}
+        Which resource are we deleting. Either "samples" or "columns"
+    name : str
+        The name of the resource to be deleted
+
+    Returns
+    -------
+    dict of {str: str}
+        A dict of the form {'status': str, 'message': str}
+    """
+    st = obj_class(obj_id)
+
+    if sample_or_col == 'columns':
+        del_func = st.delete_column
+    elif sample_or_col == 'samples':
+        del_func = st.delete_sample
+    else:
+        return {'status': 'danger',
+                'message': 'Unknown value "%s". Choose between "samples" '
+                           'and "columns"' % sample_or_col}
+
+    msg = ''
+    status = 'success'
+
+    try:
+        del_func(name)
+    except Exception as e:
+        status = 'danger'
+        msg = str(e)
+
+    return {'status': status, 'message': msg}

--- a/qiita_ware/test/test_dispatchable.py
+++ b/qiita_ware/test/test_dispatchable.py
@@ -119,7 +119,7 @@ class TestDispatchable(TestCase):
         self.assertItemsEqual(obs['message'].split('\n'),
                               exp['message'].split('\n'))
 
-    def test_delete_sample_or_colum(self):
+    def test_delete_sample_or_column(self):
         st = SampleTemplate(1)
 
         # Delete a sample template column


### PR DESCRIPTION
Several things done in this PR as during the adding of the GUI several smaller bugs were found:
 - the `to_dataframe` function was enabling a race condition. Note that the functionality itself was correct because it followed the rule of "multiple reads - single write". However, if somebody else wrote the table in the middle the function crashed. The new implementation is not only thread safe but also at least 2X faster.
 - The prep template sample deletion was not safe. Having an artifact attached is enough to not allow sample deletion. Fixed and test added.
 - Connected the GUI with the backend to delete samples/columns from the templates. @antgonza noticed that it can be slow, so we offload it to the cluster. To simplify code, a single dispatchable function has been added that can be used for both template types and both functionalities, simplifying a lot of code duplication.
 - The HTML code that @antgonza added had a fair amount of code duplication due to the previous structure of the code - I've reorganize it to reduce the amount of code duplication.