### PR TITLE
Expand html summary setter

### DIFF
--- a/qiita_db/artifact.py
+++ b/qiita_db/artifact.py
@@ -11,6 +11,9 @@ from future.utils import viewitems
 from itertools import chain
 from datetime import datetime
 from os import remove
+from os.path import isfile
+from shutil import rmtree
+from functools import partial
 
 import networkx as nx
 
@@ -941,41 +944,55 @@ class Artifact(qdb.base.QiitaObject):
 
         return res
 
-    @html_summary_fp.setter
-    def html_summary_fp(self, value):
+    def set_html_summary(self, html_fp, support_dir=None):
         """Sets the HTML summary of the artifact
 
         Parameters
         ----------
-        value : str
+        html_fp : str
             Path to the new HTML summary
+        support_dir : str
+            Path to the directory containing any support files needed by
+            the HTML file
         """
         with qdb.sql_connection.TRN:
-            current = self.html_summary_fp
-            if current:
+            if self.html_summary_fp:
                 # Delete the current HTML summary
-                fp_id = current[0]
-                fp = current[1]
+                to_delete_ids = []
+                to_delete_fps = []
+                for fp_id, fp, fp_type in self.filepaths:
+                    if fp_type in ('html_summary', 'html_summary_dir'):
+                        to_delete_ids.append([fp_id])
+                        to_delete_fps.append(fp)
                 # From the artifact_filepath table
                 sql = """DELETE FROM qiita.artifact_filepath
                          WHERE filepath_id = %s"""
-                qdb.sql_connection.TRN.add(sql, [fp_id])
+                qdb.sql_connection.TRN.add(sql, to_delete_ids, many=True)
                 # From the filepath table
                 sql = "DELETE FROM qiita.filepath WHERE filepath_id=%s"
-                qdb.sql_connection.TRN.add(sql, [fp_id])
+                qdb.sql_connection.TRN.add(sql, to_delete_ids, many=True)
                 # And from the filesystem only after the transaction is
                 # successfully completed (after commit)
-                qdb.sql_connection.TRN.add_post_commit_func(remove, fp)
+
+                def path_cleaner(fp):
+                    if isfile(fp):
+                        remove(fp)
+                    else:
+                        rmtree(fp)
+                qdb.sql_connection.TRN.add_post_commit_func(
+                    partial(map, path_cleaner, to_delete_fps))
 
             # Add the new HTML summary
+            filepaths = [(html_fp, 'html_summary')]
+            if support_dir is not None:
+                filepaths.append((support_dir, 'html_summary_dir'))
             fp_ids = qdb.util.insert_filepaths(
-                [(value, 'html_summary')], self.id, self.artifact_type,
-                "filepath")
+                filepaths, self.id, self.artifact_type, "filepath")
             sql = """INSERT INTO qiita.artifact_filepath
                         (artifact_id, filepath_id)
                      VALUES (%s, %s)"""
-            # We only inserted a single filepath, so using index 0
-            qdb.sql_connection.TRN.add(sql, [self.id, fp_ids[0]])
+            sql_args = [[self.id, id_] for id_ in fp_ids]
+            qdb.sql_connection.TRN.add(sql, sql_args, many=True)
             qdb.sql_connection.TRN.execute()
 
     @property

--- a/qiita_db/handlers/artifact.py
+++ b/qiita_db/handlers/artifact.py
@@ -131,8 +131,17 @@ class ArtifactHandler(OauthBaseHandler):
                 raise HTTPError(400, 'Incorrect path parameter value')
             else:
                 artifact = _get_artifact(artifact_id)
+
                 try:
-                    artifact.html_summary_fp = req_value
+                    html_data = loads(req_value)
+                    html_fp = html_data['html']
+                    html_dir = html_data['dir']
+                except ValueError:
+                    html_fp = req_value
+                    html_dir = None
+
+                try:
+                    artifact.set_html_summary(html_fp, html_dir)
                 except Exception as e:
                     raise HTTPError(500, str(e))
         else:

--- a/qiita_db/support_files/patches/54.sql
+++ b/qiita_db/support_files/patches/54.sql
@@ -117,4 +117,7 @@ BEGIN
     INSERT INTO qiita.command_parameter (command_id, parameter_name, parameter_type, required, default_value)
         VALUES (baf_cmd_id, 'analysis', 'analysis', True, NULL),
                (baf_cmd_id, 'merge_dup_sample_ids', 'bool', False, 'False');
