### PR TITLE
fix #1817

### DIFF
--- a/qiita_db/sql_connection.py
+++ b/qiita_db/sql_connection.py
@@ -382,7 +382,9 @@ class SQLConnectionHandler(object):
                 executor()
                 yield cur
             except PostgresError as e:
-                self._raise_execution_error(sql, sql_args, e)
+                self._connection.rollback()
+                raise ValueError("Error running SQL: %s. MSG: %s\n" % (
+                    errorcodes.lookup(e.pgcode), e.message))
             else:
                 self._connection.commit()
 


### PR DESCRIPTION
Like the discussion said, the SQL query is not useful so basically decided to use the actual error codes "translation" and the error message, which should be sufficient. The new error will look something like:
```bash
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-24-094c959462d3> in <module>()
      1 with TRN:
      2     TRN.add('SELECT * FROM bla')
----> 3     TRN.execute()
      4 

/Users/antoniog/svn_programs/qiita/qiita_db/sql_connection.py in wrapper(self, *args, **kwargs)
    506                 "Operation not permitted. Transaction methods can only be "
    507                 "invoked within the context manager.")
--> 508         return func(self, *args, **kwargs)
    509     return wrapper
    510 

/Users/antoniog/svn_programs/qiita/qiita_db/sql_connection.py in execute(self)
    755         """
    756         try:
--> 757             return self._execute()
    758         except Exception:
    759             self.rollback()

/Users/antoniog/svn_programs/qiita/qiita_db/sql_connection.py in _execute(self)
    702                     # We catch any exception as we want to make sure that we
    703                     # rollback every time that something went wrong
--> 704                     self._raise_execution_error(sql, sql_args, e)
    705 
    706                 try:

/Users/antoniog/svn_programs/qiita/qiita_db/sql_connection.py in _raise_execution_error(self, sql, sql_args, error)
    647         raise ValueError(
    648             "Error running SQL: %s. MSG: %s\n" % (
--> 649                 errorcodes.lookup(error.pgcode), error.message))
    650 
    651     @_checker

ValueError: Error running SQL: UNDEFINED_TABLE. MSG: relation "bla" does not exist
LINE 1: SELECT * FROM bla
                      ^
```