### PR TITLE
Unmoi job completion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ before_install:
 install:
   # install a few of the dependencies that pip would otherwise try to install
   # when intalling scikit-bio
-  - travis_retry conda create --yes -n env_name python=$PYTHON_VERSION pip nose flake8
+  - travis_retry conda create --yes -n qiita python=$PYTHON_VERSION pip nose flake8
     pyzmq networkx pyparsing natsort mock future libgfortran seaborn
     'pandas>=0.18' 'matplotlib>=1.1.0' 'scipy>0.13.0' 'numpy>=1.7' 'h5py>=2.3.1'
-  - source activate env_name
+  - source activate qiita
   - pip install -U pip
   - pip install sphinx sphinx-bootstrap-theme coveralls 'ipython[all]==2.4.1'
   - travis_retry pip install . --process-dependency-links
@@ -43,7 +43,7 @@ script:
   - if [ ${TEST_ADD_STUDIES} == "False" ]; then qiita-test-install ; fi
   - if [ ${TEST_ADD_STUDIES} == "False" ]; then nosetests --with-doctest --with-coverage -v --cover-package=qiita_db,qiita_pet,qiita_core,qiita_ware; fi
   - flake8 qiita_* setup.py scripts/qiita scripts/qiita-env scripts/qiita-test-install
-  - ls -R /home/travis/miniconda3/envs/env_name/lib/python2.7/site-packages/qiita_pet/support_files/doc/
+  - ls -R /home/travis/miniconda3/envs/qiita/lib/python2.7/site-packages/qiita_pet/support_files/doc/
   - qiita pet webserver
 addons:
   postgresql: "9.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ script:
   - if [ ${TEST_ADD_STUDIES} == "False" ]; then qiita-test-install ; fi
   - if [ ${TEST_ADD_STUDIES} == "False" ]; then nosetests --with-doctest --with-coverage -v --cover-package=qiita_db,qiita_pet,qiita_core,qiita_ware; fi
   - flake8 qiita_* setup.py scripts/qiita scripts/qiita-env scripts/qiita-test-install
-  - cat /home/travis/trying_to_debug.txt
   - ls -R /home/travis/miniconda3/envs/qiita/lib/python2.7/site-packages/qiita_pet/support_files/doc/
   - qiita pet webserver
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ script:
   - if [ ${TEST_ADD_STUDIES} == "False" ]; then qiita-test-install ; fi
   - if [ ${TEST_ADD_STUDIES} == "False" ]; then nosetests --with-doctest --with-coverage -v --cover-package=qiita_db,qiita_pet,qiita_core,qiita_ware; fi
   - flake8 qiita_* setup.py scripts/qiita scripts/qiita-env scripts/qiita-test-install
+  - cat /home/travis/trying_to_debug.txt
   - ls -R /home/travis/miniconda3/envs/qiita/lib/python2.7/site-packages/qiita_pet/support_files/doc/
   - qiita pet webserver
 addons:

--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -116,6 +116,10 @@ class ConfigurationManager(object):
         The portal subdirectory used in the URL
     portal_fp : str
         The filepath to the portal styling config file
+    qiita_env : str
+        The script used to start the qiita environment
+    private_launcher : str
+        The script used to start private jobs
     plugin_launcher : str
         The script used to start the plugins
     plugin_dir : str
@@ -191,6 +195,12 @@ class ConfigurationManager(object):
                              self.working_dir)
         self.max_upload_size = config.getint('main', 'MAX_UPLOAD_SIZE')
         self.require_approval = config.getboolean('main', 'REQUIRE_APPROVAL')
+
+        self.qiita_env = config.get('main', 'QIITA_ENV')
+        if not self.qiita_env:
+            self.qiita_env = ""
+
+        self.private_launcher = config.get('main', 'PRIVATE_LAUNCHER')
 
         self.plugin_launcher = config.get('main', 'PLUGIN_LAUNCHER')
         self.plugin_dir = config.get('main', 'PLUGIN_DIR')

