### PR TITLE
Remove rm not used in main system

### DIFF
--- a/qiita_db/job.py
+++ b/qiita_db/job.py
@@ -26,10 +26,8 @@ Classes
 # -----------------------------------------------------------------------------
 from __future__ import division
 from json import loads
-from os.path import join, relpath, isdir
-from os import remove
+from os.path import join, relpath
 from glob import glob
-from shutil import rmtree
 from functools import partial
 from collections import defaultdict
 
@@ -210,16 +208,6 @@ class Job(qdb.base.QiitaStatusObject):
             qdb.sql_connection.TRN.add(sql, args)
 
             qdb.sql_connection.TRN.execute()
-
-            # remove files/folders attached to job
-            _, basedir = qdb.util.get_mountpoint("job")[0]
-            path_builder = partial(join, basedir)
-            for fp, _ in filepaths:
-                fp = path_builder(fp)
-                if isdir(fp):
-                    qdb.sql_connection.TRN.add_post_commit_func(rmtree, fp)
-                else:
-                    qdb.sql_connection.TRN.add_post_commit_func(remove, fp)
 
     @classmethod
     def create(cls, datatype, command, options, analysis,


### PR DESCRIPTION
In the main system we had to comment out these lines as the mount system might fail cause the files are there yet when it tries to delete them. We thought this was OK cause we still needed to create the automatic deleting/cleaning system, issue: https://github.com/biocore/qiita/issues/814. With this in mind, we should simply remove and deal with this when that issue is solved. 