### PR TITLE
fix #388

### DIFF
--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -243,6 +243,11 @@ class TestPrepSample(TestCase):
                    "template")
         self.assertEqual(obs_msg, exp_msg)
 
+    def test_can_be_extended_duplicated_column(self):
+        """test if the template can be extended"""
+        with self.assertRaises(qdb.exceptions.QiitaDBColumnError):
+            self.prep_template.can_be_extended([], ["season_environment"])
+
     def test_metadata_headers(self):
         PT = qdb.metadata_template.prep_template.PrepTemplate
         obs = PT.metadata_headers()
@@ -1002,6 +1007,13 @@ class TestPrepTemplate(TestCase):
             qdb.metadata_template.prep_template.PrepTemplate.create(
                 self.metadata, self.test_study, self.data_type_id,
                 'Not a term')
+
+    def test_create_duplicated_column_error(self):
+        """Create raises an error if the prep has a duplicated column name"""
+        self.metadata['season_environment'] = self.metadata['primer']
+        with self.assertRaises(qdb.exceptions.QiitaDBColumnError):
+            qdb.metadata_template.prep_template.PrepTemplate.create(
+                self.metadata, self.test_study, self.data_type_id)
 
     def test_delete_error(self):
         """Try to delete a prep template that already has preprocessed data"""

--- a/qiita_db/support_files/patches/45.sql
+++ b/qiita_db/support_files/patches/45.sql
@@ -1,0 +1,4 @@
+-- Dec 15, 2016
+-- Making sure there are no duplicated columns, much easier via python
+
+SELECT 42;

--- a/qiita_db/support_files/patches/python_patches/45.py
+++ b/qiita_db/support_files/patches/python_patches/45.py
@@ -1,0 +1,36 @@
+from future.utils import viewitems
+
+from qiita_db.metadata_template.sample_template import SampleTemplate
+from qiita_db.metadata_template.prep_template import PrepTemplate
+from qiita_db.sql_connection import TRN
+
+with TRN:
+    # a few notes: just getting the preps with duplicated values; ignoring
+    # column 'sample_id' and tables 'study_sample', 'prep_template',
+    # 'prep_template_sample'
+    sql = """SELECT table_name, array_agg(column_name::text)
+                FROM information_schema.columns
+                WHERE column_name IN %s
+                    AND column_name != 'sample_id'
+                    AND table_name LIKE 'prep_%%'
+                    AND table_name NOT IN (
+                        'prep_template', 'prep_template_sample')
+                GROUP BY table_name"""
+    # note that we are looking for those columns with duplicated names in
+    # the headers
+    TRN.add(sql, [tuple(
+        set(PrepTemplate.metadata_headers()) &
+        set(SampleTemplate.metadata_headers()))])
+    overlapping = dict(TRN.execute_fetchindex())
+
+# finding actual duplicates
+for table_name, cols in viewitems(overlapping):
+    # leaving print so when we patch in the main system we know that
+    # nothing was renamed or deal with that
+    print table_name
+    with TRN:
+        for c in cols:
+            sql = 'ALTER TABLE qiita.%s RENAME COLUMN %s TO %s_renamed' % (
+                table_name, c, c)
+            TRN.add(sql)
+        TRN.execute()

--- a/qiita_db/test/test_commands.py
+++ b/qiita_db/test/test_commands.py
@@ -457,7 +457,7 @@ SAMPLE_TEMPLATE = (
 
 PREP_TEMPLATE = (
     'sample_name\tbarcode\tcenter_name\tcenter_project_name\t'
-    'description\tebi_submission_accession\temp_status\tprimer\t'
+    'description_prep\tebi_submission_accession\temp_status\tprimer\t'
     'run_prefix\tstr_column\tplatform\tlibrary_construction_protocol\t'
     'experiment_design_description\tinstrument_model\n'
     'SKB7.640196\tCCTCTGAGAGCT\tANL\tTest Project\tskb7\tNone\tEMP\t'


### PR DESCRIPTION
Decided to add _check_duplicated_columns cause it avoids duplication of code, which is an internal method in the prep_template.py.