### PR TITLE
Changing the reset of the database 

### DIFF
--- a/qiita_core/util.py
+++ b/qiita_core/util.py
@@ -104,6 +104,7 @@ def qiita_test_checker(test=False):
                 self.conn_handler = qdb.sql_connection.SQLConnectionHandler()
 
             @qdb.environment_manager.reset_test_database
+            @classmethod
             def tearDownClass(cls):
                 super(DecoratedClass, cls).tearDown()
 

--- a/qiita_core/util.py
+++ b/qiita_core/util.py
@@ -104,8 +104,8 @@ def qiita_test_checker(test=False):
                 self.conn_handler = qdb.sql_connection.SQLConnectionHandler()
 
             @qdb.environment_manager.reset_test_database
-            def tearDown(self):
-                super(DecoratedClass, self).tearDown()
+            def tearDownClass(cls):
+                super(DecoratedClass, cls).tearDown()
 
         return DecoratedClass
     return class_modifier

--- a/qiita_db/handlers/tests/test_artifact.py
+++ b/qiita_db/handlers/tests/test_artifact.py
@@ -34,6 +34,19 @@ class UtilTests(TestCase):
 
 
 class ArtifactHandlerTests(OauthTestingBase):
+    def setUp(self):
+        super(ArtifactHandlerTests, self).setUp()
+
+        fd, self.html_fp = mkstemp(suffix=".html")
+        close(fd)
+        self._clean_up_files = [self.html_fp]
+
+    def tearDown(self):
+        super(ArtifactHandlerTests, self).tearDown()
+        for fp in self._clean_up_files:
+            if exists(fp):
+                remove(fp)
+
     def test_get_artifact_does_not_exist(self):
         obs = self.get('/qiita_db/artifacts/100/', headers=self.header)
         self.assertEqual(obs.code, 404)
@@ -67,23 +80,6 @@ class ArtifactHandlerTests(OauthTestingBase):
             'processing_parameters': None,
             'files': exp_fps}
         self.assertEqual(loads(obs.body), exp)
