### PR TITLE
Speedup tests db analysis

### DIFF
--- a/qiita_db/analysis.py
+++ b/qiita_db/analysis.py
@@ -1119,9 +1119,12 @@ class Collection(qdb.base.QiitaStatusObject):
         """
         with qdb.sql_connection.TRN:
             sql = """INSERT INTO qiita.{0} (email, name, description)
-                     VALUES (%s, %s, %s)""".format(cls._table)
+                     VALUES (%s, %s, %s)
+                     RETURNING collection_id""".format(cls._table)
             qdb.sql_connection.TRN.add(sql, [owner.id, name, description])
-            qdb.sql_connection.TRN.execute()
+            c_id = qdb.sql_connection.TRN.execute_fetchlast()
+
+            return cls(c_id)
 
     @classmethod
     def delete(cls, id_):

--- a/qiita_db/analysis.py
+++ b/qiita_db/analysis.py
@@ -747,8 +747,8 @@ class Analysis(qdb.base.QiitaStatusObject):
 
         Notes
         -----
-         - When only a list of samples given, the samples will be removed from
-           all artifacts it is associated with
+        - When only a list of samples given, the samples will be removed from
+          all artifacts it is associated with
         - When only a list of artifacts is given, all samples associated with
           that artifact are removed
         - If both are passed, the given samples are removed from the given
@@ -782,8 +782,13 @@ class Analysis(qdb.base.QiitaStatusObject):
             qdb.sql_connection.TRN.execute()
 
     def generate_tgz(self):
-        fps_ids = self.all_associated_filepath_ids
         with qdb.sql_connection.TRN:
+            fps_ids = self.all_associated_filepath_ids
+            if not fps_ids:
+                raise qdb.exceptions.QiitaDBError(
+                    "The analysis %s do not have files attached, "
+                    "can't create the tgz file" % self.id)
+
             sql = """SELECT filepath, data_directory_id FROM qiita.filepath
                         WHERE filepath_id IN %s"""
             qdb.sql_connection.TRN.add(sql, [tuple(fps_ids)])

--- a/qiita_db/test/test_analysis.py
+++ b/qiita_db/test/test_analysis.py
@@ -1,5 +1,6 @@
 from unittest import TestCase, main
-from os import remove
+from tempfile import mkstemp
+from os import remove, close
 from os.path import exists, join
 from shutil import move
 
@@ -60,6 +61,30 @@ class TestAnalysis(TestCase):
 
         qiita_config.portal = self._old_portal
 
+    def _create_analyses_with_samples(self):
+        """Aux function to create an analysis with samples
+
+        Returns
+        -------
+        qiita_db.analysis.Analysis
+
+        Notes
+        -----
+        Replicates the samples contained in Analysis(1) at the moment of
+        creation of this function (September 15, 2016)
+        """
+        new = qdb.analysis.Analysis.create(
+            qdb.user.User('demo@microbio.me'), "newAnalysis",
+            "A New Analysis")
+
+        new.add_samples({4: ['1.SKB8.640193', '1.SKD8.640184', '1.SKB7.640196',
+                             '1.SKM9.640192', '1.SKM4.640180'],
+                         5: ['1.SKB8.640193', '1.SKD8.640184', '1.SKB7.640196',
+                             '1.SKM9.640192', '1.SKM4.640180'],
+                         6: ['1.SKB8.640193', '1.SKD8.640184', '1.SKB7.640196',
+                             '1.SKM9.640192', '1.SKM4.640180']})
+        return new
+
     def test_lock_check(self):
         for status in ["queued", "running", "public", "completed",
                        "error"]:
@@ -71,13 +96,19 @@ class TestAnalysis(TestCase):
                 new._lock_check()
 
     def test_lock_check_ok(self):
-        self.analysis.status = "in_construction"
-        self.analysis._lock_check()
+        analysis = qdb.analysis.Analysis.create(
+            qdb.user.User("admin@foo.bar"), "newAnalysis",
+            "A New Analysis")
+        analysis.status = "in_construction"
+        analysis._lock_check()
 
     def test_status_setter_checks(self):
-        self.analysis.status = "public"
+        analysis = qdb.analysis.Analysis.create(
+            qdb.user.User("admin@foo.bar"), "newAnalysis",
+            "A New Analysis")
+        analysis.status = "public"
         with self.assertRaises(qdb.exceptions.QiitaDBStatusError):
