### PR TITLE
fix #1609

### DIFF
--- a/qiita_pet/static/js/qiita.js
+++ b/qiita_pet/static/js/qiita.js
@@ -15,8 +15,8 @@ function bootstrapAlert(message, severity, timeout){
   timeout = timeout || -1;
 
   severity = typeof severity !== 'undefined' ? severity : 'danger';
-
-  var alertDiv = $('<div>', { 'class': 'alert fade in alert-'+severity, 'role': 'alert', 'id': 'bootstrap-alert'});
+  $("#alert-message").remove();
+  var alertDiv = $('<div>', { 'class': 'alert fade in alert-'+severity, 'role': 'alert', 'id': 'alert-message'});
 
   alertDiv.append('<a href="#" class="close" data-dismiss="alert">&times;</a>');
   alertDiv.append('<span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>');
@@ -32,7 +32,7 @@ function bootstrapAlert(message, severity, timeout){
   $('body').prepend(alertDiv);
 
   if(timeout > 0) {
-   window.setTimeout(function() { $('#bootstrap-alert').alert('close'); }, timeout);
+   window.setTimeout(function() { $('#alert-message').alert('close'); }, timeout);
   }
 }
 

--- a/qiita_pet/templates/list_studies.html
+++ b/qiita_pet/templates/list_studies.html
@@ -5,7 +5,7 @@
 <link rel="stylesheet" href="{% raw qiita_config.portal_dir %}/static/vendor/css/select2.min.css" type="text/css">
 
 <style>
-.alert {
+#alert-message {
   position: fixed;
   top: 50px;
   left: 40px;

--- a/qiita_pet/templates/portals_edit.html
+++ b/qiita_pet/templates/portals_edit.html
@@ -11,7 +11,7 @@
   .portal-select {
     width: 15em;
   }
-  .alert {
+  #alert-message {
     position: fixed;
     top: 55px;
     left:30%;

--- a/qiita_pet/templates/sitebase.html
+++ b/qiita_pet/templates/sitebase.html
@@ -8,6 +8,22 @@
 {% set user = current_user %}
 {% set qiita_version, qiita_sha = get_qiita_version() %}
 
+{% set level = globals().get('level', '') %}
+{% if level not in {'danger', 'success', 'info', 'warning'} %}
+    {% set level = 'info' %}
+{% end %}
+{% set message = globals().get('message', '') %}
+{% if maintenance is not None %}
+  {# maintenance mode takes precidence #}
+  {% set level = 'danger' %}
+  {% set message = maintenance %}
+{% elif sysmessage is not None %}
+  {# since this is a systemwide message, allow regular messages as well #}
+  {% set message = sysmessage + "<br />" + str(message) %}
+{% end %}
+
+
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US">
   <head>
@@ -109,17 +125,6 @@
   </head>
 
   <body style="padding-top: 0px; height: 100%" onload='overlay_check();'>
-    {% set level = globals().get('level', '') %}
-    {% set message = globals().get('message', '') %}
-    {% if maintenance is not None %}
-      {# maintenance mode takes precidence #}
-      {% set level = 'danger' %}
-      {% set message = maintenance %}
-    {% elif sysmessage is not None %}
-      {# since this is a systemwide message, allow regular messages as well #}
-      {% set message = sysmessage + "<br />" + str(message) %}
-    {% end %}
-
     <div id="navigation-bar" class="navbar navbar-inverse navbar-static-top navbar-custom" role="navigation">
       <div class="container">
         <div class="navbar-header">
@@ -274,17 +279,14 @@
     </div> <!--/.main nav-bar -->
 
     {% if message != '' %}
-        {% if level not in {'danger', 'success', 'info', 'warning'} %}
-            {% set level = 'info' %}
-        {% end %}
-        <div class="alert alert-{{ level }} alert-dismissable">
-          <a href="#" class="close" data-dismiss="alert">&times;</a>
-          <p align="center">
-            {% raw message %}
-          </p>
-        </div>
+      <div class="alert alert-{{ level }} alert-dismissable" id="main-alert-window">
+        <a href="#" class="close" data-dismiss="alert">&times;</a>
+        <p align="center">
+          {% raw message %}
+        </p>
+      </div>
     {% end %}
-
+    
     <!-- all templates should override this portion to present their main content -->
     <div id="template-content" class="container" style="width:99%">
       {% block content %}{% end %}

--- a/qiita_pet/templates/study_ajax/prep_summary.html
+++ b/qiita_pet/templates/study_ajax/prep_summary.html
@@ -399,7 +399,7 @@
     {% if alert_type != 'success' and alert_message != '' %}
       bootstrapAlert(decodeURIComponent("{% raw alert_message %}").replace(/\+/g,' '), "{{alert_type}}");
     {% else %}
-      $('#bootstrap-alert').alert('close');
+      $('#alert-message').alert('close');
     {% end %}
   });
 </script>

--- a/qiita_pet/templates/study_ajax/sample_prep_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_prep_summary.html
@@ -82,7 +82,7 @@
     {% if alert_type != 'success' and alert_message != '' %}
       bootstrapAlert('{% raw alert_message %}', "{{alert_type}}");
     {% else %}
-      $('#bootstrap-alert').alert('close');
+      $('#alert-message').alert('close');
     {% end %}
   });
 

--- a/qiita_pet/templates/study_ajax/sample_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_summary.html
@@ -80,7 +80,7 @@
     {% if alert_type != 'success' and alert_message != '' %}
       bootstrapAlert(decodeURIComponent("{% raw alert_message %}").replace(/\+/g,' '), "{{alert_type}}");
     {% else %}
-      $('#bootstrap-alert').alert('close');
+      $('#alert-message').alert('close');
     {% end %}
   });
 </script>


### PR DESCRIPTION
Turns out that the fix was easier than expected.

Now it looks like this with just the alert message:
Example 1:
![screen shot 2016-12-27 at 8 17 18 pm](https://cloud.githubusercontent.com/assets/2014559/21513193/fd8a4e20-cc72-11e6-91ea-2a241c66c1a4.png)
Example 2:
![screen shot 2016-12-27 at 8 17 03 pm](https://cloud.githubusercontent.com/assets/2014559/21513199/0d992cdc-cc73-11e6-8d30-a598dd30e5b8.png)
and with the extra message:
![screen shot 2016-12-27 at 8 16 53 pm](https://cloud.githubusercontent.com/assets/2014559/21513204/1b8f678e-cc73-11e6-92fb-af92f417839c.png)
and adding samples to analysis:
![screen shot 2016-12-27 at 8 17 51 pm](https://cloud.githubusercontent.com/assets/2014559/21513226/4f1eb1ae-cc73-11e6-9b32-45970aaa92a5.png)
