### PR TITLE
ENH: Move "Jobs using this data" button

### DIFF
--- a/qiita_pet/templates/artifact_ajax/artifact_summary.html
+++ b/qiita_pet/templates/artifact_ajax/artifact_summary.html
@@ -113,17 +113,6 @@
   </div>
 </div>
 
-{% if files %}
-<div class='row'>
-  <div class='col-md-12'>
-    Available files:
-    {% for f_id, f_name in files %}
-      </br><a class="btn btn-default" href="{% raw qiita_config.portal_dir %}/download/{{f_id}}"><span class="glyphicon glyphicon-download-alt"></span> {{f_name}}</a>
-    {% end %}
-  </div>
-</div>
-{% end %}
-
 <div class='row'>
   <div class='col-md-12'>
     {% if processing_jobs %}
@@ -145,6 +134,18 @@
     {% end %}
   </div>
 </div>
+
+{% if files %}
+<div class='row'>
+  <div class='col-md-12'>
+    Available files:
+    {% for f_id, f_name in files %}
+      </br><a class="btn btn-default" href="{% raw qiita_config.portal_dir %}/download/{{f_id}}"><span class="glyphicon glyphicon-download-alt"></span> {{f_name}}</a>
+    {% end %}
+  </div>
+</div>
+{% end %}
+
 <div class='row'>
   <div class='col-md-12' id='artifact-summary-content'>
     {% if summary is not None %}


### PR DESCRIPTION
The button appeared at the bottom of the page, which makes it hard to
find this information when dealing with "per-sample FASTQ files".
With this commit, this button is moved to the top of the file download
list.