-            self.analysis.status = "queued"
+            analysis.status = "queued"
 
     def test_get_by_status(self):
         qiita_config.portal = 'QIITA'
@@ -87,22 +118,28 @@ class TestAnalysis(TestCase):
         self.assertEqual(
             qdb.analysis.Analysis.get_by_status('public'), set([]))
 
-        self.analysis.status = "public"
         qiita_config.portal = 'QIITA'
+        analysis = qdb.analysis.Analysis.create(
+            qdb.user.User("admin@foo.bar"), "newAnalysis",
+            "A New Analysis")
+        analysis.status = 'public'
         self.assertEqual(qdb.analysis.Analysis.get_by_status('public'),
-                         {qdb.analysis.Analysis(1)})
+                         {analysis})
         qiita_config.portal = 'EMP'
         self.assertEqual(
             qdb.analysis.Analysis.get_by_status('public'), set([]))
 
     def test_has_access_public(self):
-        self.analysis.status = 'public'
+        analysis = qdb.analysis.Analysis.create(
+            qdb.user.User("admin@foo.bar"), "newAnalysis",
+            "A New Analysis")
+        analysis.status = 'public'
         qiita_config.portal = 'QIITA'
         self.assertTrue(
-            self.analysis.has_access(qdb.user.User("demo@microbio.me")))
+            analysis.has_access(qdb.user.User("demo@microbio.me")))
         qiita_config.portal = 'EMP'
         self.assertFalse(
-            self.analysis.has_access(qdb.user.User("demo@microbio.me")))
+            analysis.has_access(qdb.user.User("demo@microbio.me")))
 
     def test_has_access_shared(self):
         self.assertTrue(
@@ -125,57 +162,56 @@ class TestAnalysis(TestCase):
             self.analysis.has_access(qdb.user.User("demo@microbio.me")))
 
     def test_create(self):
-        sql = "SELECT EXTRACT(EPOCH FROM NOW())"
-        time1 = float(self.conn_handler.execute_fetchall(sql)[0][0])
-        new_id = qdb.util.get_count("qiita.analysis") + 1
-        new = qdb.analysis.Analysis.create(
-            qdb.user.User("admin@foo.bar"), "newAnalysis", "A New Analysis")
-        self.assertEqual(new.id, new_id)
-        sql = ("SELECT analysis_id, email, name, description, "
-               "analysis_status_id, pmid, EXTRACT(EPOCH FROM timestamp) "
-               "FROM qiita.analysis WHERE analysis_id = %s")
-        obs = self.conn_handler.execute_fetchall(sql, [new_id])
-        self.assertEqual(obs[0][:-1], [new_id, 'admin@foo.bar', 'newAnalysis',
-                                       'A New Analysis', 1, None])
-        self.assertTrue(time1 < float(obs[0][-1]))
+        with qdb.sql_connection.TRN:
+            sql = "SELECT NOW()"
+            qdb.sql_connection.TRN.add(sql)
+            time1 = qdb.sql_connection.TRN.execute_fetchlast()
 
-        # make sure portal is associated
-        obs = self.conn_handler.execute_fetchall(
-            "SELECT * from qiita.analysis_portal WHERE analysis_id = %s",
-            [new_id])
-        self.assertEqual(obs, [[new_id, 1]])
+        new_id = qdb.util.get_count("qiita.analysis") + 1
+        user = qdb.user.User("admin@foo.bar")
+        obs = qdb.analysis.Analysis.create(user, "newAnalysis",
+                                           "A New Analysis")
+
+        self.assertEqual(obs.id, new_id)
+        self.assertEqual(obs.owner, user)
+        self.assertEqual(obs.name, "newAnalysis")
+        self.assertEqual(obs._portals, ["QIITA"])
+        self.assertTrue(time1 < obs.timestamp)
+        self.assertEqual(obs.description, "A New Analysis")
+        self.assertEqual(obs.samples, {})
+        self.assertEqual(obs.dropped_samples, {})
+        self.assertEqual(obs.data_types, [])
+        self.assertEqual(obs.shared_with, [])
+        self.assertEqual(obs.all_associated_filepath_ids, set())
+        self.assertEqual(obs.biom_tables, {})
+        self.assertEqual(obs.mapping_file, None)
+        self.assertEqual(obs.tgz, None)
+        with self.assertRaises(ValueError):
+            obs.step
+        self.assertEqual(obs.jobs, [])
+        self.assertEqual(obs.pmid, None)
+        self.assertEqual(obs.status, "in_construction")
 
     def test_create_nonqiita_portal(self):
