### PR TITLE
fix #1066

### DIFF
--- a/qiita_ware/context.py
+++ b/qiita_ware/context.py
@@ -60,6 +60,14 @@ class Dispatch(object):
     def __init__(self):
         from moi import ctx_default
         self.demo = Client(profile=ctx_default)
+
+        # checking that at least 2 workers exist, see:
+        # https://github.com/biocore/qiita/issues/1066
+        workers = len(self.demo.ids)
+        if workers < 2:
+            raise ValueError('You need to have at least 2 IPython workers '
+                             'but you have %d' % workers)
+
         self.demo_lview = self.demo.load_balanced_view()
 
     def sync(self, data):


### PR DESCRIPTION
```bash
(qiita)07:38:15 qiita@master$ ipcluster start --profile=qiita_demo -n 1 &
(qiita)07:38:19 qiita@master$ 
(qiita)07:38:20 qiita@master$ ipcluster stop --profile=qiitaqiita pet webserver --no-build-docs start
/Users/antoniog/svn_programs/qiita/qiita_core/configuration_manager.py:230: UserWarning: Random cookie secret generated.
  warnings.warn("Random cookie secret generated.")
Traceback (most recent call last):
  File "/Users/antoniog/svn_programs/qiita/scripts/qiita", line 30, in <module>
    from qiita_ware.context import system_call, ComputeError
  File "/Users/antoniog/svn_programs/qiita/qiita_ware/context.py", line 274, in <module>
    context = Dispatch()
  File "/Users/antoniog/svn_programs/qiita/qiita_ware/context.py", line 69, in __init__
    'but you have %d' % workers)
ValueError: You need to have at least 2 IPython workers but you have 1
```
