### PR TITLE
limiting number of jobs retrieved

### DIFF
--- a/qiita_db/test/test_user.py
+++ b/qiita_db/test/test_user.py
@@ -454,14 +454,20 @@ class UserTest(TestCase):
         PJ = qdb.processing_job.ProcessingJob
         ignore_status = []
         # generates expected jobs
-        jobs = qdb.user.User('shared@foo.bar').jobs(ignore_status)
+        jobs = qdb.user.User('shared@foo.bar').jobs(
+            ignore_status=ignore_status)
         self.assertEqual(jobs, [
             PJ('d19f76ee-274e-4c1b-b3a2-a12d73507c55'),
             PJ('b72369f9-a886-4193-8d3d-f7b504168e75')])
 
+        # just one job
+        self.assertEqual(qdb.user.User('shared@foo.bar').jobs(
+            limit=1, ignore_status=ignore_status), [
+                PJ('d19f76ee-274e-4c1b-b3a2-a12d73507c55')])
+
         # no jobs
         self.assertEqual(qdb.user.User('admin@foo.bar').jobs(
-            ignore_status), [])
+            ignore_status=ignore_status), [])
 
     def test_jobs_defaults(self):
         PJ = qdb.processing_job.ProcessingJob

--- a/qiita_db/user.py
+++ b/qiita_db/user.py
@@ -661,12 +661,14 @@ class User(qdb.base.QiitaObject):
             qdb.sql_connection.TRN.add(sql)
             qdb.sql_connection.TRN.execute()
 
-    def jobs(self, ignore_status=['success']):
+    def jobs(self, limit=30, ignore_status=['success']):
         """Return jobs created by the user
 
         Parameters
         ----------
-        ignore_status, list of str
+        limit : int, optional
+            max number of rows to return
+        ignore_status: list of str, optional
             don't retieve jobs that have one of these status
 
         Returns
@@ -683,10 +685,10 @@ class User(qdb.base.QiitaObject):
                   """
 
             if ignore_status:
-                sql_info = [self._id, tuple(ignore_status)]
+                sql_info = [self._id, tuple(ignore_status), limit]
                 sql += "    AND processing_job_status NOT IN %s"
             else:
-                sql_info = [self._id]
+                sql_info = [self._id, limit]
 
             sql += """
                      ORDER BY CASE processing_job_status
@@ -696,7 +698,7 @@ class User(qdb.base.QiitaObject):
                             WHEN 'waiting' THEN 4
                             WHEN 'error' THEN 5
                             WHEN 'success' THEN 6
-                        END, heartbeat DESC"""
+                        END, heartbeat DESC LIMIT %s"""
 
             qdb.sql_connection.TRN.add(sql, sql_info)
             return [qdb.processing_job.ProcessingJob(p[0])

--- a/qiita_pet/handlers/api_proxy/user.py
+++ b/qiita_pet/handlers/api_proxy/user.py
@@ -30,7 +30,7 @@ def user_jobs_get_req(user, limit=30):
     """
 
     response = []
-    for i, j in enumerate(user.jobs()):
+    for i, j in enumerate(user.jobs(limit=limit)):
         name = j.command.name
         hb = j.heartbeat
         hb = "" if hb is None else hb.strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
For a second we though that user.jobs was blocking the system but now we think that's not the case. Anyway, it turns out that we are not actually limiting the number of jobs to retrieve ...