-        new_id = qdb.util.get_count("qiita.analysis") + 1
         qiita_config.portal = "EMP"
-        qdb.analysis.Analysis.create(
+        obs = qdb.analysis.Analysis.create(
             qdb.user.User("admin@foo.bar"), "newAnalysis", "A New Analysis")
 
         # make sure portal is associated
-        obs = self.conn_handler.execute_fetchall(
-            "SELECT * from qiita.analysis_portal WHERE analysis_id = %s",
-            [new_id])
-        self.assertEqual(obs, [[new_id, 2], [new_id, 1]])
+        self.assertItemsEqual(obs._portals, ["QIITA", "EMP"])
 
     def test_create_parent(self):
-        sql = "SELECT EXTRACT(EPOCH FROM NOW())"
-        time1 = float(self.conn_handler.execute_fetchall(sql)[0][0])
         new_id = qdb.util.get_count("qiita.analysis") + 1
         new = qdb.analysis.Analysis.create(
             qdb.user.User("admin@foo.bar"), "newAnalysis", "A New Analysis",
             qdb.analysis.Analysis(1))
         self.assertEqual(new.id, new_id)
-        sql = ("SELECT analysis_id, email, name, description, "
-               "analysis_status_id, pmid, EXTRACT(EPOCH FROM timestamp) "
-               "FROM qiita.analysis WHERE analysis_id = %s")
-        obs = self.conn_handler.execute_fetchall(sql, [new_id])
-        self.assertEqual(obs[0][:-1], [new_id, 'admin@foo.bar', 'newAnalysis',
-                                       'A New Analysis', 1, None])
-        self.assertTrue(time1 < float(obs[0][-1]))
 
-        sql = "SELECT * FROM qiita.analysis_chain WHERE child_id = %s"
-        obs = self.conn_handler.execute_fetchall(sql, [new_id])
-        self.assertEqual(obs, [[1, new_id]])
+        with qdb.sql_connection.TRN:
+            sql = "SELECT * FROM qiita.analysis_chain WHERE child_id = %s"
+            qdb.sql_connection.TRN.add(sql, [new_id])
+            obs = qdb.sql_connection.TRN.execute_fetchindex()
+            self.assertEqual(obs, [[1, new_id]])
 
     def test_create_from_default(self):
         new_id = qdb.util.get_count("qiita.analysis") + 1
@@ -186,20 +222,14 @@ class TestAnalysis(TestCase):
         self.assertEqual(new.step, 3)
 
         # Make sure samples were transfered properly
-        sql = "SELECT * FROM qiita.analysis_sample WHERE analysis_id = %s"
-        obs = self.conn_handler.execute_fetchall(
-            sql, [owner.default_analysis.id])
-        exp = []
-        self.assertEqual(obs, exp)
-        sql = """SELECT analysis_id, artifact_id, sample_id
-                 FROM qiita.analysis_sample
-                 WHERE analysis_id = %s"""
-        obs = self.conn_handler.execute_fetchall(sql, [new_id])
-        exp = [[new_id, 4, '1.SKD8.640184'],
-               [new_id, 4, '1.SKB7.640196'],
-               [new_id, 4, '1.SKM9.640192'],
-               [new_id, 4, '1.SKM4.640180']]
-        self.assertEqual(obs, exp)
+        # Magic number 4 -> the id of the artifact where the samples are taken
+        # from
+        self.assertEqual(owner.default_analysis.samples, {})
+        obs = new.samples
+        self.assertEqual(obs.keys(), [4])
+        exp = ['1.SKD8.640184', '1.SKB7.640196', '1.SKM9.640192',
+               '1.SKM4.640180']
+        self.assertItemsEqual(obs[4], exp)
 
     def test_exists(self):
         qiita_config.portal = 'QIITA'
@@ -213,14 +243,16 @@ class TestAnalysis(TestCase):
 
     def test_delete(self):
         # successful delete
-        total_analyses = qdb.util.get_count("qiita.analysis")
-        qdb.analysis.Analysis.delete(1)
-        self.assertEqual(total_analyses - 1,
-                         qdb.util.get_count("qiita.analysis"))
+        new = qdb.analysis.Analysis.create(
+            qdb.user.User('demo@microbio.me'), "newAnalysis",
+            "A New Analysis")
+        self.assertTrue(qdb.analysis.Analysis.exists(new.id))
+        qdb.analysis.Analysis.delete(new.id)
+        self.assertFalse(qdb.analysis.Analysis.exists(new.id))
 
         # no possible to delete
         with self.assertRaises(qdb.exceptions.QiitaDBUnknownIDError):
-            qdb.analysis.Analysis.delete(total_analyses + 1)
+            qdb.analysis.Analysis.delete(new.id)
 
     def test_retrieve_owner(self):
         self.assertEqual(self.analysis.owner, qdb.user.User("test@foo.bar"))
@@ -331,22 +363,22 @@ class TestAnalysis(TestCase):
                                                 prep_template=pt)
         self.table_fp = artifact.filepaths[0][1]
 
