### PR TITLE
Redbiom improving listing

### DIFF
--- a/qiita_pet/handlers/qiita_redbiom.py
+++ b/qiita_pet/handlers/qiita_redbiom.py
@@ -96,8 +96,7 @@ class RedbiomPublicSearch(BaseHandler):
                                     a.artifact_id
                             JOIN qiita.artifact_type at ON (
                                 at.artifact_type_id = a.artifact_type_id
-                                AND artifact_type = 'BIOM')
-                            ORDER BY artifact_id),
+                                AND artifact_type = 'BIOM')),
                          parent_query AS (
                             SELECT artifact_query.*,
                                 array_agg(parent_params) as parent_parameters
@@ -114,6 +113,7 @@ class RedbiomPublicSearch(BaseHandler):
                                 artifact_query.command_id,
                                 artifact_query.artifact_id)
                         SELECT * FROM parent_query
+                        ORDER BY parent_parameters, artifact_id
                         """
 
                         sql_params = """

--- a/qiita_pet/static/js/qiita.js
+++ b/qiita_pet/static/js/qiita.js
@@ -301,17 +301,3 @@ function display_number_of_samples_added(num_samples) {
   bootstrapAlert(num_samples + ' samples selected.', "success", 10000);
   $('#dflt-sel-info').css('color', 'rgb(0, 160, 0)');
 }
-
-/**
- *
- * Function to show the loading gif in a given div
- *
- * @param div_name string with the name of the div to populate with the loading gif
- *
- * This function replaces the content of the given div with the
- * gif to show that the section of page is loading
- *
- */
-function show_loading(div_name) {
-    $("#" + div_name).html("<img src='{% raw qiita_config.portal_dir %}/static/img/waiting.gif' style='display:block;margin-left: auto;margin-right: auto'/>");
-}

--- a/qiita_pet/templates/redbiom.html
+++ b/qiita_pet/templates/redbiom.html
@@ -13,6 +13,9 @@
     $("#redbiom-table").dataTable({
       "dom": 'lfrt<"footer">ip',
       'footerCallback': function ( row, data, start, end, display ) {
+
+        // adding total features found
+
         var api = this.api(), data;
         var total_features = api
           .column(4)
@@ -30,34 +33,40 @@
           }
         }
         $('.footer').html(text)
+
+        // adding selectors for filtering
+
+        this.api().columns().every( function (iterator) {
+          var column = this;
+          if (iterator == 3 && column.data().length != 0) {
+            var select = $('<select><option value=""></option></select>')
+              .appendTo( $(column.footer()).empty() )
+              .on('change', function () {
+                var val = $.fn.dataTable.util.escapeRegex( $(this).val() );
+                column
+                  .search( val ? '^'+val+'$' : '', true, false )
+                  .draw();
+              });
+            var added = [];
+            column.data().each(function (d){
+              var cmd = d.command;
+              if (added.indexOf(cmd) == -1){
+                added.push(cmd);
+                select.append('<option value="' + cmd + '">' + cmd + '</option>');
+              }
+            });
+          }
+        });
       },
       "columns": [
         { "data": null, "orderable": false, "width": "10%" },
         { "data": null, "width": "40%"  },
-        { "data": "aname", "width": "20%"  },
-        { "data": null, "width": "20%"  },
+        { "data": null, "width": "10%"  },
+        { "data": null, "width": "30%"  },
         { "data": null, "width": "10%" }
       ],
-      "order": [[ 3, 'asc' ]],
-      // "displayLength": 25,
-      "drawCallback": function ( settings ) {
-          var api = this.api();
-          var rows = api.rows( {page:'current'} ).nodes();
-          var last=null;
-
-          api.column(3, {page:'current'} ).data().each( function ( data, i ) {
-            group = data.command;
-            if ( last !== group ) {
-              $(rows).eq( i ).before(
-                '<tr class="group"><td colspan="5">'+group+'</td></tr>'
-              );
-              last = group;
-            }
-          });
-      },
       columnDefs: [
-        { "visible": false, "targets": 3 },
-        { type:'natural', targets: [1,2,4] },
+        { type:'natural', targets: [1,2,3,4] },
         // render Add to Analysis button
         {"render": function ( data, type, row, meta ) {
           var text = '';
@@ -87,6 +96,10 @@
           }
           return text;
         }, targets: [2]},
