### PR TITLE
Remove race condition - Fixes 2143

### DIFF
--- a/qiita_db/private.py
+++ b/qiita_db/private.py
@@ -49,7 +49,7 @@ def build_analysis_files(job):
 
     # The validator jobs no longer finish the job automatically so we need
     # to release the validators here
-    release_validators(job)
+    job.release_validators()
 
 
 def release_validators(job):

--- a/qiita_db/private.py
+++ b/qiita_db/private.py
@@ -47,6 +47,10 @@ def build_analysis_files(job):
             j.submit()
             sleep(1)
 
+    # The validator jobs no longer finish the job automatically so we need
+    # to release the validators here
+    release_validators(job)
+
 
 def release_validators(job):
     """Waits until all the validators of a job are completed

--- a/qiita_db/private.py
+++ b/qiita_db/private.py
@@ -48,7 +48,22 @@ def build_analysis_files(job):
             sleep(1)
 
 
-TASK_DICT = {'build_analysis_files': build_analysis_files}
+def release_validators(job):
+    """Waits until all the validators of a job are completed
+
+    Parameters
+    ----------
+    job : qiita_db.processing_job.ProcessingJob
+        The processing job with the information of the parent job
+    """
+    with qdb.sql_connection.TRN:
+        qdb.processing_job.ProcessingJob(
+            job.parameters.values['job']).release_validators()
+        job._set_status('success')
+
+
+TASK_DICT = {'build_analysis_files': build_analysis_files,
+             'release_validators': release_validators}
 
 
 def private_task(job_id):

--- a/qiita_db/processing_job.py
+++ b/qiita_db/processing_job.py
@@ -421,8 +421,9 @@ class ProcessingJob(qdb.base.QiitaObject):
                     "Only artifact transformation and private jobs can "
                     "release validators")
 
-            # Check if all the validators are ready by checking that there is
-            # no validator processing job whose status is not waiting
+            # Check if all the validators are completed. Validator jobs can be
+            # in two states when completed: 'waiting' in case of success
+            # or 'error' otherwise
             sql = """SELECT COUNT(1)
                      FROM qiita.processing_job_validator pjv
                         JOIN qiita.processing_job pj ON

--- a/qiita_db/processing_job.py
+++ b/qiita_db/processing_job.py
@@ -653,6 +653,16 @@ class ProcessingJob(qdb.base.QiitaObject):
             for j in validator_jobs:
                 j.submit()
 
