### PR TITLE
Registering commands after updating plugins

### DIFF
--- a/qiita_db/handlers/plugin.py
+++ b/qiita_db/handlers/plugin.py
@@ -228,4 +228,6 @@ class ReloadPluginAPItestHandler(OauthBaseHandler):
         for fp in conf_files:
             s = qdb.software.Software.from_file(fp, update=True)
             s.activate()
+            s.register_commands()
+
         self.finish()


### PR DESCRIPTION
Found this while helping @antgonza debugging de qp-qiime2 plugin tests. In short, the database gets reseted when the tests are run, the plugins then get activated but their commands are not registered. This makes the qiime2 plugin fail because it needs the qtp-diversity plugin to be installed and registered.