### PR TITLE
Fix documentation link on homepage.

### DIFF
--- a/qiita_pet/support_files/config_portal.cfg
+++ b/qiita_pet/support_files/config_portal.cfg
@@ -32,7 +32,7 @@ TEXT = <p align="justify">
   </p>
   <p align="justify">
   For more information about how to use Qiita visit the
-  <a href=”static/doc/html/index.html”>documentation</a>.
+  <a href="static/doc/html/index.html">documentation</a>.
   </p>
   <p align="justify">
   Note that you should be log into the system to access to any studies and


### PR DESCRIPTION
Replaces smart quotes with ASCII quotes so that the link works.