+        // render # of samples/categories
+        {"render": function ( data, type, row, meta ) {
+          return row.command;
+        }, targets: [3]},
         // render # of samples/categories
         {"render": function ( data, type, row, meta ) {
           return row.samples.length;
@@ -127,15 +140,16 @@
               var header_0 =  "";
             {% end %}
             var header_2 =  "Artifact Name";
-            var header_3 =  "# of Samples Found";
+            var header_4 =  "# of Samples";
             if (search_on == 'categories') {
               header_2 =  "Metadata Categories";
-              header_3 =  "# of Categories Found";
+              header_4 =  "# of Categories";
             }
             $('#redbiom-table tr:eq(0) th:eq(0)').text(header_0);
             $('#redbiom-table tr:eq(0) th:eq(1)').text("Study Title");
             $('#redbiom-table tr:eq(0) th:eq(2)').text(header_2);
-            $('#redbiom-table tr:eq(0) th:eq(3)').text(header_3);
+            $('#redbiom-table tr:eq(0) th:eq(3)').text("Processing Parameters");
+            $('#redbiom-table tr:eq(0) th:eq(4)').text(header_4);
 
             redbiom_table.rows.add(data.data).draw();
             redbiom_info.html('');
@@ -143,19 +157,6 @@
         }
       });
     });
-
-    // Order by the grouping
-    $('#redbiom-table tbody').on( 'click', 'tr.group', function () {
-      var table = $('#redbiom-table').DataTable();
-      var currentOrder = table.order()[0];
-      if (currentOrder[0] === 3 && currentOrder[1] === 'asc') {
-        table.order([ 3, 'desc' ]).draw();
-      }
-      else {
-        table.order([ 3, 'asc' ]).draw();
-      }
-    });
-
   });
 </script>
 
@@ -199,6 +200,15 @@
           <th></th>
         </tr>
       </thead>
+      <tfoot>
+        <tr>
+          <th></th>
+          <th></th>
+          <th></th>
+          <th></th>
+          <th></th>
+        </tr>
+      </tfoot>
     </table>
   </div>
 

