### PR TITLE
Fixing sample template GUI

### DIFF
--- a/qiita_pet/handlers/api_proxy/sample_template.py
+++ b/qiita_pet/handlers/api_proxy/sample_template.py
@@ -196,24 +196,31 @@ def get_sample_template_processing_status(st_id):
         job_info = loads(job_info)
         job_id = job_info['job_id']
         if job_id:
-            redis_info = loads(r_client.get(job_id))
-            processing = redis_info['status_msg'] == 'Running'
-            if processing:
-                alert_type = 'info'
-                alert_msg = 'This sample template is currently being processed'
-            elif redis_info['status_msg'] == 'Success':
-                alert_type = redis_info['return']['status']
-                alert_msg = redis_info['return']['message'].replace('\n',
-                                                                    '</br>')
-                payload = {'job_id': None,
-                           'status': alert_type,
-                           'message': alert_msg}
-                r_client.set(SAMPLE_TEMPLATE_KEY_FORMAT % st_id,
-                             dumps(payload))
+            redis_info = r_client.get(job_id)
+            if redis_info:
+                redis_info = loads(redis_info)
+                processing = redis_info['status_msg'] == 'Running'
+                if processing:
+                    alert_type = 'info'
+                    alert_msg = ('This sample template is currently being '
+                                 'processed')
+                elif redis_info['status_msg'] == 'Success':
+                    alert_type = redis_info['return']['status']
+                    alert_msg = redis_info['return']['message'].replace(
+                        '\n', '</br>')
+                    payload = {'job_id': None,
+                               'status': alert_type,
+                               'message': alert_msg}
+                    r_client.set(SAMPLE_TEMPLATE_KEY_FORMAT % st_id,
+                                 dumps(payload))
+                else:
+                    alert_type = redis_info['return']['status']
+                    alert_msg = redis_info['return']['message'].replace(
+                        '\n', '</br>')
             else:
-                alert_type = redis_info['return']['status']
-                alert_msg = redis_info['return']['message'].replace('\n',
-                                                                    '</br>')
+                processing = False
+                alert_type = ''
+                alert_msg = ''
         else:
             processing = False
             alert_type = job_info['status']

--- a/qiita_pet/handlers/api_proxy/tests/test_sample_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_sample_template.py
@@ -183,6 +183,13 @@ class TestSampleAPI(TestCase):
         self.assertEqual(obs_at, "error")
         self.assertEqual(obs_am, "Some</br>error")
 
+        # With job expired
+        r_client.set(key, dumps({'job_id': "non_existent_job"}))
+        obs_proc, obs_at, obs_am = get_sample_template_processing_status(1)
+        self.assertFalse(obs_proc)
+        self.assertEqual(obs_at, "")
+        self.assertEqual(obs_am, "")
+
     def test_sample_template_summary_get_req(self):
         obs = sample_template_summary_get_req(1, 'test@foo.bar')
         exp = {


### PR DESCRIPTION
This fixes the error that @ackermag reported with Sample Template pages not showing up correctly. The main issue is that there are expiration dates on the redis keys and the system raises an error when this occurs, instead of just defaulting to the fact that the sample template is not being processed.

cc @antgonza 