### PR TITLE
public studies are being shown in the user own studies

### DIFF
--- a/qiita_pet/handlers/study_handlers/listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/listing_handlers.py
@@ -71,15 +71,16 @@ def _build_study_info(user, search_type, study_proc=None, proc_samples=None):
         build_samples = True
 
     # get list of studies for table
+    user_study_set = user.user_studies.union(user.shared_studies)
     if search_type == 'user':
-        user_study_set = user.user_studies.union(user.shared_studies)
         if user.level == 'admin':
             user_study_set = (user_study_set |
                               Study.get_by_status('sandbox') |
-                              Study.get_by_status('private'))
-        study_set = user_study_set - Study.get_by_status('public')
+                              Study.get_by_status('private') -
+                              Study.get_by_status('public'))
+        study_set = user_study_set
     elif search_type == 'public':
-        study_set = Study.get_by_status('public')
+        study_set = Study.get_by_status('public') - user_study_set
     else:
         raise ValueError('Not a valid search type')
     if study_proc is not None:

--- a/qiita_pet/handlers/study_handlers/tests/test_listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_listing_handlers.py
@@ -84,8 +84,36 @@ class TestHelpers(TestHandlerBase):
         self.exp = [self.single_exp]
 
     def test_build_study_info(self):
+        for a in Study(1).artifacts():
+            a.visibility='private'
+
         obs = _build_study_info(User('test@foo.bar'), 'user')
         self.assertEqual(obs, self.exp)
+
+        obs = _build_study_info(User('test@foo.bar'), 'public')
+        self.assertEqual(obs, [])
+
+        obs = _build_study_info(User('demo@microbio.me'), 'public')
+        self.assertEqual(obs, [])
+
+        # make all the artifacts public - (1) the only study in the tests,
+        for a in Study(1).artifacts():
+            a.visibility='public'
+        self.exp[0]['status'] = 'public'
+
+        obs = _build_study_info(User('test@foo.bar'), 'user')
+        self.assertEqual(obs, self.exp)
+
+        obs = _build_study_info(User('test@foo.bar'), 'public')
+        self.assertEqual(obs, [])
+
+        obs = _build_study_info(User('demo@microbio.me'), 'public')
+        self.assertEqual(obs, self.exp)
+
+        # return to it's private status
+        for a in Study(1).artifacts():
+            a.visibility='private'
+
 
     def test_build_study_info_erros(self):
         with self.assertRaises(IncompetentQiitaDeveloperError):

--- a/qiita_pet/handlers/study_handlers/tests/test_listing_handlers.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_listing_handlers.py
@@ -85,7 +85,7 @@ class TestHelpers(TestHandlerBase):
 
     def test_build_study_info(self):
         for a in Study(1).artifacts():
-            a.visibility='private'
+            a.visibility = 'private'
 
         obs = _build_study_info(User('test@foo.bar'), 'user')
         self.assertEqual(obs, self.exp)
@@ -98,7 +98,7 @@ class TestHelpers(TestHandlerBase):
 
         # make all the artifacts public - (1) the only study in the tests,
         for a in Study(1).artifacts():
-            a.visibility='public'
+            a.visibility = 'public'
         self.exp[0]['status'] = 'public'
 
         obs = _build_study_info(User('test@foo.bar'), 'user')
@@ -112,8 +112,7 @@ class TestHelpers(TestHandlerBase):
 
         # return to it's private status
         for a in Study(1).artifacts():
-            a.visibility='private'
-
+            a.visibility = 'private'
 
     def test_build_study_info_erros(self):
         with self.assertRaises(IncompetentQiitaDeveloperError):


### PR DESCRIPTION
This fixes: 
- https://github.com/biocore/qiita/issues/2069, now the public study is shown in the owner/shared section so the button is automatically added
- and the idea that the owner's studies should always be in their own list even if public but for other users it should be in the public list

Note that these changes will make a lot of the tests fail but want to see which are they ... 