### PR TITLE
Plugin install gui

### DIFF
--- a/qiita_db/handlers/artifact.py
+++ b/qiita_db/handlers/artifact.py
@@ -197,11 +197,6 @@ class ArtifactTypeHandler(OauthBaseHandler):
         filepath_types : list of (str, bool)
             The list filepath types that the new artifact type supports, and
             if they're required or not in an artifact instance of this type
-
-        Raises
-        ------
-        HTTPError
-            If the artifact type already exists, with error code 400
         """
         a_type = self.get_argument('type_name')
         a_desc = self.get_argument('description')
@@ -212,7 +207,7 @@ class ArtifactTypeHandler(OauthBaseHandler):
         try:
             qdb.artifact.Artifact.create_type(a_type, a_desc, ebi, vamps,
                                               fp_types)
-        except qdb.exceptions.QiitaDBDuplicateError as e:
-            raise HTTPError(400, str(e))
+        except qdb.exceptions.QiitaDBDuplicateError:
+            pass
 
         self.finish()

--- a/qiita_db/handlers/artifact.py
+++ b/qiita_db/handlers/artifact.py
@@ -208,6 +208,8 @@ class ArtifactTypeHandler(OauthBaseHandler):
             qdb.artifact.Artifact.create_type(a_type, a_desc, ebi, vamps,
                                               fp_types)
         except qdb.exceptions.QiitaDBDuplicateError:
+            # Ignoring this error as we want this endpoint in the rest api
+            # to be idempotent.
             pass
 
         self.finish()

--- a/qiita_db/handlers/artifact.py
+++ b/qiita_db/handlers/artifact.py
@@ -210,6 +210,6 @@ class ArtifactTypeHandler(OauthBaseHandler):
         except qdb.exceptions.QiitaDBDuplicateError:
             # Ignoring this error as we want this endpoint in the rest api
             # to be idempotent.
-            pass
+            self.set_status(200, reason="Artifact type already exists")
 
         self.finish()

--- a/qiita_db/handlers/tests/test_artifact.py
+++ b/qiita_db/handlers/tests/test_artifact.py
@@ -211,8 +211,7 @@ class ArtifactTypeHandlerTests(OauthTestingBase):
 
         obs = self.post('/qiita_db/artifacts/types/', headers=self.header,
                         data=data)
-        self.assertEqual(obs.code, 400)
-        self.assertIn('already exists', obs.body)
+        self.assertEqual(obs.code, 200)
 
 if __name__ == '__main__':
     main()

--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -9,11 +9,13 @@
 from json import dumps, loads
 from copy import deepcopy
 from future import standard_library
+from multiprocessing import Process
 import inspect
 import warnings
 
 import networkx as nx
 
+from qiita_core.qiita_settings import qiita_config
 import qiita_db as qdb
 
 with standard_library.hooks():
@@ -493,6 +495,18 @@ class Software(qdb.base.QiitaObject):
     qiita_db.software.Command
     """
     _table = "software"
+
+    @classmethod
+    def iter_active(cls):
+        """Iterates over all active software"""
+        with qdb.sql_connection.TRN:
+            sql = """SELECT software_id
+                     FROM qiita.software
+                     WHERE active = True
+                     ORDER BY software_id"""
+            qdb.sql_connection.TRN.add(sql)
+            for s_id in qdb.sql_connection.TRN.execute_fetchflatten():
+                yield cls(s_id)
 
     @classmethod
     def deactivate_all(cls):
@@ -1014,6 +1028,15 @@ class Software(qdb.base.QiitaObject):
                      WHERE software_id = %s"""
             qdb.sql_connection.TRN.add(sql, [self.id])
             return qdb.sql_connection.TRN.execute_fetchlast()
+
+    def register_commands(self):
+        """Registers the software commands"""
+        url = "%s%s" % (qiita_config.base_url, qiita_config.portal_dir)
+        cmd = '%s "%s" "%s" "%s" "register" "ignored"' % (
+            qiita_config.plugin_launcher, self.environment_script,
+            self.start_script, url)
+        p = Process(target=qdb.processing_job._system_call, args=(cmd,))
+        p.start()
 
 
 class DefaultParameters(qdb.base.QiitaObject):

--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -51,8 +51,9 @@ class Command(qdb.base.QiitaObject):
         ----------
         artifact_type : list of str
             The artifact types
-        active_only : bool
+        active_only : bool, optional
             If True, return only active commands, otherwise return all commands
+            Default: True
 
         Returns
         -------
@@ -68,7 +69,7 @@ class Command(qdb.base.QiitaObject):
                         JOIN qiita.software_command USING (command_id)
                      WHERE artifact_type IN %s"""
             if active_only:
-                sql = "%s AND active = True" % sql
+                sql += " AND active = True"
             qdb.sql_connection.TRN.add(sql, [tuple(artifact_types)])
             for c_id in qdb.sql_connection.TRN.execute_fetchflatten():
                 yield cls(c_id)

--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -42,13 +42,15 @@ class Command(qdb.base.QiitaObject):
     _table = "software_command"
 
     @classmethod