-END $do$
+END $do$;
+
+-- Add a new filepath type
+INSERT INTO qiita.filepath_type (filepath_type) VALUES ('html_summary_dir');

--- a/qiita_db/test/test_setup.py
+++ b/qiita_db/test/test_setup.py
@@ -39,7 +39,7 @@ class SetupTest(TestCase):
         self.assertEqual(get_count("qiita.filepath"), 25)
 
     def test_filepath_type(self):
-        self.assertEqual(get_count("qiita.filepath_type"), 21)
+        self.assertEqual(get_count("qiita.filepath_type"), 22)
 
     def test_study_prep_template(self):
         self.assertEqual(get_count("qiita.study_prep_template"), 2)

--- a/qiita_pet/handlers/api_proxy/__init__.py
+++ b/qiita_pet/handlers/api_proxy/__init__.py
@@ -30,7 +30,7 @@ from .studies import (
     study_tags_request)
 from .artifact import (artifact_graph_get_req, artifact_types_get_req,
                        artifact_post_req, artifact_get_req,
-                       artifact_status_put_req, artifact_delete_req,
+                       artifact_status_put_req,
                        artifact_summary_get_request, artifact_get_prep_req,
                        artifact_summary_post_request, artifact_patch_request)
 from .ontology import ontology_patch_handler
@@ -51,7 +51,7 @@ __all__ = ['prep_template_summary_get_req', 'sample_template_post_req',
            'prep_template_delete_req', 'artifact_get_prep_req',
            'prep_template_graph_get_req', 'prep_template_filepaths_get_req',
            'artifact_get_req', 'artifact_status_put_req',
-           'artifact_delete_req', 'prep_template_get_req', 'study_delete_req',
+           'prep_template_get_req', 'study_delete_req',
            'study_prep_get_req', 'sample_template_get_req',
            'artifact_graph_get_req', 'artifact_types_get_req',
            'artifact_post_req',

--- a/qiita_pet/handlers/api_proxy/artifact.py
+++ b/qiita_pet/handlers/api_proxy/artifact.py
@@ -17,7 +17,7 @@ from qiita_core.util import execute_as_transaction
 from qiita_core.qiita_settings import qiita_config
 from qiita_pet.handlers.api_proxy.util import check_access, check_fp
 from qiita_ware.context import safe_submit
-from qiita_ware.dispatchable import (copy_raw_data, delete_artifact)
+from qiita_ware.dispatchable import copy_raw_data
 from qiita_db.artifact import Artifact
 from qiita_db.user import User
 from qiita_db.metadata_template.prep_template import PrepTemplate

--- a/qiita_pet/handlers/api_proxy/artifact.py
+++ b/qiita_pet/handlers/api_proxy/artifact.py
@@ -506,37 +506,6 @@ def artifact_graph_get_req(artifact_id, direction, user_id):
             'message': ''}
 
 