-        sql = """INSERT INTO qiita.analysis_sample (analysis_id, artifact_id,
-                                                    sample_id)
-                 VALUES (1, %s, '2.SKB8.640193'),
-                        (1, %s, '2.SKD8.640184'),
-                        (1, %s, '2.SKB7.640196')"""
-        self.conn_handler.execute(sql, [artifact.id, artifact.id, artifact.id])
+        new = self._create_analyses_with_samples()
+
+        new.add_samples({artifact.id: ['%s.SKB8.640193' % study.id,
+                                       '%s.SKD8.640184' % study.id,
+                                       '%s.SKB7.640196' % study.id]})
 
         grouped_samples = {'18S.1.3': [
             (4, ['1.SKB8.640193', '1.SKD8.640184', '1.SKB7.640196']),
-            (artifact.id, ['2.SKB8.640193', '2.SKD8.640184'])]}
-        self.analysis._build_biom_tables(grouped_samples, 10000)
+            (artifact.id, ['%s.SKB8.640193' % study.id,
+                           '%s.SKD8.640184' % study.id])]}
+        new._build_biom_tables(grouped_samples, 10000)
         exp = {4: {'1.SKM4.640180', '1.SKM9.640192'},
                5: {'1.SKM4.640180', '1.SKM9.640192'},
                6: {'1.SKM4.640180', '1.SKM9.640192'},
-               artifact.id: {'2.SKB7.640196'}}
-        self.assertEqual(self.analysis.dropped_samples, exp)
+               artifact.id: {'%s.SKB7.640196' % study.id}}
+        self.assertEqual(new.dropped_samples, exp)
 
     def test_empty_analysis(self):
         analysis = qdb.analysis.Analysis(2)
@@ -380,25 +412,19 @@ class TestAnalysis(TestCase):
         self.assertEqual(new.biom_tables, {})
 
     def test_set_step(self):
-        new_id = qdb.util.get_count("qiita.analysis") + 1
         new = qdb.analysis.Analysis.create(
             qdb.user.User("admin@foo.bar"), "newAnalysis",
             "A New Analysis", qdb.analysis.Analysis(1))
         new.step = 2
-        sql = "SELECT * FROM qiita.analysis_workflow WHERE analysis_id = %s"
-        obs = self.conn_handler.execute_fetchall(sql, [new_id])
-        self.assertEqual(obs, [[new_id, 2]])
+        self.assertEqual(new.step, 2)
 
     def test_set_step_twice(self):
-        new_id = qdb.util.get_count("qiita.analysis") + 1
         new = qdb.analysis.Analysis.create(
             qdb.user.User("admin@foo.bar"), "newAnalysis", "A New Analysis",
             qdb.analysis.Analysis(1))
         new.step = 2
         new.step = 4