--- a/qiita_core/support_files/config_test.cfg
+++ b/qiita_core/support_files/config_test.cfg
@@ -42,7 +42,7 @@ VALID_UPLOAD_EXTENSION = fastq,fastq.gz,txt,tsv,sff,fna,qual
 
 # The script used to start the qiita environment, if any
 # used to spawn private CLI to a cluster
-QIITA_ENV = export PATH=/home/travis/miniconda3/bin:$PATH; export MOI_CONFIG_FP=`pwd`/qiita_core/support_files/config_test.cfg; source activate qiita
+QIITA_ENV = source activate qiita
 
 # Script used for launching private Qiita tasks
 PRIVATE_LAUNCHER = qiita-private-launcher

--- a/qiita_core/support_files/config_test.cfg
+++ b/qiita_core/support_files/config_test.cfg
@@ -40,6 +40,13 @@ BASE_DATA_DIR =
 # Valid upload extension, comma separated. Empty for no uploads
 VALID_UPLOAD_EXTENSION = fastq,fastq.gz,txt,tsv,sff,fna,qual
 
+# The script used to start the qiita environment, if any
+# used to spawn private CLI to a cluster
+QIITA_ENV = source activate qiita
+
+# Script used for launching private Qiita tasks
+PRIVATE_LAUNCHER = qiita-private-launcher
+
 # Script used for launching plugins
 PLUGIN_LAUNCHER = qiita-plugin-launcher
 

--- a/qiita_core/support_files/config_test.cfg
+++ b/qiita_core/support_files/config_test.cfg
@@ -42,7 +42,7 @@ VALID_UPLOAD_EXTENSION = fastq,fastq.gz,txt,tsv,sff,fna,qual
 
 # The script used to start the qiita environment, if any
 # used to spawn private CLI to a cluster
-QIITA_ENV = source activate qiita
+QIITA_ENV = export PATH=/home/travis/miniconda3/bin:$PATH; export MOI_CONFIG_FP=`pwd`/qiita_core/support_files/config_test.cfg; source activate qiita
 
 # Script used for launching private Qiita tasks
 PRIVATE_LAUNCHER = qiita-private-launcher

--- a/qiita_core/testing.py
+++ b/qiita_core/testing.py
@@ -59,4 +59,4 @@ def wait_for_processing_job(job_id):
     job = ProcessingJob(job_id)
     while job.status not in ('success', 'error'):
         sleep(0.05)
-    sleep(0.05)
+    sleep(0.5)

--- a/qiita_core/tests/test_configuration_manager.py
+++ b/qiita_core/tests/test_configuration_manager.py
@@ -48,6 +48,8 @@ class ConfigurationManagerTests(TestCase):
         self.assertEqual(obs.base_url, "https://localhost")
         self.assertEqual(obs.max_upload_size, 100)
         self.assertTrue(obs.require_approval)