-def artifact_delete_req(artifact_id, user_id):
-    """Deletes the artifact
-
-    Parameters
-    ----------
-    artifact_id : int
-        Artifact being acted on
-    user_id : str
-        The user requesting the action
-
-    Returns
-    -------
-    dict
-        Status of action, in the form {'status': status, 'message': msg}
-        status: status of the action, either success or error
-        message: Human readable message for status
-    """
-    pd = Artifact(int(artifact_id))
-    pt_id = pd.prep_templates[0].id
-    access_error = check_access(pd.study.id, user_id)
-    if access_error:
-        return access_error
-
-    job_id = safe_submit(user_id, delete_artifact, artifact_id)
-    r_client.set(PREP_TEMPLATE_KEY_FORMAT % pt_id,
-                 dumps({'job_id': job_id, 'is_qiita_job': False}))
-
-    return {'status': 'success',
-            'message': ''}
-
-
 def artifact_status_put_req(artifact_id, user_id, visibility):
     """Set the status of the artifact given
 

--- a/qiita_pet/handlers/api_proxy/tests/test_artifact.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_artifact.py
@@ -234,7 +234,7 @@ class TestArtifactAPI(TestCase):
         with open(fp, 'w') as f:
             f.write('<b>HTML TEST - not important</b>\n')
         a = Artifact(1)
-        a.html_summary_fp = fp
+        a.set_html_summary(fp)
         self._files_to_remove.extend([fp, a.html_summary_fp[1]])
         exp_files.append(
             (a.html_summary_fp[0],

--- a/qiita_pet/handlers/api_proxy/tests/test_artifact.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_artifact.py
@@ -27,7 +27,7 @@ from qiita_db.software import Command, Parameters, DefaultParameters
 from qiita_db.exceptions import QiitaDBWarning
 from qiita_pet.handlers.api_proxy.artifact import (
     artifact_get_req, artifact_status_put_req, artifact_graph_get_req,
-    artifact_delete_req, artifact_types_get_req, artifact_post_req,
+    artifact_types_get_req, artifact_post_req,
     artifact_summary_get_request, artifact_summary_post_request,
     artifact_patch_request, artifact_get_prep_req)
 
@@ -391,22 +391,6 @@ class TestArtifactAPI(TestCase):
         exp = {'status': 'error',
                'message': 'Operation "add" not supported. Current supported '
                           'operations: replace'}
-        self.assertEqual(obs, exp)
-
-    def test_artifact_delete_req(self):
-        obs = artifact_delete_req(self.artifact.id, 'test@foo.bar')
-        exp = {'status': 'success', 'message': ''}
-        self.assertEqual(obs, exp)
-
-        # This is needed so the clean up works - this is a distributed system
-        # so we need to make sure that all processes are done before we reset
-        # the test database
-        wait_for_prep_information_job(1)
-
-    def test_artifact_delete_req_no_access(self):
-        obs = artifact_delete_req(self.artifact.id, 'demo@microbio.me')
-        exp = {'status': 'error',
-               'message': 'User does not have access to study'}
         self.assertEqual(obs, exp)
 
     def test_artifact_get_prep_req(self):

--- a/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
+++ b/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
@@ -145,7 +145,7 @@ class TestBaseHandlersUtils(TestCase):
         with open(fp, 'w') as f:
             f.write('<b>HTML TEST - not important</b>\n')
         a = Artifact(1)
-        a.html_summary_fp = fp
+        a.set_html_summary(fp)
         self._files_to_remove.extend([fp, a.html_summary_fp[1]])
         exp_files.append(
             (a.html_summary_fp[0],
@@ -375,7 +375,7 @@ class TestBaseHandlers(TestHandlerBase):
         with open(fp, 'w') as f:
             f.write('<b>HTML TEST - not important</b>\n')
         a = Artifact(1)
-        a.html_summary_fp = fp
+        a.set_html_summary(fp)
         self._files_to_remove.extend([fp, a.html_summary_fp[1]])
 
         summary = relpath(a.html_summary_fp[1], qiita_config.base_data_dir)

--- a/qiita_pet/handlers/study_handlers/tests/test_artifact.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_artifact.py
@@ -123,6 +123,8 @@ class NewArtifactHandlerTests(TestHandlerBase):
             'import-artifact': ''}
         response = self.post('/study/new_artifact/', args)
         self.assertEqual(response.code, 200)
+        self.assertEqual(loads(response.body),
+                         {'status': 'success', 'message': ''})
 
         # make sure new artifact created
         wait_for_prep_information_job(self.prep.id)

--- a/qiita_pet/handlers/study_handlers/tests/test_sample_template.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_sample_template.py
@@ -7,6 +7,9 @@
 # -----------------------------------------------------------------------------
 from unittest import main
 from json import loads
+from time import sleep
+
+from moi import r_client
 
 from qiita_pet.test.tornado_test_base import TestHandlerBase
 from qiita_pet.handlers.study_handlers.sample_template import (
@@ -65,6 +68,14 @@ class TestSampleTemplateAJAX(TestHandlerBase):
                '"message": ""}')
         # checking that the action was sent
         self.assertEqual(response.body, exp)
+
+        # Wait until the job has completed
+        obs = r_client.get('sample_template_1')
+        self.assertIsNotNone(obs)
+        redis_info = loads(r_client.get(loads(obs)['job_id']))
+        while redis_info['status_msg'] == 'Running':
+            sleep(0.5)
+            redis_info = loads(r_client.get(loads(obs)['job_id']))
 
 
 class TestSampleAJAXReadOnly(TestHandlerBase):


### PR DESCRIPTION
Now the HTML summaries of the artifacts can contain an optional directory with any extra files needed by the HTML to show correctly. This was not taken into account in the previous implementation of the HTML summary setter, so it has been extended here so it supports now an optional HTML summary directory.