### PR TITLE
Fix 1836

### DIFF
--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -766,16 +766,16 @@ class UtilTests(TestCase):
         obs = qdb.util.infer_status([])
         self.assertEqual(obs, 'sandbox')
 
-        obs = qdb.util.infer_status([['private']])
+        obs = qdb.util.infer_status(['private'])
         self.assertEqual(obs, 'private')
 
-        obs = qdb.util.infer_status([['private'], ['public']])
+        obs = qdb.util.infer_status(['private', 'public'])
         self.assertEqual(obs, 'public')
 
-        obs = qdb.util.infer_status([['sandbox'], ['awaiting_approval']])
+        obs = qdb.util.infer_status(['sandbox', 'awaiting_approval'])
         self.assertEqual(obs, 'awaiting_approval')
 
-        obs = qdb.util.infer_status([['sandbox'], ['sandbox']])
+        obs = qdb.util.infer_status(['sandbox', 'sandbox'])
         self.assertEqual(obs, 'sandbox')
 
     def test_get_pubmed_ids_from_dois(self):

--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -766,16 +766,16 @@ class UtilTests(TestCase):
         obs = qdb.util.infer_status([])
         self.assertEqual(obs, 'sandbox')
 
-        obs = qdb.util.infer_status(['private'])
+        obs = qdb.util.infer_status([['private']])
         self.assertEqual(obs, 'private')
 
-        obs = qdb.util.infer_status(['private', 'public'])
+        obs = qdb.util.infer_status([['private'], ['public']])
         self.assertEqual(obs, 'public')
 
-        obs = qdb.util.infer_status(['sandbox', 'awaiting_approval'])
+        obs = qdb.util.infer_status([['sandbox'], ['awaiting_approval']])
         self.assertEqual(obs, 'awaiting_approval')
 
-        obs = qdb.util.infer_status(['sandbox', 'sandbox'])
+        obs = qdb.util.infer_status([['sandbox'], ['sandbox']])
         self.assertEqual(obs, 'sandbox')
 
     def test_get_pubmed_ids_from_dois(self):

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -1129,6 +1129,7 @@ def infer_status(statuses):
         (4) sandbox
     """
     if statuses:
+        statuses = set(s[0] for s in statuses)
         if 'public' in statuses:
             return 'public'
         if 'private' in statuses:
@@ -1387,7 +1388,9 @@ def generate_study_list(study_ids, build_samples):
                 info['pmid'] = []
 
             # visibility
-            info["status"] = infer_status(info['artifacts_visibility'])
+            # infer_status expects a list of list of str
+            info["status"] = infer_status(
+                [[s] for s in info['artifacts_visibility']])
             del info['artifacts_visibility']
 
             # pi info

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -1388,7 +1388,7 @@ def generate_study_list(study_ids, build_samples):
                 info['pmid'] = []
 
             # visibility
-            info["status"] = infer_status([info['artifacts_visibility']])
+            info["status"] = infer_status(info['artifacts_visibility'])
             del info['artifacts_visibility']
 
             # pi info

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -1388,7 +1388,9 @@ def generate_study_list(study_ids, build_samples):
                 info['pmid'] = []
 
             # visibility
-            info["status"] = infer_status(info['artifacts_visibility'])
+            # info['artifacts_visibility'] is a list of list with 1 element
+            info["status"] = infer_status(
+                [s[0] for s in info['artifacts_visibility']])
             del info['artifacts_visibility']
 
             # pi info

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -1371,7 +1371,7 @@ def generate_study_list(study_ids, build_samples):
                 FROM qiita.study
                 LEFT JOIN qiita.study_person ON (
                     study_person_id=principal_investigator_id)
-                WHERE study_id IN %s"""
+                WHERE study_id IN %s ORDER BY study_id"""
         qdb.sql_connection.TRN.add(sql, [tuple(study_ids)])
         infolist = []
         refs = {}
@@ -1389,9 +1389,9 @@ def generate_study_list(study_ids, build_samples):
 
             # visibility
             # infer_status expects a list of list of str
-            info["status"] = infer_status(
-                [[s] for s in info['artifacts_visibility']])
+            iav = info['artifacts_visibility']
             del info['artifacts_visibility']
+            info["status"] = infer_status([[s] for s in iav] if iav else [])
 
             # pi info
             info["pi"] = (info['pi_email'], info['pi_name'])

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -1129,7 +1129,6 @@ def infer_status(statuses):
         (4) sandbox
     """
     if statuses:
-        statuses = set(s[0] for s in statuses)
         if 'public' in statuses:
             return 'public'
         if 'private' in statuses:
@@ -1388,9 +1387,7 @@ def generate_study_list(study_ids, build_samples):
                 info['pmid'] = []
 
             # visibility
-            # info['artifacts_visibility'] is a list of list with 1 element
-            info["status"] = infer_status(
-                [s[0] for s in info['artifacts_visibility']])
+            info["status"] = infer_status(info['artifacts_visibility'])
             del info['artifacts_visibility']
 
             # pi info

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -1290,9 +1290,12 @@ def generate_study_list(study_ids, build_samples):
                 WHERE artifact_type='BIOM' AND
                     study_id = qiita.study.study_id) AS artifact_biom_ts,
     - all the visibilities of all artifacts that belong to the study
-            (SELECT array_agg(DISTINCT visibility) FROM qiita.artifact
+            (SELECT array_agg(DISTINCT visibility)
+                FROM qiita.study_artifact
+                LEFT JOIN qiita.artifact USING (artifact_id)
+                LEFT JOIN qiita.artifact_type USING (artifact_type_id)
                 LEFT JOIN qiita.visibility USING (visibility_id)
-                WHERE study_id=qiita.study.study_id)
+                WHERE study_id = qiita.study.study_id)
                 AS artifacts_visibility,
     - all the publication_doi that belong to the study
             (SELECT array_agg(publication_doi ORDER BY publication_doi)
@@ -1349,9 +1352,12 @@ def generate_study_list(study_ids, build_samples):
                     LEFT JOIN qiita.artifact_type USING (artifact_type_id)
                     WHERE artifact_type='BIOM' AND
                         study_id = qiita.study.study_id) AS artifact_biom_ts,
-                (SELECT array_agg(DISTINCT visibility) FROM qiita.artifact
+                (SELECT array_agg(DISTINCT visibility)
+                    FROM qiita.study_artifact
+                    LEFT JOIN qiita.artifact USING (artifact_id)
+                    LEFT JOIN qiita.artifact_type USING (artifact_type_id)
                     LEFT JOIN qiita.visibility USING (visibility_id)
-                    WHERE study_id=qiita.study.study_id)
+                    WHERE study_id = qiita.study.study_id)
                     AS artifacts_visibility,
                 (SELECT array_agg(publication_doi ORDER BY publication_doi)
                     FROM qiita.study_publication

--- a/qiita_pet/handlers/study_handlers/listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/listing_handlers.py
@@ -72,7 +72,8 @@ def _build_study_info(user, search_type, study_proc=None, proc_samples=None):
 
     # get list of studies for table
     if search_type == 'user':
-        study_set = user.user_studies.union(user.shared_studies)
+        user_study_set = user.user_studies.union(user.shared_studies)
+        study_set = user_study_set - Study.get_by_status('public')
     elif search_type == 'public':
         study_set = Study.get_by_status('public')
     else:

--- a/qiita_pet/handlers/study_handlers/tests/test_listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_listing_handlers.py
@@ -176,7 +176,7 @@ class TestBuildStudyWithDBAccess(TestHelpers):
             'shared': [],
             'pmid': [],
             'pi': ('PI_dude@foo.bar', 'PIDude'),
-            'status': 'private',
+            'status': 'sandbox',
             'proc_data_info': [],
             'publication_doi': [],
             'study_abstract': 'abstract',
@@ -184,6 +184,7 @@ class TestBuildStudyWithDBAccess(TestHelpers):
             'ebi_study_accession': None,
             'study_title': 'My study',
             'number_samples_collected': 0})
+
         self.assertItemsEqual(obs, self.exp)
 
 

--- a/qiita_pet/templates/list_studies.html
+++ b/qiita_pet/templates/list_studies.html
@@ -129,6 +129,7 @@ $(document).ready(function() {
   });
 
   $('#studies-table').dataTable({
+      "lengthMenu": [[5, 10, 50, -1], [5, 10, 50, "All"]],
       "deferRender": true,
       "sDom": '<"top">rti<"bottom"p><"clear">',
       "bLengthChange": false,


### PR DESCRIPTION
- make both lists start with 5 element
Fixed via datatables config 

-  filter user study list to not contain public studies
Fixed in qiita_pet/handlers/study_handlers/listing_handlers.py by removing public studies from the list

- check why everything in the user study list is awaiting approval
This one was trickier than expected: (1) there was an error in the SQL, we were retrieving all available statuses vs. all statuses of all the artifacts in that study; and (2) the infer_status method was expecting a list of list with one string element but it really returned a list of strings, we were comparing against the first letter. Had to change some of the tests. 

Note that this was tested in the test environment and it works as expected, still deploy if you want to take a look. 