+        self.assertEqual(obs.qiita_env, "source activate qiita")
+        self.assertEqual(obs.private_launcher, 'qiita-private-launcher')
         self.assertEqual(obs.plugin_launcher, "qiita-plugin-launcher")
         self.assertEqual(obs.plugin_dir, "/tmp/")
         self.assertEqual(
@@ -121,6 +123,7 @@ class ConfigurationManagerTests(TestCase):
         conf_setter('PLUGIN_DIR', '')
         conf_setter('CERTIFICATE_FILE', '')
         conf_setter('KEY_FILE', '')
+        conf_setter('QIITA_ENV', '')
 
         # Warning raised if No files will be allowed to be uploaded
         # Warning raised if no cookie_secret
@@ -167,6 +170,8 @@ class ConfigurationManagerTests(TestCase):
         conf_setter('VALID_UPLOAD_EXTENSION', '')
         with self.assertRaises(ValueError):
             obs._get_main(self.conf)
+
+        self.assertEqual(obs.qiita_env, "")
 
     def test_get_postgres(self):
         obs = ConfigurationManager()
@@ -223,6 +228,13 @@ BASE_DATA_DIR = /tmp/
 
 # Valid upload extension, comma separated. Empty for no uploads
 VALID_UPLOAD_EXTENSION = fastq,fastq.gz,txt,tsv,sff,fna,qual
+
+# The script used to start the qiita environment, if any
+# used to spawn private CLI to a cluster
+QIITA_ENV = source activate qiita
+
+# Script used for launching private Qiita tasks
+PRIVATE_LAUNCHER = qiita-private-launcher
 
 # Script used for launching plugins
 PLUGIN_LAUNCHER = qiita-plugin-launcher

--- a/qiita_core/tests/test_configuration_manager.py
+++ b/qiita_core/tests/test_configuration_manager.py
@@ -36,6 +36,8 @@ class ConfigurationManagerTests(TestCase):
     def tearDown(self):
         if self.old_conf_fp is not None:
             environ['QIITA_CONFIG_FP'] = self.old_conf_fp
+        else:
+            del environ['QIITA_CONFIG_FP']
         remove(self.conf_fp)
 
     def test_init(self):

--- a/qiita_db/commands.py
+++ b/qiita_db/commands.py
@@ -9,6 +9,8 @@
 from functools import partial
 from future import standard_library
 from json import loads
+from sys import exc_info
+import traceback
 
 import qiita_db as qdb
 
@@ -275,3 +277,27 @@ def update_artifact_from_cmd(filepaths, filepath_types, artifact_id):
         qdb.sql_connection.TRN.execute()
 
     return artifact
+
+
+def complete_job_cmd(job_id, payload):
+    """Completes the given job
+
+    Parameters
+    ----------
+    job_id : str
+        The job id
+    payload : str
+        JSON string with the payload to complete the job
+    """
+    payload = loads(payload)
+    if payload['success']:
+        artifacts = payload['artifacts']
+        error = None
+    else:
+        artifacts = None
+        error = payload['error']
+    job = qdb.processing_job.ProcessingJob(job_id)
+    try:
+        job.complete(payload['success'], artifacts, error)
+    except:
+        job._set_error(traceback.format_exception(*exc_info()))

--- a/qiita_db/handlers/processing_job.py
+++ b/qiita_db/handlers/processing_job.py
@@ -59,8 +59,9 @@ def _job_completer(job_id, payload):
         completing the job
     """
     import qiita_db as qdb
-    cmd = "%s %s %s '%s'" % (qiita_config.private_launcher, 'complete_job',
-                             job_id, payload)
+    cmd = "%s '%s' %s %s '%s'" % (qiita_config.private_launcher,
+                                  qiita_config.qiita_env, 'complete_job',
+                                  job_id, payload)
     std_out, std_err, return_value = qdb.processing_job._system_call(cmd)
     if return_value != 0:
         error = ("Can't submit private task 'complete job:\n"

--- a/qiita_db/handlers/processing_job.py
+++ b/qiita_db/handlers/processing_job.py
@@ -9,6 +9,7 @@
 from json import loads
 from sys import exc_info
 import traceback
+from multiprocessing import Process
 
 from tornado.web import HTTPError
 
@@ -17,6 +18,7 @@ from tornado.web import HTTPError
 # is acceptable to import from qiita_ware, specially to offload
 # processing to the ipython cluster
 from qiita_ware.context import safe_submit
+from qiita_core.qiita_settings import qiita_config
 import qiita_db as qdb
 from .oauth2 import OauthBaseHandler, authenticate_oauth
 
@@ -59,21 +61,18 @@ def _job_completer(job_id, payload):
     ----------
     job_id : str
         The job to complete
-    payload : dict
-        The parameters of the HTTP POST request that is completing the job
+    payload : str
+        The JSON string with the parameters of the HTTP POST request that is
+        completing the job
     """
-    payload_success = payload['success']
-    if payload_success:
-        artifacts = payload['artifacts']
-        error = None
-    else:
-        artifacts = None
-        error = payload['error']
-    job = qdb.processing_job.ProcessingJob(job_id)
-    try:
-        job.complete(payload_success, artifacts, error)
-    except:
-        job._set_error(traceback.format_exception(*exc_info()))
+    cmd = "%s %s %s '%s'" % (qiita_config.private_launcher, 'complete_job',
+                             job_id, payload)
+    std_out, std_err, return_value = qdb.processing_job._system_call(cmd)
+    if return_value != 0:
+        error = ("Can't submit private task 'complete job:\n"
+                 "Std output:%s\nStd error:%s'" % (std_out, std_err))
+        job = qdb.processing_job.ProcessingJob(job_id)
+        job.complete(False, error=error)
 
 
 class JobHandler(OauthBaseHandler):
@@ -168,8 +167,10 @@ class CompleteHandler(OauthBaseHandler):
                 raise HTTPError(
                     403, "Can't complete job: not in a running state")
 
-            payload = loads(self.request.body)
-            safe_submit(job.user.email, _job_completer, job_id, payload)
+            p = Process(target=_job_completer,
+                        args=(job_id, self.request.body))
+            p.start()
+            # safe_submit(job.user.email, _job_completer, job_id, payload)
 
         self.finish()
 

--- a/qiita_db/handlers/processing_job.py
+++ b/qiita_db/handlers/processing_job.py
@@ -7,17 +7,10 @@
 # -----------------------------------------------------------------------------
 
 from json import loads
-from sys import exc_info
-import traceback
 from multiprocessing import Process
 
 from tornado.web import HTTPError
 
-# We agreed before that qiita db should never import from
-# qiita_ware. However, this is part of the rest API and I think it
-# is acceptable to import from qiita_ware, specially to offload
-# processing to the ipython cluster
-from qiita_ware.context import safe_submit
 from qiita_core.qiita_settings import qiita_config
 import qiita_db as qdb
 from .oauth2 import OauthBaseHandler, authenticate_oauth

--- a/qiita_db/handlers/processing_job.py
+++ b/qiita_db/handlers/processing_job.py
@@ -58,6 +58,7 @@ def _job_completer(job_id, payload):
         The JSON string with the parameters of the HTTP POST request that is
         completing the job
     """
+    import qiita_db as qdb
     cmd = "%s %s %s '%s'" % (qiita_config.private_launcher, 'complete_job',
                              job_id, payload)
     std_out, std_err, return_value = qdb.processing_job._system_call(cmd)

--- a/qiita_db/handlers/tests/test_processing_job.py
+++ b/qiita_db/handlers/tests/test_processing_job.py
@@ -222,7 +222,6 @@ class CompleteHandlerTests(OauthTestingBase):
             payload, headers=self.header)
         wait_for_processing_job(job.id)
         self.assertEqual(obs.code, 200)
-        self.assertEqual(job.log.msg, 'success')
         self.assertEqual(job.status, 'success')
         self.assertEqual(qdb.util.get_count('qiita.artifact'),
                          exp_artifact_count)

--- a/qiita_db/handlers/tests/test_processing_job.py
+++ b/qiita_db/handlers/tests/test_processing_job.py
@@ -10,7 +10,7 @@ from unittest import main, TestCase
 from tempfile import mkstemp
 from json import loads, dumps
 from datetime import datetime
-from os import close, remove, environ
+from os import close, remove
 from os.path import exists
 
 from tornado.web import HTTPError

--- a/qiita_db/handlers/tests/test_processing_job.py
+++ b/qiita_db/handlers/tests/test_processing_job.py
@@ -136,7 +136,6 @@ class ActiveStepHandlerTests(OauthTestingBase):
 class CompleteHandlerTests(OauthTestingBase):
     def setUp(self):
         self._clean_up_files = []
-        environ['QIITA_CONFIG_FP'] = environ['MOI_CONFIG_FP']
         super(CompleteHandlerTests, self).setUp()
 
     def tearDown(self):

--- a/qiita_db/handlers/tests/test_processing_job.py
+++ b/qiita_db/handlers/tests/test_processing_job.py
@@ -10,7 +10,7 @@ from unittest import main, TestCase
 from tempfile import mkstemp
 from json import loads, dumps
 from datetime import datetime
-from os import close, remove
+from os import close, remove, environ
 from os.path import exists
 
 from tornado.web import HTTPError
@@ -136,6 +136,7 @@ class ActiveStepHandlerTests(OauthTestingBase):
 class CompleteHandlerTests(OauthTestingBase):
     def setUp(self):
         self._clean_up_files = []
+        environ['QIITA_CONFIG_FP'] = environ['MOI_CONFIG_FP']
         super(CompleteHandlerTests, self).setUp()
 
     def tearDown(self):

--- a/qiita_db/handlers/tests/test_processing_job.py
+++ b/qiita_db/handlers/tests/test_processing_job.py
@@ -222,6 +222,7 @@ class CompleteHandlerTests(OauthTestingBase):
             payload, headers=self.header)
         wait_for_processing_job(job.id)
         self.assertEqual(obs.code, 200)
+        self.assertEqual(job.log.msg, 'success')
         self.assertEqual(job.status, 'success')
         self.assertEqual(qdb.util.get_count('qiita.artifact'),
                          exp_artifact_count)

--- a/qiita_db/test/test_commands.py
+++ b/qiita_db/test/test_commands.py
@@ -15,8 +15,10 @@ from six import StringIO
 from future import standard_library
 from functools import partial
 from operator import itemgetter
+from json import dumps
 
 import pandas as pd
+import numpy.testing as npt
 
 from qiita_core.util import qiita_test_checker
 
@@ -400,6 +402,84 @@ class TestUpdateArtifactFromCmd(TestCase):
         for obs, exp in zip(sorted(artifact.filepaths, key=itemgetter(1)),
                             self.checksums):
             self.assertEqual(qdb.util.compute_checksum(obs[1]), exp)
+
+
+@qiita_test_checker()
+class TestCompleteJobCmd(TestCase):
+    def setUp(self):
+        self._clean_up_files = []
+
+    def tearDown(self):
+        for fp in self._clean_up_files:
+            if exists(fp):
+                remove(fp)
+
+    def test_complete_success(self):
+        pt = npt.assert_warns(
+            qdb.exceptions.QiitaDBWarning,
+            qdb.metadata_template.prep_template.PrepTemplate.create,
+            pd.DataFrame({'new_col': {'1.SKD6.640190': 1}}),
+            qdb.study.Study(1), '16S')
+        job = qdb.processing_job.ProcessingJob.create(
+            qdb.user.User('test@foo.bar'),
+            qdb.software.Parameters.load(
+                qdb.software.Command.get_validator('BIOM'),
+                values_dict={'template': pt.id, 'files':
+                             dumps({'BIOM': ['file']}),
+                             'artifact_type': 'BIOM'}))
+        job._set_status('running')
+
+        fd, fp = mkstemp(suffix='_table.biom')
+        close(fd)
+        with open(fp, 'w') as f:
+            f.write('\n')
+
+        self._clean_up_files.append(fp)
+
+        exp_artifact_count = qdb.util.get_count('qiita.artifact') + 1
+        payload = dumps(
+            {'success': True, 'error': '',
+             'artifacts': {'OTU table': {'filepaths': [(fp, 'biom')],
+                                         'artifact_type': 'BIOM'}}})
+        qdb.commands.complete_job_cmd(job.id, payload)
+        self.assertEqual(job.status, 'success')
+        self.assertEqual(qdb.util.get_count('qiita.artifact'),
+                         exp_artifact_count)
+
+    def test_complete_job_error(self):
+        payload = dumps({'success': False, 'error': 'Job failure'})
+        qdb.commands.complete_job_cmd(
+            'bcc7ebcd-39c1-43e4-af2d-822e3589f14d', payload)
+        job = qdb.processing_job.ProcessingJob(
+            'bcc7ebcd-39c1-43e4-af2d-822e3589f14d')
+        self.assertEqual(job.status, 'error')
+        self.assertEqual(job.log,
+                         qdb.logger.LogEntry.newest_records(numrecords=1)[0])
+        self.assertEqual(job.log.msg, 'Job failure')
+
+    def test_complete_error(self):
+        pt = npt.assert_warns(
+            qdb.exceptions.QiitaDBWarning,
+            qdb.metadata_template.prep_template.PrepTemplate.create,
+            pd.DataFrame({'new_col': {'1.SKD6.640190': 1}}),
+            qdb.study.Study(1), '16S')
+        job = qdb.processing_job.ProcessingJob.create(
+            qdb.user.User('test@foo.bar'),
+            qdb.software.Parameters.load(
+                qdb.software.Command.get_validator('BIOM'),
+                values_dict={'template': pt.id, 'files':
+                             dumps({'BIOM': ['file']}),
+                             'artifact_type': 'BIOM'}))
+        job._set_status('running')
+
+        fp = '/surprised/if/this/path/exists.biom'
+        payload = dumps(
+            {'success': True, 'error': '',
+             'artifacts': {'OTU table': {'filepaths': [(fp, 'biom')],
+                                         'artifact_type': 'BIOM'}}})
+        qdb.commands.complete_job_cmd(job.id, payload)
+        self.assertEqual(job.status, 'error')
+        self.assertIn('No such file or directory', job.log.msg)
 
 
 CONFIG_1 = """[required]

--- a/scripts/qiita
+++ b/scripts/qiita
@@ -91,6 +91,13 @@ def plugins():
     pass
 
 
+# The private group holds commands that should never be called by the user
+# since they are used internally by Qiita to be able to distribute compute
+@qiita.group()
+def private():
+    pass
+
+
 @ware.group()
 def ebi():
     pass
@@ -482,6 +489,17 @@ def _activate_or_update_plugins(update=False):
 def update():
     """Updates the plugins in the database"""
     _activate_or_update_plugins(update=True)
+
+
+# #############################################################################
+# PRIVATE COMMANDS
+# #############################################################################
+@private.command()
+@click.argument('job_id', required=True, type=click.STRING)
+@click.argument('payload', required=True, type=click.STRING)
+def complete_job(job_id, payload):
+    qdb.commands.complete_job_cmd(job_id, payload)
+
 
 if __name__ == '__main__':
     qiita()

--- a/scripts/qiita-private-launcher
+++ b/scripts/qiita-private-launcher
@@ -9,23 +9,22 @@
 # -----------------------------------------------------------------------------
 
 from subprocess import Popen, PIPE
-from qiita_core.qiita_settings import qiita_config
 
 import click
 
 
 @click.command()
+@click.argument('qiita_env', required=True, nargs=1)
 @click.argument('command', required=True, nargs=1)
 @click.argument('arguments', required=True, nargs=-1)
-def start(command, arguments):
+def start(qiita_env, command, arguments):
     """Starts the plugin environment"""
     cmd = ['qiita private', command]
     cmd.extend(["'%s'" % arg for arg in arguments])
     # When Popen executes, the shell is not in interactive mode,
     # so it is not sourcing any of the bash configuration files
     # We need to source it so the env_script are available
-    cmd = "source ~/.bash_profile; %s; %s" % (qiita_config.qiita_env,
-                                              ' '.join(cmd))
+    cmd = "source ~/.bash_profile; %s; %s" % (qiita_env, ' '.join(cmd))
     proc = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE)
     stdout, stderr = proc.communicate()
     if proc.returncode and proc.returncode != 0:

--- a/scripts/qiita-private-launcher
+++ b/scripts/qiita-private-launcher
@@ -37,7 +37,9 @@ def start(qiita_env, command, arguments):
     close(fd)
     with open(fp, 'w') as f:
         f.write(SCRIPT % (qiita_env, ' '.join(cmd)))
-    cmd = "sh %s" % fp
+    with open("/home/travis/trying_to_debug.txt", "w") as f:
+        f.write(SCRIPT % (qiita_env, ' '.join(cmd)))
+    cmd = "bash %s" % fp
     proc = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE)
     stdout, stderr = proc.communicate()
     remove(fp)

--- a/scripts/qiita-private-launcher
+++ b/scripts/qiita-private-launcher
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014--, The Qiita Development Team.
+#
+# Distributed under the terms of the BSD 3-clause License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# -----------------------------------------------------------------------------
+
+from subprocess import Popen, PIPE
+from qiita_core.qiita_settings import qiita_config
+
+import click
+
+
+@click.command()
+@click.argument('command', required=True, nargs=1)
+@click.argument('arguments', required=True, nargs=-1)
+def start(command, arguments):
+    """Starts the plugin environment"""
+    cmd = ['qiita private', command]
+    cmd.extend(["'%s'" % arg for arg in arguments])
+    # When Popen executes, the shell is not in interactive mode,
+    # so it is not sourcing any of the bash configuration files
+    # We need to source it so the env_script are available
+    cmd = "source ~/.bash_profile; %s; %s" % (qiita_config.qiita_env,
+                                              ' '.join(cmd))
+    proc = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE)
+    stdout, stderr = proc.communicate()
+    if proc.returncode and proc.returncode != 0:
+        raise ValueError(
+            "Error launching internal task:\n\tStdout: %s\n\tStderr: %s"
+            % (stdout, stderr))
+
+
+if __name__ == '__main__':
+    start()