-
-
-class ArtifactHandlerTestsReadWrite(OauthTestingBase):
-    database = True
-
-    def setUp(self):
-        super(ArtifactHandlerTestsReadWrite, self).setUp()
-
-        fd, self.html_fp = mkstemp(suffix=".html")
-        close(fd)
-        self._clean_up_files = [self.html_fp]
-
-    def tearDown(self):
-        super(ArtifactHandlerTestsReadWrite, self).tearDown()
-        for fp in self._clean_up_files:
-            if exists(fp):
-                remove(fp)
 
     def test_patch(self):
         arguments = {'op': 'add', 'path': '/html_summary/',
@@ -125,8 +121,6 @@ class ArtifactHandlerTestsReadWrite(OauthTestingBase):
 
 
 class ArtifactAPItestHandlerTests(OauthTestingBase):
-    database = True
-
     def setUp(self):
         super(ArtifactAPItestHandlerTests, self).setUp()
 

--- a/qiita_db/handlers/tests/test_prep_template.py
+++ b/qiita_db/handlers/tests/test_prep_template.py
@@ -127,8 +127,6 @@ class PrepTemplateDataHandlerTests(OauthTestingBase):
 
 
 class PrepTemplateAPItestHandlerTests(OauthTestingBase):
-    database = True
-
     def test_post(self):
         metadata_dict = {
             'SKB8.640193': {'primer': 'GTGCCAGCMGCCGCGGTAA',

--- a/qiita_db/handlers/tests/test_processing_job.py
+++ b/qiita_db/handlers/tests/test_processing_job.py
@@ -57,8 +57,6 @@ class JobHandlerTests(OauthTestingBase):
 
 
 class HeartbeatHandlerTests(OauthTestingBase):
-    database = True
-
     def test_post_job_does_not_exists(self):
         obs = self.post('/qiita_db/jobs/do-not-exist/heartbeat/', '',
                         headers=self.header)
@@ -102,8 +100,6 @@ class HeartbeatHandlerTests(OauthTestingBase):
 
 
 class ActiveStepHandlerTests(OauthTestingBase):
-    database = True
-
     def test_post_no_header(self):
         obs = self.post(
             '/qiita_db/jobs/063e553b-327c-4818-ab4a-adfe58e49860/step/', '')
@@ -135,8 +131,6 @@ class ActiveStepHandlerTests(OauthTestingBase):
 
 
 class CompleteHandlerTests(OauthTestingBase):
-    database = True
-
     def setUp(self):
         self._clean_up_files = []
         super(CompleteHandlerTests, self).setUp()
@@ -181,6 +175,10 @@ class CompleteHandlerTests(OauthTestingBase):
         self.assertEqual(job.log.msg, 'Job failure')
 
     def test_post_job_success(self):
+        job = qdb.processing_job.ProcessingJob(
+            'd19f76ee-274e-4c1b-b3a2-a12d73507c55')
+        job._set_status('running')
+
         fd, fp = mkstemp(suffix='_table.biom')
         close(fd)
         with open(fp, 'w') as f:
@@ -192,19 +190,15 @@ class CompleteHandlerTests(OauthTestingBase):
              'artifacts': {'OTU table': {'filepaths': [(fp, 'biom')],
                                          'artifact_type': 'BIOM'}}})
         obs = self.post(
-            '/qiita_db/jobs/bcc7ebcd-39c1-43e4-af2d-822e3589f14d/complete/',
+            '/qiita_db/jobs/d19f76ee-274e-4c1b-b3a2-a12d73507c55/complete/',
             payload, headers=self.header)
         self.assertEqual(obs.code, 200)
-        job = qdb.processing_job.ProcessingJob(
-            'bcc7ebcd-39c1-43e4-af2d-822e3589f14d')
         self.assertEqual(job.status, 'success')
         self.assertEqual(qdb.util.get_count('qiita.artifact'),
                          exp_artifact_count)
 
 
 class ProcessingJobAPItestHandlerTests(OauthTestingBase):
-    database = True
-
     def test_post_processing_job(self):
         data = {
             'user': 'demo@microbio.me',

--- a/qiita_db/test/test_study.py
+++ b/qiita_db/test/test_study.py
@@ -165,7 +165,6 @@ class TestStudy(TestCase):
             'spatial_series': False,
             'study_description': 'Analysis of the Cannabis Plant Microbiome',
             'study_alias': 'Cannabis Soils',
-            'most_recent_contact': '2014-05-19 16:11',
             'most_recent_contact': datetime(2014, 5, 19, 16, 11),
             'lab_person': qdb.study.StudyPerson(1),
             'number_samples_collected': 27}

--- a/qiita_pet/test/tornado_test_base.py
+++ b/qiita_pet/test/tornado_test_base.py
@@ -20,10 +20,9 @@ class TestHandlerBase(AsyncHTTPTestCase):
         self.app.settings['debug'] = False
         return self.app
 
-    def tearDown(self):
-        if self.database:
-            clean_test_environment()
-        super(TestHandlerBase, self).tearDown()
+    @classmethod
+    def tearDownClass(cls):
+        clean_test_environment()
 
     # helpers from http://www.peterbe.com/plog/tricks-asynchttpclient-tornado
     def get(self, url, data=None, headers=None, doseq=True):


### PR DESCRIPTION
The reset of the database is executed by class rather than by test.

Tests will fail in this PR. The idea is to get this merged on a different branch and try to parallelize the work on fixing the tests.

Now tests will be independent by class (rather than all of them independent). The developer will be in charge of making sure that the changes in a single test does not affect other tests in the same class, but he doesn't need to worry about tests in other classes, since the DB will be reseted.

@antgonza once this is merged I will create another PR with the list of files that need to be changed, so we can "self-assign" them.