### PR TITLE
fixing edit check access

### DIFF
--- a/qiita_pet/handlers/study_handlers/base.py
+++ b/qiita_pet/handlers/study_handlers/base.py
@@ -62,6 +62,7 @@ class StudyBaseInfoAJAX(BaseHandler):
 
 
 class StudyDeleteAjax(BaseHandler):
+    @authenticated
     def post(self):
         study_id = self.get_argument('study_id')
         self.write(study_delete_req(int(study_id), self.current_user.id))

--- a/qiita_pet/handlers/study_handlers/edit_handlers.py
+++ b/qiita_pet/handlers/study_handlers/edit_handlers.py
@@ -166,7 +166,7 @@ class StudyEditHandler(BaseHandler):
             raise HTTPError(404, "Study %s does not exist" % study_id)
 
         # We need to check if the user has access to the study
-        check_access(self.current_user, study)
+        check_access(self.current_user, study, raise_error=True)
         return study
 
     def _get_study_person_id(self, index, new_people_info):

--- a/qiita_pet/handlers/study_handlers/tests/test_edit_handlers.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_edit_handlers.py
@@ -7,9 +7,12 @@
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
 from unittest import main
+from mock import Mock
 
+from qiita_pet.handlers.base_handlers import BaseHandler
 from qiita_pet.test.tornado_test_base import TestHandlerBase
 from qiita_db.study import StudyPerson, Study
+from qiita_db.user import User
 from qiita_db.util import get_count, check_count
 
 
@@ -126,12 +129,26 @@ class TestStudyEditHandler(TestHandlerBase):
             'principal_investigator': study_info['principal_investigator'].id,
             'lab_person': study_info['lab_person'].id}
 
-        self.post('/study/edit/1', post_data)
-
+        response = self.post('/study/edit/1', post_data)
+        self.assertEqual(response.code, 200)
         # Check that the study was updated
         self.assertTrue(check_count('qiita.study', study_count_before))
         self.assertEqual(study.title, 'New title - test post edit')
         self.assertEqual(study.publications, [])
+
+        # check for failure
+        old_title = post_data['study_title']
+        post_data['study_title'] = 'My new title!'
+        shared = User('shared@foo.bar')
+        study.unshare(shared)
+        BaseHandler.get_current_user = Mock(return_value=shared)
+        response = self.post('/study/edit/1', post_data)
+        self.assertEqual(response.code, 403)
+        # Check that the study wasn't updated
+        self.assertEqual(study.title, old_title)
+
+        # returning sharing
+        study.share(shared)
 
 
 class TestCreateStudyAJAX(TestHandlerBase):


### PR DESCRIPTION
The issue was that qiita_pet.handlers.util.check_access within the edit wasn't raising an error (due to parameters passed). I added this, a test and also checked everywhere that method is used to make sure that we didn't have the same issue. Note that we have other 2 check_access methods: qiita_pet.handlers.api_proxy.util and qiita_pet.handlers.logger_handlers.

cc: @tanaes 