-        sql = "SELECT * FROM qiita.analysis_workflow WHERE analysis_id = %s"
-        obs = self.conn_handler.execute_fetchall(sql, [new_id])
-        self.assertEqual(obs, [[new_id, 4]])
+        self.assertEqual(new.step, 4)
 
     def test_retrieve_step(self):
         new = qdb.analysis.Analysis.create(
@@ -415,9 +441,12 @@ class TestAnalysis(TestCase):
             new.step
 
     def test_retrieve_step_locked(self):
-        self.analysis.status = "public"
+        new = qdb.analysis.Analysis.create(
+            qdb.user.User("admin@foo.bar"), "newAnalysis", "A New Analysis",
+            qdb.analysis.Analysis(1))
+        new.status = "public"
         with self.assertRaises(qdb.exceptions.QiitaDBStatusError):
-            self.analysis.step = 3
+            new.step = 3
 
     def test_retrieve_jobs(self):
         self.assertEqual(self.analysis.jobs,
@@ -439,8 +468,11 @@ class TestAnalysis(TestCase):
         self.assertEqual(new.pmid, None)
 
     def test_set_pmid(self):
-        self.analysis.pmid = "11211221212213"
-        self.assertEqual(self.analysis.pmid, "11211221212213")
+        new = qdb.analysis.Analysis.create(
+            qdb.user.User("admin@foo.bar"), "newAnalysis", "A New Analysis",
+            qdb.analysis.Analysis(1))
+        new.pmid = "11211221212213"
+        self.assertEqual(new.pmid, "11211221212213")
 
     def test_retrieve_mapping_file(self):
         exp = join(self.fp, "1_analysis_mapping.txt")
@@ -458,18 +490,34 @@ class TestAnalysis(TestCase):
     def test_retrieve_tgz(self):
         # generating here as the tgz is only generated once the analysis runs
         # to completion (un)successfully
-        analysis = qdb.analysis.Analysis(1)
+        analysis = qdb.analysis.Analysis.create(
+            qdb.user.User("admin@foo.bar"), "newAnalysis", "A New Analysis",
+            qdb.analysis.Analysis(1))
         fp = self.get_fp('test.tgz')
         with open(fp, 'w') as f:
             f.write('')
         analysis._add_file(fp, 'tgz')
-        self.assertEqual(self.analysis.tgz, fp)
+        self.assertEqual(analysis.tgz, fp)
 
     def test_retrieve_tgz_none(self):
         self.assertIsNone(self.analysis.tgz)
 
     def test_generate_tgz(self):
-        obs_sout, obs_serr, obs_return = self.analysis.generate_tgz()
+        analysis = qdb.analysis.Analysis.create(
+            qdb.user.User("admin@foo.bar"), "newAnalysis", "A New Analysis",
+            qdb.analysis.Analysis(1))
+
+        # Raises an error because there are no files attached to it
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            analysis.generate_tgz()
+
+        analysis_mp = qdb.util.get_mountpoint('analysis')[0][1]
+        fd, fp = mkstemp(dir=analysis_mp, suffix='.txt')
+        close(fd)
+        with open(fp, 'w') as f:
+            f.write("")
+        analysis._add_file(fp, 'plain_text')
+        obs_sout, obs_serr, obs_return = analysis.generate_tgz()
         # not testing obs_serr as it will change depending on the system's tar
         # version
         self.assertEqual(obs_sout, "")
@@ -497,50 +545,65 @@ class TestAnalysis(TestCase):
         self.assertItemsEqual(obs[1], ['1.SKB8.640193', '1.SKD5.640186'])
 
     def test_remove_samples_both(self):
-        self.analysis.remove_samples(artifacts=(qdb.artifact.Artifact(4), ),
-                                     samples=('1.SKB8.640193', ))
+        analysis = self._create_analyses_with_samples()
+        analysis.remove_samples(artifacts=(qdb.artifact.Artifact(4), ),
+                                samples=('1.SKB8.640193', ))
         exp = {4: ['1.SKD8.640184', '1.SKB7.640196', '1.SKM9.640192',
                    '1.SKM4.640180'],
                5: ['1.SKD8.640184', '1.SKB7.640196', '1.SKM9.640192',
-                   '1.SKM4.640180'],
+                   '1.SKM4.640180', '1.SKB8.640193'],
                6: ['1.SKD8.640184', '1.SKB7.640196', '1.SKM9.640192',
-                   '1.SKM4.640180']}
-        self.assertItemsEqual(self.analysis.samples, exp)
+                   '1.SKM4.640180', '1.SKB8.640193']}
+        obs = analysis.samples
+        self.assertItemsEqual(obs.keys(), exp.keys())
+        for k in obs:
+            self.assertItemsEqual(obs[k], exp[k])
 
     def test_remove_samples_samples(self):
