### PR TITLE
fixing download buttons show

### DIFF
--- a/qiita_pet/handlers/api_proxy/studies.py
+++ b/qiita_pet/handlers/api_proxy/studies.py
@@ -105,6 +105,11 @@ def study_get_req(study_id, user_id):
     study_info['has_access_to_raw_data'] = study.has_access(
         User(user_id), True)
 
+    study_info['show_biom_download_button'] = 'BIOM' in [
+        a.artifact_type for a in study.artifacts()]
+    study_info['show_raw_download_button'] = bool([
+        True for pt in study.prep_templates() if pt.artifact is not None])
+
     return {'status': 'success',
             'message': '',
             'study_info': study_info,

--- a/qiita_pet/handlers/api_proxy/studies.py
+++ b/qiita_pet/handlers/api_proxy/studies.py
@@ -107,7 +107,7 @@ def study_get_req(study_id, user_id):
 
     study_info['show_biom_download_button'] = 'BIOM' in [
         a.artifact_type for a in study.artifacts()]
-    study_info['show_raw_download_button'] = bool([
+    study_info['show_raw_download_button'] = any([
         True for pt in study.prep_templates() if pt.artifact is not None])
 
     return {'status': 'success',

--- a/qiita_pet/handlers/api_proxy/tests/test_studies.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_studies.py
@@ -95,6 +95,8 @@ class TestStudyAPI(TestCase):
                 'owner': 'test@foo.bar',
                 'ebi_submission_status': 'submitted',
                 'has_access_to_raw_data': True,
+                'show_biom_download_button': True,
+                'show_raw_download_button': True,
                 'ebi_study_accession': 'EBI123456-BB'},
             'editable': True}
         self.assertEqual(obs, exp)

--- a/qiita_pet/templates/study_base.html
+++ b/qiita_pet/templates/study_base.html
@@ -239,8 +239,10 @@
       <a class="btn btn-default btn-block" href="{% raw qiita_config.portal_dir %}/study/upload/{{study_info['study_id']}}"><span class="glyphicon glyphicon-upload"></span> Upload Files</a>
       <button class="btn btn-default btn-block" onclick="populate_main_div('{% raw qiita_config.portal_dir %}/study/new_prep_template/', { study_id: {{study_info['study_id']}} })" id="add-new-preparation-btn"><span class="glyphicon glyphicon-plus-sign"></span> Add New Preparation</button>
     {% end %}
-    <a class="btn btn-default btn-block" href="{% raw qiita_config.portal_dir %}/download_study_bioms/{{study_info['study_id']}}"><span class="glyphicon glyphicon-download-alt"></span> All QIIME maps and BIOMs</a>
-    {% if study_info['has_access_to_raw_data'] %}
+    {% if study_info['show_biom_download_button'] %}
+      <a class="btn btn-default btn-block" href="{% raw qiita_config.portal_dir %}/download_study_bioms/{{study_info['study_id']}}"><span class="glyphicon glyphicon-download-alt"></span> All QIIME maps and BIOMs</a>
+    {% end %}
+    {% if study_info['has_access_to_raw_data'] and study_info['show_raw_download_button'] %}
       <a class="btn btn-default btn-block" href="{% raw qiita_config.portal_dir %}/download_raw_data/{{study_info['study_id']}}"><span class="glyphicon glyphicon-download-alt"></span> All raw data</a>
     {% end %}
     <div style="text-align: center;"><small><a href="{% raw qiita_config.portal_dir %}/static/doc/html/faq.html#how-to-solve-unzip-errors">Issues opening the downloaded zip?</a></small></div>


### PR DESCRIPTION
Currently, the download bioms and raw data is always present, this will only show the buttons when there is data to download. 