--- a/qiita_pet/templates/redbiom.html
+++ b/qiita_pet/templates/redbiom.html
@@ -11,7 +11,7 @@
     moi.init(null, window.location.host + '{% raw qiita_config.portal_dir %}/study/list/socket/', function(){}, error, error);
     moi.add_callback('sel', display_number_of_samples_added);
     $("#redbiom-table").dataTable({
-      "dom": 'lfrt<"footer">ip',
+      "dom": '<"ps">lfr<t><"footer">ip',
       'footerCallback': function ( row, data, start, end, display ) {
 
         // adding total features found
@@ -39,20 +39,24 @@
         this.api().columns().every( function (iterator) {
           var column = this;
           if (iterator == 3 && column.data().length != 0) {
-            var select = $('<select><option value=""></option></select>')
-              .appendTo( $(column.footer()).empty() )
+            var placer = $(".ps");
+            placer.empty();
+            placer.append("<b>Filter by Processing paramters</b>: ")
+            var selector = $('<select><option value=""></option></select>')
+              .appendTo( placer )
               .on('change', function () {
                 var val = $.fn.dataTable.util.escapeRegex( $(this).val() );
                 column
                   .search( val ? '^'+val+'$' : '', true, false )
                   .draw();
               });
+
             var added = [];
             column.data().each(function (d){
               var cmd = d.command;
               if (added.indexOf(cmd) == -1){
                 added.push(cmd);
-                select.append('<option value="' + cmd + '">' + cmd + '</option>');
+                selector.append('<option value="' + cmd + '">' + cmd + '</option>');
               }
             });
           }
@@ -110,7 +114,7 @@
         }, targets: [4]}
       ],
       "language": {
-          "search": "Filter results by column data (Study Name, Artifact Name, Software, etc):",
+          "search": "Filter results by column data:",
           "loadingRecords": "Please wait - loading information ...",
           "zeroRecords": "  "
       },
@@ -128,7 +132,11 @@
       .done(function ( data ){
         var redbiom_table = $('#redbiom-table').DataTable();
         var redbiom_info = $('#redbiom-info');
+        // the next 4 lines reset the column filtering
+        var placer = $(".ps");
+        redbiom_table.column(3).search("").draw();
         redbiom_table.clear().draw();
+        placer.empty();
         if(data.status == "error") {
           bootstrapAlert(data.message.replace("\n", "<br/>"), "danger");
         } else {
@@ -156,7 +164,6 @@
             $('#redbiom-table tr:eq(0) th:eq(2)').text(header_2);
             $('#redbiom-table tr:eq(0) th:eq(3)').text(header_3);
             $('#redbiom-table tr:eq(0) th:eq(4)').text(header_4);
-
             redbiom_table.rows.add(data.data).draw();
             redbiom_info.html('');
           }
@@ -206,15 +213,6 @@
           <th></th>
         </tr>
       </thead>
-      <tfoot>
-        <tr>
-          <th></th>
-          <th></th>
-          <th></th>
-          <th></th>
-          <th></th>
-        </tr>
-      </tfoot>
     </table>
   </div>
 

--- a/qiita_pet/templates/redbiom.html
+++ b/qiita_pet/templates/redbiom.html
@@ -38,8 +38,26 @@
         { "data": null, "width": "20%"  },
         { "data": null, "width": "10%" }
       ],
+      "order": [[ 3, 'asc' ]],
+      // "displayLength": 25,
+      "drawCallback": function ( settings ) {
+          var api = this.api();
+          var rows = api.rows( {page:'current'} ).nodes();
+          var last=null;
+
+          api.column(3, {page:'current'} ).data().each( function ( data, i ) {
+            group = data.command;
+            if ( last !== group ) {
+              $(rows).eq( i ).before(
+                '<tr class="group"><td colspan="5">'+group+'</td></tr>'
+              );
+              last = group;
+            }
+          });
+      },
       columnDefs: [
-        {type:'natural', targets:[1,2,3,4]},
+        { "visible": false, "targets": 3 },
+        { type:'natural', targets: [1,2,4] },
         // render Add to Analysis button
         {"render": function ( data, type, row, meta ) {
           {% if current_user is not None %}
@@ -86,46 +104,59 @@
       },
   });
 
-    $("#submitForm").submit(function(event){
-      event.preventDefault();
+  $("#submitForm").submit(function(event){
+    event.preventDefault();
 
-      show_loading("redbiom-info");
+    show_loading("redbiom-info");
 
-      var search = $("#search").val();
-      var search_on = $("#search_on").val();
+    var search = $("#search").val();
+    var search_on = $("#search_on").val();
 
-      $.post("{% raw qiita_config.portal_dir %}/redbiom/", {'search': search, 'search_on': search_on})
-        .done(function ( data ){
-          var redbiom_table = $('#redbiom-table').DataTable();
-          var redbiom_info = $('#redbiom-info');
-          redbiom_table.clear().draw();
-          if(data.status == "error") {
-            bootstrapAlert(data.message.replace("\n", "<br/>"), "danger");
-          } else {
-            if(data.message != ''){
-              redbiom_info.html(
-                `<div class="alert alert-warning alert-dismissible" role="alert">
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <strong>Warning!</strong> ` + data.message + `</div><br/>`)
-            } else if(data.data){
-              $('#redbiom-table tr:eq(0) th:eq(1)').text("Study Title");
-              if (search_on != 'categories') {
-                {% if current_user is not None %}
-                  $('#redbiom-table tr:eq(0) th:eq(0)').text("Add to Analysis");
-                {% end %}
-                $('#redbiom-table tr:eq(0) th:eq(2)').text("Artifact Name");
-                $('#redbiom-table tr:eq(0) th:eq(3)').text("Artifact Processing");
-                $('#redbiom-table tr:eq(0) th:eq(4)').text("# of Samples Found");
-              } else {
-                $('#redbiom-table tr:eq(0) th:eq(3)').text("Metadata Categories");
-                $('#redbiom-table tr:eq(0) th:eq(4)').text("# of Categories Found");
-              }
-              redbiom_table.rows.add(data.data).draw();
-              redbiom_info.html('');
+    $.post("{% raw qiita_config.portal_dir %}/redbiom/", {'search': search, 'search_on': search_on})
+      .done(function ( data ){
+        var redbiom_table = $('#redbiom-table').DataTable();
+        var redbiom_info = $('#redbiom-info');
+        redbiom_table.clear().draw();
+        if(data.status == "error") {
+          bootstrapAlert(data.message.replace("\n", "<br/>"), "danger");
+        } else {
+          if(data.message != ''){
+            redbiom_info.html(
+              `<div class="alert alert-warning alert-dismissible" role="alert">
+              <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+              <strong>Warning!</strong> ` + data.message + `</div><br/>`)
+          } else if(data.data){
+            $('#redbiom-table tr:eq(0) th:eq(1)').text("Study Title");
+            if (search_on != 'categories') {
+              {% if current_user is not None %}
+                $('#redbiom-table tr:eq(0) th:eq(0)').text("Add to Analysis");
+              {% end %}
+              $('#redbiom-table tr:eq(0) th:eq(2)').text("Artifact Name");
+              $('#redbiom-table tr:eq(0) th:eq(3)').text("Artifact Processing");
+              $('#redbiom-table tr:eq(0) th:eq(4)').text("# of Samples Found");
+            } else {
+              $('#redbiom-table tr:eq(0) th:eq(3)').text("Metadata Categories");
+              $('#redbiom-table tr:eq(0) th:eq(4)').text("# of Categories Found");
             }
+            redbiom_table.rows.add(data.data).draw();
+            redbiom_info.html('');
           }
-        });
+        }
+      });
     });
+
+    // Order by the grouping
+    $('#redbiom-table tbody').on( 'click', 'tr.group', function () {
+      var table = $('#redbiom-table').DataTable();
+      var currentOrder = table.order()[0];
+      if (currentOrder[0] === 3 && currentOrder[1] === 'asc') {
+        table.order([ 3, 'desc' ]).draw();
+      }
+      else {
+        table.order([ 3, 'asc' ]).draw();
+      }
+    });
+
   });
 </script>
 

--- a/qiita_pet/templates/redbiom.html
+++ b/qiita_pet/templates/redbiom.html
@@ -88,17 +88,21 @@
           {% end %}
           return text;
         }, targets: [1]},
-        // render Artifact Name or Metadata Categories
+        // render Artifact Name
         {"render": function ( data, type, row, meta ) {
           var text = row.aname;
+          if ($("#search_on").val() == 'categories'){
+            text = '';
+          }
+          return text;
+        }, targets: [2]},
+        // render Processing Parameters or Metadata Categories
+        {"render": function ( data, type, row, meta ) {
+          var text = row.command;
           if ($("#search_on").val() == 'categories'){
             text = row.samples.join(', ');
           }
           return text;
-        }, targets: [2]},
-        // render # of samples/categories
-        {"render": function ( data, type, row, meta ) {
-          return row.command;
         }, targets: [3]},
         // render # of samples/categories
         {"render": function ( data, type, row, meta ) {
@@ -139,16 +143,18 @@
             {% else %}
               var header_0 =  "";
             {% end %}
-            var header_2 =  "Artifact Name";
-            var header_4 =  "# of Samples";
+            var header_2 = "Artifact Name";
+            var header_3 = "Processing Parameters";
+            var header_4 = "# of Samples";
             if (search_on == 'categories') {
-              header_2 =  "Metadata Categories";
-              header_4 =  "# of Categories";
+              header_2 = "";
+              header_3 = "Metadata Categories";
+              header_4 = "# of Categories";
             }
             $('#redbiom-table tr:eq(0) th:eq(0)').text(header_0);
             $('#redbiom-table tr:eq(0) th:eq(1)').text("Study Title");
             $('#redbiom-table tr:eq(0) th:eq(2)').text(header_2);
-            $('#redbiom-table tr:eq(0) th:eq(3)').text("Processing Parameters");
+            $('#redbiom-table tr:eq(0) th:eq(3)').text(header_3);
             $('#redbiom-table tr:eq(0) th:eq(4)').text(header_4);
 
             redbiom_table.rows.add(data.data).draw();

--- a/qiita_pet/templates/redbiom.html
+++ b/qiita_pet/templates/redbiom.html
@@ -60,11 +60,12 @@
         { type:'natural', targets: [1,2,4] },
         // render Add to Analysis button
         {"render": function ( data, type, row, meta ) {
+          var text = '';
           {% if current_user is not None %}
-            var text = '<input type="button" class="btn btn-sm" value="Add to analysis" onclick="redbiom_send_to_moi(' +
-                       row.artifact_id + ', ' + meta.row + ')">';
-          {% else %}
-            var text = '';
+            if ($("#search_on").val() != 'categories'){
+              var text = '<input type="button" class="btn btn-sm" value="Add to analysis" onclick="redbiom_send_to_moi(' +
+                         row.artifact_id + ', ' + meta.row + ')">';
+            }
           {% end %}
           return text;
         }, targets: [0]},
@@ -78,21 +79,15 @@
           {% end %}
           return text;
         }, targets: [1]},
-        // render Artifact Processing
+        // render Artifact Name or Metadata Categories
         {"render": function ( data, type, row, meta ) {
-            var text = '';
-            if (!(!row.command)) {
-              text += row.command;
-            }
-            if (!(!row.software)) {
-              text += ' ' + row.software;
-            }
-            if (!(!row.version)) {
-              text += ' v' + row.version;
-            }
+          var text = row.aname;
+          if ($("#search_on").val() == 'categories'){
+            text = row.samples.join(', ');
+          }
           return text;
-        }, targets: [3]},
-        // render Artifact Processing
+        }, targets: [2]},
+        // render # of samples/categories
         {"render": function ( data, type, row, meta ) {
           return row.samples.length;
         }, targets: [4]}
@@ -126,18 +121,22 @@
               <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
               <strong>Warning!</strong> ` + data.message + `</div><br/>`)
           } else if(data.data){
-            $('#redbiom-table tr:eq(0) th:eq(1)').text("Study Title");
-            if (search_on != 'categories') {
-              {% if current_user is not None %}
-                $('#redbiom-table tr:eq(0) th:eq(0)').text("Add to Analysis");
-              {% end %}
-              $('#redbiom-table tr:eq(0) th:eq(2)').text("Artifact Name");
-              $('#redbiom-table tr:eq(0) th:eq(3)').text("Artifact Processing");
-              $('#redbiom-table tr:eq(0) th:eq(4)').text("# of Samples Found");
-            } else {
-              $('#redbiom-table tr:eq(0) th:eq(3)').text("Metadata Categories");
-              $('#redbiom-table tr:eq(0) th:eq(4)').text("# of Categories Found");
+            {% if current_user is not None %}
+              var header_0 =  "Add to Analysis";
+            {% else %}
+              var header_0 =  "";
+            {% end %}
+            var header_2 =  "Artifact Name";
+            var header_3 =  "# of Samples Found";
+            if (search_on == 'categories') {
+              header_2 =  "Metadata Categories";
+              header_3 =  "# of Categories Found";
             }
+            $('#redbiom-table tr:eq(0) th:eq(0)').text(header_0);
+            $('#redbiom-table tr:eq(0) th:eq(1)').text("Study Title");
+            $('#redbiom-table tr:eq(0) th:eq(2)').text(header_2);
+            $('#redbiom-table tr:eq(0) th:eq(3)').text(header_3);
+
             redbiom_table.rows.add(data.data).draw();
             redbiom_info.html('');
           }

--- a/qiita_pet/templates/sitebase.html
+++ b/qiita_pet/templates/sitebase.html
@@ -54,6 +54,20 @@
     <link rel="shortcut icon" href="{% raw qiita_config.portal_dir %}/static/img/favicon.ico">
 
     <script>
+      /**
+       *
+       * Function to show the loading gif in a given div
+       *
+       * @param div_name string with the name of the div to populate with the loading gif
+       *
+       * This function replaces the content of the given div with the
+       * gif to show that the section of page is loading
+       *
+       */
+      function show_loading(div_name) {
+          $("#" + div_name).html("<img src='{% raw qiita_config.portal_dir %}/static/img/waiting.gif' style='display:block;margin-left: auto;margin-right: auto'/>");
+      }
+
       function overlay_check() {
         // from http://stackoverflow.com/q/5916900/379593
         var ua=navigator.userAgent,tem,M=ua.match(/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];

--- a/qiita_pet/test/test_qiita_redbiom.py
+++ b/qiita_pet/test/test_qiita_redbiom.py
@@ -123,41 +123,44 @@ class TestRedbiom(TestHandlerBase):
 
 
 OBSERVATION = [
-    {'artifact_id': 4, 'study_id': 1, 'version': '1.9.1',
-     'command': 'Pick closed-reference OTUs', 'samples': [
+    {'artifact_id': 4, 'study_id': 1,
+     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Split libraries FASTQ', 'samples': [
         '1.SKD1.640179', '1.SKD2.640178', '1.SKD3.640198', '1.SKD4.640185',
         '1.SKD5.640186', '1.SKD6.640190', '1.SKD7.640191', '1.SKD8.640184',
         '1.SKD9.640182'],
      'study_title': 'Identification of the Microbiomes for Cannabis Soils',
-     'aname': 'BIOM', 'software': 'QIIME'},
-    {'artifact_id': 5, 'study_id': 1, 'version': '1.9.1',
-     'command': 'Pick closed-reference OTUs', 'samples': [
+     'aname': 'BIOM'},
+    {'artifact_id': 5, 'study_id': 1,
+     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Split libraries FASTQ', 'samples': [
         '1.SKD1.640179', '1.SKD2.640178', '1.SKD3.640198', '1.SKD4.640185',
         '1.SKD5.640186', '1.SKD6.640190', '1.SKD7.640191', '1.SKD8.640184',
         '1.SKD9.640182'],
      'study_title': 'Identification of the Microbiomes for Cannabis Soils',
-     'aname': 'BIOM', 'software': 'QIIME'},
-    {'artifact_id': 6, 'study_id': 1, 'version': u'1.9.1',
-     'command': 'Pick closed-reference OTUs', 'samples': [
+     'aname': 'BIOM'},
+    {'artifact_id': 6, 'study_id': 1,
+     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Split libraries FASTQ', 'samples': [
         '1.SKD1.640179', '1.SKD2.640178', '1.SKD3.640198', '1.SKD4.640185',
         '1.SKD5.640186', '1.SKD6.640190', '1.SKD7.640191', '1.SKD8.640184',
         '1.SKD9.640182'],
      'study_title': 'Identification of the Microbiomes for Cannabis Soils',
-     'aname': 'BIOM', 'software': 'QIIME'}]
+     'aname': 'BIOM'}]
 
 SEQUENCE = [
-    {'artifact_id': 4, 'study_id': 1, 'version': '1.9.1',
-     'command': 'Pick closed-reference OTUs', 'samples': ['1.SKM3.640197'],
+    {'artifact_id': 4, 'study_id': 1,
+     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Split libraries FASTQ',
+     'samples': ['1.SKM3.640197'],
      'study_title': 'Identification of the Microbiomes for Cannabis Soils',
-     'aname': 'BIOM', 'software': 'QIIME'},
-    {'artifact_id': 5, 'study_id': 1, 'version': '1.9.1',
-     'command': 'Pick closed-reference OTUs', 'samples': ['1.SKM3.640197'],
+     'aname': 'BIOM'},
+    {'artifact_id': 5, 'study_id': 1,
+     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Split libraries FASTQ',
+     'samples': ['1.SKM3.640197'],
      'study_title': 'Identification of the Microbiomes for Cannabis Soils',
-     'aname': 'BIOM', 'software': 'QIIME'},
-    {'artifact_id': 6, 'study_id': 1, 'version': u'1.9.1',
-     'command': 'Pick closed-reference OTUs', 'samples': ['1.SKM3.640197'],
+     'aname': 'BIOM'},
+    {'artifact_id': 6, 'study_id': 1,
+     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Split libraries FASTQ',
+     'samples': ['1.SKM3.640197'],
      'study_title': 'Identification of the Microbiomes for Cannabis Soils',
-     'aname': 'BIOM', 'software': 'QIIME'}]
+     'aname': 'BIOM'}]
 
 CATEGORIES = [
     {'artifact_id': None, 'study_id': 1, 'version': None,

--- a/qiita_pet/test/test_qiita_redbiom.py
+++ b/qiita_pet/test/test_qiita_redbiom.py
@@ -124,21 +124,24 @@ class TestRedbiom(TestHandlerBase):
 
 OBSERVATION = [
     {'artifact_id': 4, 'study_id': 1,
-     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Split libraries FASTQ', 'samples': [
+     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Defaults',
+     'samples': [
         '1.SKD1.640179', '1.SKD2.640178', '1.SKD3.640198', '1.SKD4.640185',
         '1.SKD5.640186', '1.SKD6.640190', '1.SKD7.640191', '1.SKD8.640184',
         '1.SKD9.640182'],
      'study_title': 'Identification of the Microbiomes for Cannabis Soils',
      'aname': 'BIOM'},
     {'artifact_id': 5, 'study_id': 1,
-     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Split libraries FASTQ', 'samples': [
+     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Defaults',
+     'samples': [
         '1.SKD1.640179', '1.SKD2.640178', '1.SKD3.640198', '1.SKD4.640185',
         '1.SKD5.640186', '1.SKD6.640190', '1.SKD7.640191', '1.SKD8.640184',
         '1.SKD9.640182'],
      'study_title': 'Identification of the Microbiomes for Cannabis Soils',
      'aname': 'BIOM'},
     {'artifact_id': 6, 'study_id': 1,
-     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Split libraries FASTQ', 'samples': [
+     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Defaults',
+     'samples': [
         '1.SKD1.640179', '1.SKD2.640178', '1.SKD3.640198', '1.SKD4.640185',
         '1.SKD5.640186', '1.SKD6.640190', '1.SKD7.640191', '1.SKD8.640184',
         '1.SKD9.640182'],
@@ -147,17 +150,17 @@ OBSERVATION = [
 
 SEQUENCE = [
     {'artifact_id': 4, 'study_id': 1,
-     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Split libraries FASTQ',
+     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Defaults',
      'samples': ['1.SKM3.640197'],
      'study_title': 'Identification of the Microbiomes for Cannabis Soils',
      'aname': 'BIOM'},
     {'artifact_id': 5, 'study_id': 1,
-     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Split libraries FASTQ',
+     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Defaults',
      'samples': ['1.SKM3.640197'],
      'study_title': 'Identification of the Microbiomes for Cannabis Soils',
      'aname': 'BIOM'},
     {'artifact_id': 6, 'study_id': 1,
-     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Split libraries FASTQ',
+     'command': 'Pick closed-reference OTUs - QIIME v1.9.1 @ Defaults',
      'samples': ['1.SKM3.640197'],
      'study_title': 'Identification of the Microbiomes for Cannabis Soils',
      'aname': 'BIOM'}]


### PR DESCRIPTION
Changes based on discussion during our 05/10/17 meeting. Basically, we are grouping by parent (trim, split, etc).

Note that there are different ways to do this: *(A)* changes in the db so it's "easy" to retrieve the default setting name from parents or any artifact, *(B)* do the matching in SQL or *(C)* python. *(A)* will need a lot of changes to the code and the db, and we will need B or C to make it happen as we will need to populate all current artifacts. Thus, decided that *(B)* or *(C)* were the option. Started with *(B)* and realized that all json operation in postgres (the processing parameters are stored as json) are not easy (or even possible) in any version below 9.4; in fact, greater of 9.5 will make life easier; our servers have 9.3. Even so, tried this way and the query was taking around 12 seconds from the 'infant' test (it originally took ~500ms) so discarded that version. Thus, implemented *(C)* and it's the one in this PR ('infant' test takes ~1s, not terrible).

Will deploy in the test environment in a few minutes. 