-        self.analysis.remove_samples(samples=('1.SKD8.640184', ))
+        analysis = self._create_analyses_with_samples()
+        analysis.remove_samples(samples=('1.SKD8.640184', ))
         exp = {4: ['1.SKB8.640193', '1.SKB7.640196', '1.SKM9.640192',
                    '1.SKM4.640180'],
                5: ['1.SKB8.640193', '1.SKB7.640196', '1.SKM9.640192',
                    '1.SKM4.640180'],
                6: ['1.SKB8.640193', '1.SKB7.640196', '1.SKM9.640192',
                    '1.SKM4.640180']}
-        self.assertItemsEqual(self.analysis.samples, exp)
+        self.assertItemsEqual(analysis.samples, exp)
 
     def test_remove_samples_artifact(self):
-        self.analysis.remove_samples(
+        analysis = self._create_analyses_with_samples()
+        analysis.remove_samples(
             artifacts=(qdb.artifact.Artifact(4), qdb.artifact.Artifact(5)))
         exp = {6: {'1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
                    '1.SKM4.640180', '1.SKM9.640192'}}
-        self.assertItemsEqual(self.analysis.samples, exp)
+        self.assertItemsEqual(analysis.samples, exp)
 
     def test_share(self):
-        self.analysis.share(qdb.user.User("admin@foo.bar"))
-        exp = [qdb.user.User("shared@foo.bar"), qdb.user.User("admin@foo.bar")]
-        self.assertEqual(self.analysis.shared_with, exp)
+        analysis = self._create_analyses_with_samples()
+        user = qdb.user.User("admin@foo.bar")
+        self.assertEqual(analysis.shared_with, [])
+        analysis.share(user)
+        exp = [user]
+        self.assertEqual(analysis.shared_with, exp)
 
     def test_unshare(self):
-        self.analysis.unshare(qdb.user.User("shared@foo.bar"))
-        self.assertEqual(self.analysis.shared_with, [])
+        analysis = self._create_analyses_with_samples()
+        user = qdb.user.User("admin@foo.bar")
+        analysis.share(user)
+        exp = [user]
+        self.assertEqual(analysis.shared_with, exp)
+        analysis.unshare(user)
+        self.assertEqual(analysis.shared_with, [])
 
     def test_build_mapping_file(self):
-        new_id = qdb.util.get_count('qiita.filepath') + 1
+        analysis = self._create_analyses_with_samples()
         samples = {4: ['1.SKB8.640193', '1.SKD8.640184', '1.SKB7.640196']}
 
         npt.assert_warns(qdb.exceptions.QiitaDBWarning,
-                         self.analysis._build_mapping_file, samples)
-        obs = self.analysis.mapping_file
-        self.assertEqual(obs, self.map_fp)
+                         analysis._build_mapping_file, samples)
+        obs = analysis.mapping_file
+        exp = self.get_fp("%s_analysis_mapping.txt" % analysis.id)
+        self.assertEqual(obs, exp)
 
         obs = qdb.metadata_template.util.load_template_to_dataframe(
             obs, index='#SampleID')
@@ -550,28 +613,15 @@ class TestAnalysis(TestCase):
             self.map_exp_fp, index='#SampleID')
         assert_frame_equal(obs, exp)
 
-        sql = """SELECT * FROM qiita.filepath
-                 WHERE filepath=%s ORDER BY filepath_id"""
-        obs = self.conn_handler.execute_fetchall(
-            sql, ("%d_analysis_mapping.txt" % self.analysis.id,))
-
-        exp = [[16, '1_analysis_mapping.txt', 9, '852952723', 1, 1],
-               [new_id, '1_analysis_mapping.txt', 9, '1542374513', 1, 1]]
-        self.assertItemsEqual(obs, exp)
-
-        sql = """SELECT * FROM qiita.analysis_filepath
-                 WHERE analysis_id=%s ORDER BY filepath_id"""
-        obs = self.conn_handler.execute_fetchall(sql, (self.analysis.id,))
-        exp = [[1L, 14L, 2L], [1L, 15L, None], [1L, new_id, None]]
-
     def test_build_mapping_file_duplicated_samples_no_merge(self):
