### PR TITLE
fix #2030

### DIFF
--- a/qiita_pet/handlers/api_proxy/studies.py
+++ b/qiita_pet/handlers/api_proxy/studies.py
@@ -179,7 +179,7 @@ def study_prep_get_req(study_id, user_id):
                 info['start_artifact_id'] = start_artifact.id
                 info['youngest_artifact'] = '%s - %s' % (
                     youngest_artifact.name, youngest_artifact.artifact_type)
-                info['ebi_experiment'] = bool(
+                info['ebi_experiment'] = len(
                     [v for _, v in viewitems(prep.ebi_experiment_accessions)
                      if v is not None])
             else:

--- a/qiita_pet/handlers/api_proxy/tests/test_studies.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_studies.py
@@ -174,13 +174,13 @@ class TestStudyAPI(TestCase):
                        'start_artifact_id': 1,
                        'start_artifact': 'FASTQ',
                        'youngest_artifact': 'BIOM - BIOM',
-                       'ebi_experiment': True}, {
+                       'ebi_experiment': 27}, {
                        'id': 2,
                        'status': 'private',
                        'name': 'PREP 2 NAME',
                        'start_artifact': 'BIOM',
                        'youngest_artifact': 'BIOM - BIOM',
-                       'ebi_experiment': True,
+                       'ebi_experiment': 27,
                        'start_artifact_id': 7}]}}
         self.assertEqual(obs, exp)
 
@@ -200,21 +200,21 @@ class TestStudyAPI(TestCase):
                             'start_artifact_id': 1,
                             'start_artifact': 'FASTQ',
                             'youngest_artifact': 'BIOM - BIOM',
-                            'ebi_experiment': True},
+                            'ebi_experiment': 27},
                            {'id': 2,
                             'status': 'private',
                             'name': 'PREP 2 NAME',
                             'start_artifact_id': 7,
                             'start_artifact': 'BIOM',
                             'youngest_artifact': 'BIOM - BIOM',
-                            'ebi_experiment': True}],
+                            'ebi_experiment': 27}],
                    '16S': [{'id': pt.id,
                             'status': 'sandbox',
                             'name': 'PREP %d NAME' % pt.id,
                             'start_artifact_id': None,
                             'start_artifact': None,
                             'youngest_artifact': None,
-                            'ebi_experiment': False}]}}
+                            'ebi_experiment': 0}]}}
         self.assertEqual(obs, exp)
 
         obs = study_prep_get_req(1, 'admin@foo.bar')
@@ -231,7 +231,7 @@ class TestStudyAPI(TestCase):
                             'start_artifact_id': 1,
                             'start_artifact': 'FASTQ',
                             'youngest_artifact': 'BIOM - BIOM',
-                            'ebi_experiment': True}]}}
+                            'ebi_experiment': 27}]}}
         self.assertEqual(obs, exp)
         # Reset visibility of the artifacts
         for i in range(4, 0, -1):

--- a/qiita_pet/templates/study_ajax/data_type_menu.html
+++ b/qiita_pet/templates/study_ajax/data_type_menu.html
@@ -16,11 +16,11 @@
         <div id="collapse{{cleaned_dt}}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading{{cleaned_dt}}">
           <div class="panel-body">
             {% for prep in prep_info[dt] %}
+              {% if prep['ebi_experiment'] %}
+                <img src="{% raw qiita_config.portal_dir %}/static/img/ena.png" style="width:20px;height:20px;"> ({{prep['ebi_experiment']}})
+              {% end %}
               <a href="#" style="display:block;color:black;" onclick="populate_main_div('{% raw qiita_config.portal_dir %}/study/description/prep_template/', { prep_id: {{prep['id']}}, study_id: {{study_id}} });">
                 <span id="prep-header-{{prep['id']}}">
-                  {% if prep['ebi_experiment'] %}
-                    <img src="{% raw qiita_config.portal_dir %}/static/img/ena.png" style="width:20px;height:20px;">
-                  {% end %}
                   {{prep['name']}} - ID {{prep['id']}} - {{prep['status']}}
                 </span><br/>
                 {{prep['start_artifact']}} - ID {{prep['start_artifact_id']}}<br/>


### PR DESCRIPTION
Now it looks like - the number between parenthesis is the number of samples submitted:
![screen shot 2016-12-27 at 10 03 39 am](https://cloud.githubusercontent.com/assets/2014559/21504407/e7aa73ca-cc1b-11e6-8266-f71eec7c5bb8.png)