-    def get_commands_by_input_type(cls, artifact_types):
+    def get_commands_by_input_type(cls, artifact_types, active_only=True):
         """Returns the commands that can process the given artifact types
 
         Parameters
         ----------
         artifact_type : list of str
             The artifact types
+        active_only : bool
+            If True, return only active commands, otherwise return all commands
 
         Returns
         -------
@@ -61,7 +63,10 @@ class Command(qdb.base.QiitaObject):
                         JOIN qiita.parameter_artifact_type
                             USING (command_parameter_id)
                         JOIN qiita.artifact_type USING (artifact_type_id)
+                        JOIN qiita.software_command USING (command_id)
                      WHERE artifact_type IN %s"""
+            if active_only:
+                sql = "%s AND active = True" % sql
             qdb.sql_connection.TRN.add(sql, [tuple(artifact_types)])
             for c_id in qdb.sql_connection.TRN.execute_fetchflatten():
                 yield cls(c_id)

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -32,17 +32,26 @@ class CommandTests(TestCase):
         self.outputs = {'out1': 'BIOM'}
 
     def test_get_commands_by_input_type(self):
+        qdb.software.Software.deactivate_all()
         obs = list(qdb.software.Command.get_commands_by_input_type(['FASTQ']))
-        exp = [qdb.software.Command(1)]
+        self.assertEqual(obs, [])
+
+        cmd = qdb.software.Command(1)
+        cmd.activate()
+        obs = list(qdb.software.Command.get_commands_by_input_type(['FASTQ']))
+        exp = [cmd]
         self.assertItemsEqual(obs, exp)
 
         obs = list(qdb.software.Command.get_commands_by_input_type(
             ['FASTQ', 'per_sample_FASTQ']))
-        exp = [qdb.software.Command(1)]
         self.assertItemsEqual(obs, exp)
 
         obs = list(qdb.software.Command.get_commands_by_input_type(
             ['FASTQ', 'SFF']))
+        self.assertEqual(obs, exp)
+
+        obs = list(qdb.software.Command.get_commands_by_input_type(
+            ['FASTQ', 'SFF'], active_only=False))
         exp = [qdb.software.Command(1), qdb.software.Command(2)]
         self.assertItemsEqual(obs, exp)
 

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -298,6 +298,23 @@ class SoftwareTests(TestCase):
             if exists(f):
                 remove(f)
 
+    def test_iter_active(self):
+        qdb.software.Software.deactivate_all()
+        obs = list(qdb.software.Software.iter_active())
+        self.assertEqual(obs, [])
+
+        s2 = qdb.software.Software(2)
+        s2.activate()
+        obs = list(qdb.software.Software.iter_active())
+        self.assertEqual(obs, [s2])
+
+        s1 = qdb.software.Software(1)
+        s3 = qdb.software.Software(3)
+        s1.activate()
+        s3.activate()
+        obs = list(qdb.software.Software.iter_active())
+        self.assertEqual(obs, [s1, s2, s3])
+
     def test_from_name_and_version(self):
         obs = qdb.software.Software.from_name_and_version('QIIME', '1.9.1')
         exp = qdb.software.Software(1)

--- a/scripts/qiita
+++ b/scripts/qiita
@@ -15,7 +15,6 @@ from datetime import datetime, timedelta
 from os.path import join, abspath, dirname, basename
 from future.utils import viewitems
 from glob import glob
-from time import time
 
 import click
 import tornado.httpserver
@@ -440,11 +439,12 @@ def start(port, master):
     click.echo("Qiita started on port %d" % port)
     ioloop = tornado.ioloop.IOLoop.instance()
 
-    def callback_function():
-        for s in qdb.software.Software.iter_active():
-            s.register_commands()
+    if master:
+        def callback_function():
+            for s in qdb.software.Software.iter_active():
+                s.register_commands()
 
-    ioloop.add_timeout(time() + 0.5, callback_function)
+        ioloop.add_timeout(ioloop.time() + 0.5, callback_function)
     ioloop.start()
 
 # #############################################################################

--- a/scripts/qiita
+++ b/scripts/qiita
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta
 from os.path import join, abspath, dirname, basename
 from future.utils import viewitems
 from glob import glob
+from time import time
 
 import click
 import tornado.httpserver
@@ -437,7 +438,14 @@ def start(port, master):
             raise
 
     click.echo("Qiita started on port %d" % port)
-    tornado.ioloop.IOLoop.instance().start()
+    ioloop = tornado.ioloop.IOLoop.instance()
+
+    def callback_function():
+        for s in qdb.software.Software.iter_active():
+            s.register_commands()
+
+    ioloop.add_timeout(time() + 0.5, callback_function)
+    ioloop.start()
 
 # #############################################################################
 # PLUGIN COMMANDS


### PR DESCRIPTION
Depends on #1965 so review/merge that one first.

Modifies the command retrieval to retrieve only active commands (this way only active commands are shown in the GUI).

Makes sure that when Qiita starts, the plugins are called so they register their commands.

The call to create types need to be idempotent, instead of failing. So I changed it here.