+        analysis = self._create_analyses_with_samples()
         samples = {4: ['1.SKB8.640193', '1.SKD8.640184', '1.SKB7.640196'],
                    3: ['1.SKB8.640193', '1.SKD8.640184', '1.SKB7.640196']}
         npt.assert_warns(qdb.exceptions.QiitaDBWarning,
-                         self.analysis._build_mapping_file, samples, True)
+                         analysis._build_mapping_file, samples, True)
 
         obs = qdb.metadata_template.util.load_template_to_dataframe(
-            self.analysis.mapping_file, index='#SampleID')
+            analysis.mapping_file, index='#SampleID')
         exp = npt.assert_warns(
             qdb.exceptions.QiitaDBWarning,
             qdb.metadata_template.util.load_template_to_dataframe,
@@ -584,12 +634,13 @@ class TestAnalysis(TestCase):
         assert_frame_equal(obs, exp)
 
     def test_build_mapping_file_duplicated_samples_merge(self):
+        analysis = self._create_analyses_with_samples()
         samples = {4: ['1.SKB8.640193', '1.SKD8.640184', '1.SKB7.640196'],
                    3: ['1.SKB8.640193', '1.SKD8.640184', '1.SKB7.640196']}
         npt.assert_warns(qdb.exceptions.QiitaDBWarning,
-                         self.analysis._build_mapping_file, samples)
+                         analysis._build_mapping_file, samples)
         obs = qdb.metadata_template.util.load_template_to_dataframe(
-            self.analysis.mapping_file, index='#SampleID')
+            analysis.mapping_file, index='#SampleID')
         exp = npt.assert_warns(
             qdb.exceptions.QiitaDBWarning,
             qdb.metadata_template.util.load_template_to_dataframe,
@@ -597,14 +648,15 @@ class TestAnalysis(TestCase):
         assert_frame_equal(obs, exp)
 
     def test_build_biom_tables(self):
-        new_id = qdb.util.get_count('qiita.filepath') + 1
+        analysis = self._create_analyses_with_samples()
         grouped_samples = {'18S.1.3': [(
             4, ['1.SKB8.640193', '1.SKD8.640184', '1.SKB7.640196'])]}
-        self.analysis._build_biom_tables(grouped_samples, 100)
-        obs = self.analysis.biom_tables
-        self.assertEqual(obs, {'18S': self.biom_fp})
+        analysis._build_biom_tables(grouped_samples, 100)
+        obs = analysis.biom_tables
+        biom_fp = self.get_fp("%s_analysis_dt-18S_r-1_c-3.biom" % analysis.id)
+        self.assertEqual(obs, {'18S': biom_fp})
 
-        table = load_table(self.biom_fp)
+        table = load_table(biom_fp)
         obs = set(table.ids(axis='sample'))
         exp = {'1.SKB8.640193', '1.SKD8.640184', '1.SKB7.640196'}
         self.assertEqual(obs, exp)
@@ -617,25 +669,17 @@ class TestAnalysis(TestCase):
                'command_id': '3'}
         self.assertEqual(obs, exp)
 
-        sql = """SELECT EXISTS(SELECT * FROM qiita.filepath
-                 WHERE filepath_id=%s)"""
-        obs = self.conn_handler.execute_fetchone(sql, (new_id,))[0]
-        self.assertTrue(obs)
-
-        sql = """SELECT * FROM qiita.analysis_filepath
-                 WHERE analysis_id=%s ORDER BY filepath_id"""
-        obs = self.conn_handler.execute_fetchall(sql, (self.analysis.id,))
-        exp = [[1L, 15L, 2L], [1L, 16L, None], [1L, new_id, 2L]]
-        self.assertEqual(obs, exp)
-
     def test_build_biom_tables_duplicated_samples_not_merge(self):
+        analysis = self._create_analyses_with_samples()
         grouped_samples = {'18S.1.3': [
             (4, ['1.SKB8.640193', '1.SKD8.640184', '1.SKB7.640196']),
             (5, ['1.SKB8.640193', '1.SKD8.640184', '1.SKB7.640196'])]}