+            # Submit the job that will release all the validators
+            plugin = qdb.software.Software.from_name_and_version(
+                'Qiita', 'alpha')
+            cmd = plugin.get_command('release_validators')
+            params = qdb.software.Parameters.load(
+                cmd, values_dict={'job': self.id})
+            job = ProcessingJob.create(self.user, params)
+        # Doing the submission outside of the transaction
+        job.submit()
+
     def _set_validator_jobs(self, validator_jobs):
         """Sets the validator jobs for the current job
 

--- a/qiita_db/support_files/patches/57.sql
+++ b/qiita_db/support_files/patches/57.sql
@@ -1,0 +1,19 @@
+-- Aug 8, 2017
+-- Add release validators internal Qiita command
+
+DO $do$
+DECLARE
+    qiita_sw_id     bigint;
+    rv_cmd_id       bigint;
+BEGIN
+    SELECT software_id INTO qiita_sw_id
+        FROM qiita.software
+        WHERE name = 'Qiita' AND version = 'alpha';
+
+    INSERT INTO qiita.software_command (software_id, name, description)
+        VALUES (qiita_sw_id, 'release_validators', 'Releases the job validators')
+        RETURNING command_id INTO rv_cmd_id;
+
+    INSERT INTO qiita.command_parameter (command_id, parameter_name, parameter_type, required, default_value)
+        VALUES (rv_cmd_id, 'job', 'string', True, NULL);
+END $do$;

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -1011,6 +1011,7 @@ class ArtifactTests(TestCase):
         job.complete(True, artifacts_data=data)
         job = qdb.processing_job.ProcessingJob(
             "bcc7ebcd-39c1-43e4-af2d-822e3589f14d")
+        job.release_validators()
         artifact = job.outputs['OTU table']
         self._clean_up_files.extend([afp for _, afp, _ in artifact.filepaths])
 

--- a/qiita_db/test/test_processing_job.py
+++ b/qiita_db/test/test_processing_job.py
@@ -359,6 +359,12 @@ class ProcessingJobTest(TestCase):
         artifact_data_2 = {'filepaths': [(fp2, 'biom')],
                            'artifact_type': 'BIOM'}
         obs2._complete_artifact_definition(artifact_data_2)
+        self.assertEqual(obs1.status, 'waiting')
+        self.assertEqual(obs2.status, 'waiting')
+        self.assertEqual(job.status, 'running')
+
+        job.release_validators()
+
         self.assertEqual(obs1.status, 'success')
         self.assertEqual(obs2.status, 'success')
         self.assertEqual(job.status, 'success')
@@ -386,7 +392,8 @@ class ProcessingJobTest(TestCase):
             qdb.user.User('test@foo.bar'), params)
         job._set_validator_jobs([obs])
         obs._complete_artifact_definition(artifact_data)
-        self.assertEqual(job.status, 'success')
+        self.assertEqual(obs.status, 'waiting')
+        self.assertEqual(job.status, 'running')
         # Upload case implicitly tested by "test_complete_type"
 
     def test_complete_artifact_transformation(self):
@@ -477,7 +484,10 @@ class ProcessingJobTest(TestCase):
         obsjobs = set(self._get_all_job_ids())
 
         self.assertEqual(len(obsjobs), len(alljobs) + 1)
-        self._wait_for_job(job)
+
+        # Release the validators of the job. This will make sure that all
+        # the validator jobs have been completed
+        job.release_validators()
 
     def test_complete_failure(self):
         job = _create_job()
@@ -501,12 +511,17 @@ class ProcessingJobTest(TestCase):
         )
         obs = qdb.processing_job.ProcessingJob.create(
             qdb.user.User('test@foo.bar'), params)
+        job._set_validator_jobs([obs])
         obs.complete(False, error="Validation failure")
         self.assertEqual(obs.status, 'error')
         self.assertEqual(obs.log.msg, 'Validation failure')
 
+        self.assertEqual(job.status, 'running')
+        job.release_validators()
         self.assertEqual(job.status, 'error')
-        self.assertEqual(job.log.msg, 'Validation failure')
+        self.assertEqual(
+            job.log.msg, '1 validator jobs failed: Validator %s '
+                         'error message: Validation failure' % obs.id)
 
     def test_complete_error(self):
         with self.assertRaises(
@@ -628,6 +643,7 @@ class ProcessingJobTest(TestCase):
         job._set_validator_jobs([obs])
         exp_artifact_count = qdb.util.get_count('qiita.artifact') + 1
         obs._complete_artifact_definition(artifact_data)
+        job.release_validators()
         self.assertEqual(job.status, 'success')
 
         obs = job.outputs

--- a/qiita_db/test/test_processing_job.py
+++ b/qiita_db/test/test_processing_job.py
@@ -483,11 +483,9 @@ class ProcessingJobTest(TestCase):
 
         obsjobs = set(self._get_all_job_ids())
 
-        self.assertEqual(len(obsjobs), len(alljobs) + 1)
-
-        # Release the validators of the job. This will make sure that all
-        # the validator jobs have been completed
-        job.release_validators()
+        # The complete submits the release validators job
+        self.assertEqual(len(obsjobs), len(alljobs) + 2)
+        self._wait_for_job(job)
 
     def test_complete_failure(self):
         job = _create_job()

--- a/qiita_db/test/test_processing_job.py
+++ b/qiita_db/test/test_processing_job.py
@@ -483,7 +483,8 @@ class ProcessingJobTest(TestCase):
 
         obsjobs = set(self._get_all_job_ids())
 
-        # The complete submits the release validators job
+        # The complete call above submits 2 new jobs: the validator job and
+        # the release validators job. Hence the +2
         self.assertEqual(len(obsjobs), len(alljobs) + 2)
         self._wait_for_job(job)
 


### PR DESCRIPTION
Fixes #2143 

Adds a new internal command: `release_validators`. The validators themselves no longer try to free up the parent job. The `release_validators` is a command that performs an active polling checking for the jobs to complete. It is automatically submitted to the queue after the validators have been submitted.