--- a/scripts/qiita-private-launcher
+++ b/scripts/qiita-private-launcher
@@ -9,8 +9,20 @@
 # -----------------------------------------------------------------------------
 
 from subprocess import Popen, PIPE
+from os import close, remove
+from tempfile import mkstemp
 
 import click
+
+# When Popen executes, the shell is not in interactive mode,
+# so it is not sourcing any of the bash configuration files
+# We need to source it so the env_script are available
+SCRIPT = """#!/bin/bash
+
+source ~/.bash_profile
+%s
+%s
+"""
 
 
 @click.command()
@@ -21,14 +33,14 @@ def start(qiita_env, command, arguments):
     """Starts the plugin environment"""
     cmd = ['qiita private', command]
     cmd.extend(["'%s'" % arg for arg in arguments])
-    # When Popen executes, the shell is not in interactive mode,
-    # so it is not sourcing any of the bash configuration files
-    # We need to source it so the env_script are available
-    cmd = "source ~/.bash_profile; %s; %s" % (qiita_env, ' '.join(cmd))
-    with open('/home/travis/trying_to_debug.txt', 'w') as f:
-        f.write(cmd)
+    fd, fp = mkstemp(suffix=".sh")
+    close(fd)
+    with open(fp, 'w') as f:
+        f.write(SCRIPT % (qiita_env, ' '.join(cmd)))
+    cmd = "sh %s" % fp
     proc = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE)
     stdout, stderr = proc.communicate()
+    remove(fp)
     if proc.returncode and proc.returncode != 0:
         raise ValueError(
             "Error launching internal task:\n\tStdout: %s\n\tStderr: %s"

--- a/scripts/qiita-private-launcher
+++ b/scripts/qiita-private-launcher
@@ -25,6 +25,8 @@ def start(qiita_env, command, arguments):
     # so it is not sourcing any of the bash configuration files
     # We need to source it so the env_script are available
     cmd = "source ~/.bash_profile; %s; %s" % (qiita_env, ' '.join(cmd))
+    with open('/home/travis/trying_to_debug.txt', 'w') as f:
+        f.write(cmd)
     proc = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE)
     stdout, stderr = proc.communicate()
     if proc.returncode and proc.returncode != 0:


### PR DESCRIPTION
The PRs in other packages was failing because moi was not submitting the job. This has been a recurrent problem lately (during the Qiita workshop, a couple of deploys later, plugins tests...) so we (@antgonza and I) decided to not use moi when completing the job.

Instead, the job will be submitted to the queue (or whatever the Qiita admin actually wants) using a configuration script in a similar way that plugins are started.