-        self.analysis._build_biom_tables(grouped_samples, 100, True)
-        obs = self.analysis.biom_tables
+        analysis._build_biom_tables(grouped_samples, 100, True)
+        obs = analysis.biom_tables
+        biom_fp = self.get_fp("%s_analysis_dt-18S_r-1_c-3.biom" % analysis.id)
+        self.assertEqual(obs, {'18S': biom_fp})
 
-        table = load_table(self.biom_fp)
+        table = load_table(biom_fp)
         obs = set(table.ids(axis='sample'))
         exp = {'4.1.SKD8.640184', '4.1.SKB7.640196', '4.1.SKB8.640193',
                '5.1.SKB8.640193', '5.1.SKB7.640196', '5.1.SKD8.640184'}
@@ -655,14 +699,15 @@ class TestAnalysis(TestCase):
             self.analysis._build_biom_tables(grouped_samples, 100000)
 
     def test_build_files(self):
+        analysis = self._create_analyses_with_samples()
         npt.assert_warns(qdb.exceptions.QiitaDBWarning,
-                         self.analysis.build_files)
+                         analysis.build_files)
 
         # testing that the generated files have the same sample ids
         biom_ids = load_table(
-            self.analysis.biom_tables['18S']).ids(axis='sample')
+            analysis.biom_tables['18S']).ids(axis='sample')
         mf_ids = qdb.metadata_template.util.load_template_to_dataframe(
-            self.analysis.mapping_file, index='#SampleID').index
+            analysis.mapping_file, index='#SampleID').index
 
         self.assertItemsEqual(biom_ids, mf_ids)
 
@@ -672,16 +717,17 @@ class TestAnalysis(TestCase):
         self.assertItemsEqual(biom_ids, exp)
 
     def test_build_files_merge_duplicated_sample_ids(self):
+        analysis = self._create_analyses_with_samples()
         npt.assert_warns(qdb.exceptions.QiitaDBWarning,
-                         self.analysis.build_files,
+                         analysis.build_files,
                          merge_duplicated_sample_ids=True)
 
         # testing that the generated files have the same sample ids
         biom_ids = []
-        for _, fp in viewitems(self.analysis.biom_tables):
+        for _, fp in viewitems(analysis.biom_tables):
             biom_ids.extend(load_table(fp).ids(axis='sample'))
         mf_ids = qdb.metadata_template.util.load_template_to_dataframe(
-            self.analysis.mapping_file, index='#SampleID').index
+            analysis.mapping_file, index='#SampleID').index
         self.assertItemsEqual(biom_ids, mf_ids)
 
         # now that the samples have been prefixed
@@ -708,23 +754,15 @@ class TestAnalysis(TestCase):
             self.analysis.build_files(-10)
 
     def test_add_file(self):
+        analysis = self._create_analyses_with_samples()
         new_id = qdb.util.get_count('qiita.filepath') + 1
         fp = self.get_fp('testfile.txt')
         with open(fp, 'w') as f:
             f.write('testfile!')
-        self.analysis._add_file('testfile.txt', 'plain_text', '18S')
 
-        obs = self.conn_handler.execute_fetchall(
-            'SELECT * FROM qiita.filepath WHERE filepath_id = %s',
-            (new_id,))
-        exp = [[new_id, 'testfile.txt', 9, '3675007573', 1, 1]]
-        self.assertEqual(obs, exp)
-
-        obs = self.conn_handler.execute_fetchall(
-            'SELECT * FROM qiita.analysis_filepath WHERE filepath_id = %s',
-            (new_id,))
-        exp = [[1, new_id, 2]]
-        self.assertEqual(obs, exp)
+        self.assertEqual(analysis.all_associated_filepath_ids, set())
+        analysis._add_file('testfile.txt', 'plain_text', '18S')
+        self.assertEqual(analysis.all_associated_filepath_ids, {new_id})
 
 
 @qiita_test_checker()


### PR DESCRIPTION
Well this was a hard one!

The tests were not following the standard of not using SQL on the tests, so I've updated that.
There was 2 bugs that I fixed:

1. `generate_tgz` failed if the analysis didn't had any file. Now it raises a useful error
2. `Collection.create` was not returning the object... Not a big deal since this was never used