### PR TITLE
Fix 2210

### DIFF
--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -853,7 +853,8 @@ class UtilTests(TestCase):
         exp = [
             {'files': ['1_study_1001_closed_reference_otu_table.biom'],
              'target_subfragment': ['V4'], 'artifact_id': 4,
-             'algorithm': 'Pick closed-reference OTUs, QIIMEv1.9.1 | Defaults',
+             'algorithm': ('Pick closed-reference OTUs, QIIMEv1.9.1 |'
+                           'barcode_type 8, defaults'),
              'data_type': '18S', 'prep_samples': 27,
              'parameters': {
                 'reference': 1, 'similarity': 0.97, 'sortmerna_e_value': 1,

--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -854,7 +854,7 @@ class UtilTests(TestCase):
             {'files': ['1_study_1001_closed_reference_otu_table.biom'],
              'target_subfragment': ['V4'], 'artifact_id': 4,
              'algorithm': ('Pick closed-reference OTUs, QIIMEv1.9.1 |'
-                           ' Defaults'),
+                           ' barcode_type 8, defaults'),
              'data_type': '18S', 'prep_samples': 27,
              'parameters': {
                 'reference': 1, 'similarity': 0.97, 'sortmerna_e_value': 1,
@@ -866,18 +866,6 @@ class UtilTests(TestCase):
             {'files': ['biom_table.biom'], 'target_subfragment': [],
              'algorithm': '', 'artifact_id': 8, 'data_type': '18S',
              'prep_samples': 0, 'parameters': {}, 'name': 'noname'}]
-        print len(obs), len(exp)
-        for o, e in zip(obs, exp):
-            if o != e:
-                print o
-                print e
-                print "---------------"
-                for k in o:
-                    if o[k] != e[k]:
-                        print k
-                        print o[k]
-                        print e[k]
-                print "==============="
         self.assertItemsEqual(obs, exp)
 
 

--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -854,7 +854,7 @@ class UtilTests(TestCase):
             {'files': ['1_study_1001_closed_reference_otu_table.biom'],
              'target_subfragment': ['V4'], 'artifact_id': 4,
              'algorithm': ('Pick closed-reference OTUs, QIIMEv1.9.1 |'
-                           'barcode_type 8, defaults'),
+                           ' Defaults'),
              'data_type': '18S', 'prep_samples': 27,
              'parameters': {
                 'reference': 1, 'similarity': 0.97, 'sortmerna_e_value': 1,

--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -866,6 +866,18 @@ class UtilTests(TestCase):
             {'files': ['biom_table.biom'], 'target_subfragment': [],
              'algorithm': '', 'artifact_id': 8, 'data_type': '18S',
              'prep_samples': 0, 'parameters': {}, 'name': 'noname'}]
+        print len(obs), len(exp)
+        for o, e in zip(obs, exp):
+            if o != e:
+                print o
+                print e
+                print "---------------"
+                for k in o:
+                    if o[k] != e[k]:
+                        print k
+                        print o[k]
+                        print e[k]
+                print "==============="
         self.assertItemsEqual(obs, exp)
 
 

--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -852,19 +852,19 @@ class UtilTests(TestCase):
 
         exp = [
             {'files': ['1_study_1001_closed_reference_otu_table.biom'],
-             'target_subfragment': ['V4'], 'data_type': '18S',
+             'target_subfragment': ['V4'],
+             'algorithm': 'Pick closed-reference OTUs, QIIMEv1.9.1 | Defaults',
+             'artifact_id': 4, 'data_type': '18S', 'prep_samples': 27,
              'parameters': {
                 'reference': 1, 'similarity': 0.97, 'sortmerna_e_value': 1,
                 'sortmerna_max_pos': 10000, 'input_data': 2, 'threads': 1,
-                'sortmerna_coverage': 0.97}, 'name': 'BIOM',
-                'algorithm': ('Pick closed-reference OTUs, QIIMEv1.9.1 '
-                              '| barcode_type 8, defaults'), 'artifact_id': 4},
-            {'files': [], 'target_subfragment': ['V4'], 'data_type': '16S',
-             'parameters': {}, 'name': 'BIOM', 'algorithm': '',
-             'artifact_id': 7},
+                'sortmerna_coverage': 0.97}, 'name': 'BIOM'},
+            {'files': [], 'target_subfragment': ['V4'], 'algorithm': '',
+             'artifact_id': 7L, 'data_type': '16S', 'prep_samples': 27,
+             'parameters': {}, 'name': 'BIOM'},
             {'files': ['biom_table.biom'], 'target_subfragment': [],
-             'data_type': '18S', 'parameters': {}, 'name': 'noname',
-             'algorithm': '', 'artifact_id': 8}]
+             'algorithm': '', 'artifact_id': 8, 'data_type': '18S',
+             'prep_samples': 0, 'parameters': {}, 'name': 'noname'}]
         self.assertEqual(obs, exp)
 
 

--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -865,7 +865,7 @@ class UtilTests(TestCase):
             {'files': ['biom_table.biom'], 'target_subfragment': [],
              'algorithm': '', 'artifact_id': 8, 'data_type': '18S',
              'prep_samples': 0, 'parameters': {}, 'name': 'noname'}]
-        self.assertEqual(obs, exp)
+        self.assertItemsEqual(obs, exp)
 
 
 if __name__ == '__main__':

--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -852,15 +852,15 @@ class UtilTests(TestCase):
 
         exp = [
             {'files': ['1_study_1001_closed_reference_otu_table.biom'],
-             'target_subfragment': ['V4'],
+             'target_subfragment': ['V4'], 'artifact_id': 4,
              'algorithm': 'Pick closed-reference OTUs, QIIMEv1.9.1 | Defaults',
-             'artifact_id': 4, 'data_type': '18S', 'prep_samples': 27,
+             'data_type': '18S', 'prep_samples': 27,
              'parameters': {
                 'reference': 1, 'similarity': 0.97, 'sortmerna_e_value': 1,
                 'sortmerna_max_pos': 10000, 'input_data': 2, 'threads': 1,
                 'sortmerna_coverage': 0.97}, 'name': 'BIOM'},
             {'files': [], 'target_subfragment': ['V4'], 'algorithm': '',
-             'artifact_id': 7L, 'data_type': '16S', 'prep_samples': 27,
+             'artifact_id': 7, 'data_type': '16S', 'prep_samples': 27,
              'parameters': {}, 'name': 'BIOM'},
             {'files': ['biom_table.biom'], 'target_subfragment': [],
              'algorithm': '', 'artifact_id': 8, 'data_type': '18S',

--- a/qiita_pet/handlers/api_proxy/tests/test_artifact.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_artifact.py
@@ -224,7 +224,8 @@ class TestArtifactAPI(TestCase):
         data = [
             {'files': ['1_study_1001_closed_reference_otu_table_Silva.biom'],
              'target_subfragment': ['V4'],
-             'algorithm': 'Pick closed-reference OTUs, QIIMEv1.9.1 | Defaults',
+             'algorithm': ('Pick closed-reference OTUs, QIIMEv1.9.1 | '
+                           'barcode_type 8, defaults'),
              'artifact_id': 6, 'data_type': '16S',
              'timestamp': '2012-10-02 17:30:00', 'prep_samples': 27,
              'parameters': {
@@ -233,7 +234,8 @@ class TestArtifactAPI(TestCase):
                 'sortmerna_coverage': 0.97}, 'name': 'BIOM'},
             {'files': ['1_study_1001_closed_reference_otu_table.biom'],
              'target_subfragment': ['V4'],
-             'algorithm': 'Pick closed-reference OTUs, QIIMEv1.9.1 | Defaults',
+             'algorithm': ('Pick closed-reference OTUs, QIIMEv1.9.1 | '
+                           'barcode_type 8, defaults'),
              'artifact_id': 5, 'data_type': '18S',
              'timestamp': '2012-10-02 17:30:00', 'prep_samples': 27,
              'parameters': {

--- a/qiita_pet/handlers/api_proxy/tests/test_artifact.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_artifact.py
@@ -223,25 +223,27 @@ class TestArtifactAPI(TestCase):
         obs = artifact_get_info('test@foo.bar', [5, 6, 7])
         data = [
             {'files': ['1_study_1001_closed_reference_otu_table_Silva.biom'],
-             'target_subfragment': ['V4'], 'algorithm': (
-                'Pick closed-reference OTUs, QIIMEv1.9.1 | barcode_type 8, '
-                'defaults'), 'artifact_id': 6, 'data_type': '16S',
-             'timestamp': '2012-10-02 17:30:00', 'parameters': {
-                'reference': 2, 'similarity': 0.97, 'sortmerna_e_value': 1,
+             'target_subfragment': ['V4'],
+             'algorithm': 'Pick closed-reference OTUs, QIIMEv1.9.1 | Defaults',
+             'artifact_id': 6, 'data_type': '16S',
+             'timestamp': '2012-10-02 17:30:00', 'prep_samples': 27,
+             'parameters': {
+                'reference': 2, 'similarity': 0.97, u'sortmerna_e_value': 1,
                 'sortmerna_max_pos': 10000, 'input_data': 2, 'threads': 1,
                 'sortmerna_coverage': 0.97}, 'name': 'BIOM'},
             {'files': ['1_study_1001_closed_reference_otu_table.biom'],
-             'target_subfragment': ['V4'], 'algorithm': (
-                'Pick closed-reference OTUs, QIIMEv1.9.1 | barcode_type 8, '
-                'defaults'), 'artifact_id': 5, 'data_type': '18S',
-                'timestamp': '2012-10-02 17:30:00', 'parameters': {
-                    'reference': 1, 'similarity': 0.97, 'sortmerna_e_value': 1,
-                    'sortmerna_max_pos': 10000, 'input_data': 2, 'threads': 1,
-                    'sortmerna_coverage': 0.97}, 'name': 'BIOM'},
+             'target_subfragment': ['V4'],
+             'algorithm': 'Pick closed-reference OTUs, QIIMEv1.9.1 | Defaults',
+             'artifact_id': 5, 'data_type': '18S',
+             'timestamp': '2012-10-02 17:30:00', 'prep_samples': 27,
+             'parameters': {
+                'reference': 1, 'similarity': 0.97, 'sortmerna_e_value': 1,
+                'sortmerna_max_pos': 10000, 'input_data': 2, 'threads': 1,
+                'sortmerna_coverage': 0.97}, 'name': 'BIOM'},
             {'files': [], 'target_subfragment': ['V4'], 'algorithm': '',
              'artifact_id': 7, 'data_type': '16S',
-             'timestamp': '2012-10-02 17:30:00', 'parameters': {},
-             'name': 'BIOM'}]
+             'timestamp': '2012-10-02 17:30:00', 'prep_samples': 27,
+             'parameters': {}, 'name': 'BIOM'}]
         exp = {'status': 'success', 'msg': '', 'data': data}
         self.assertEqual(obs, exp)
 

--- a/qiita_pet/handlers/api_proxy/tests/test_artifact.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_artifact.py
@@ -245,7 +245,10 @@ class TestArtifactAPI(TestCase):
              'timestamp': '2012-10-02 17:30:00', 'prep_samples': 27,
              'parameters': {}, 'name': 'BIOM'}]
         exp = {'status': 'success', 'msg': '', 'data': data}
-        self.assertEqual(obs, exp)
+        self.assertItemsEqual(obs.keys(), exp.keys())
+        self.assertEqual(obs['status'], exp['status'])
+        self.assertEqual(obs['msg'], exp['msg'])
+        self.assertItemsEqual(obs['data'], exp['data'])
 
     def test_artifact_post_req(self):
         # Create new prep template to attach artifact to

--- a/qiita_pet/handlers/study_handlers/tests/test_artifact.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_artifact.py
@@ -181,7 +181,24 @@ class ArtifactGetInfoTest(TestHandlerBase):
         self.assertItemsEqual(obs.keys(), exp.keys())
         self.assertEqual(obs['status'], exp['status'])
         self.assertEqual(obs['msg'], exp['msg'])
-        self.assertItemsEqual(obs['data'], exp['data'])
+
+        obs = obs['data']
+        exp = exp['data']
+        print len(obs), len(exp)
+        for o, e in zip(obs, exp):
+            if o != e:
+                print o
+                print e
+                print "---------------"
+                for k in o:
+                    if o[k] != e[k]:
+                        print k
+                        print o[k]
+                        print e[k]
+                print "==============="
+
+        # self.assertItemsEqual(obs['data'], exp['data'])
+        self.assertItemsEqual(obs, exp)
 
 
 class ArtifactAdminAJAXTestsReadOnly(TestHandlerBase):

--- a/qiita_pet/handlers/study_handlers/tests/test_artifact.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_artifact.py
@@ -164,19 +164,24 @@ class ArtifactGetInfoTest(TestHandlerBase):
         self.assertEqual(response.code, 200)
         data = [
             {'files': ['1_study_1001_closed_reference_otu_table_Silva.biom'],
-             'target_subfragment': ['V4'], 'algorithm': (
-                'Pick closed-reference OTUs, QIIMEv1.9.1 | barcode_type 8, '
-                'defaults'), 'artifact_id': 6, 'data_type': '16S',
-             'timestamp': '2012-10-02 17:30:00', 'parameters': {
+             'target_subfragment': ['V4'], 'artifact_id': 6,
+             'data_type': '16S', 'timestamp': '2012-10-02 17:30:00',
+             'prep_samples': 27,
+             'algorithm': 'Pick closed-reference OTUs, QIIMEv1.9.1 | Defaults',
+             'parameters': {
                 'reference': 2, 'similarity': 0.97, 'sortmerna_e_value': 1,
                 'sortmerna_max_pos': 10000, 'input_data': 2, 'threads': 1,
                 'sortmerna_coverage': 0.97}, 'name': 'BIOM'},
-            {'files': [], 'target_subfragment': ['V4'], 'algorithm': '',
-             'artifact_id': 7, 'data_type': '16S',
-             'timestamp': '2012-10-02 17:30:00', 'parameters': {},
+            {'files': [], 'target_subfragment': ['V4'], 'artifact_id': 7,
+             'data_type': '16S', 'timestamp': '2012-10-02 17:30:00',
+             'prep_samples': 27, 'algorithm': '', 'parameters': {},
              'name': 'BIOM'}]
         exp = {'status': 'success', 'msg': '', 'data': data}
-        self.assertEqual(loads(response.body), exp)
+        obs = loads(response.body)
+        self.assertItemsEqual(obs.keys(), exp.keys())
+        self.assertEqual(obs['status'], exp['status'])
+        self.assertEqual(obs['msg'], exp['msg'])
+        self.assertItemsEqual(obs['data'], exp['data'])
 
 
 class ArtifactAdminAJAXTestsReadOnly(TestHandlerBase):

--- a/qiita_pet/handlers/study_handlers/tests/test_artifact.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_artifact.py
@@ -167,7 +167,8 @@ class ArtifactGetInfoTest(TestHandlerBase):
              'target_subfragment': ['V4'], 'artifact_id': 6,
              'data_type': '16S', 'timestamp': '2012-10-02 17:30:00',
              'prep_samples': 27,
-             'algorithm': 'Pick closed-reference OTUs, QIIMEv1.9.1 | Defaults',
+             'algorithm': 'Pick closed-reference OTUs, QIIMEv1.9.1 | '
+                          'barcode_type 8, defaults',
              'parameters': {
                 'reference': 2, 'similarity': 0.97, 'sortmerna_e_value': 1,
                 'sortmerna_max_pos': 10000, 'input_data': 2, 'threads': 1,
@@ -181,24 +182,7 @@ class ArtifactGetInfoTest(TestHandlerBase):
         self.assertItemsEqual(obs.keys(), exp.keys())
         self.assertEqual(obs['status'], exp['status'])
         self.assertEqual(obs['msg'], exp['msg'])
-
-        obs = obs['data']
-        exp = exp['data']
-        print len(obs), len(exp)
-        for o, e in zip(obs, exp):
-            if o != e:
-                print o
-                print e
-                print "---------------"
-                for k in o:
-                    if o[k] != e[k]:
-                        print k
-                        print o[k]
-                        print e[k]
-                print "==============="
-
-        # self.assertItemsEqual(obs['data'], exp['data'])
-        self.assertItemsEqual(obs, exp)
+        self.assertItemsEqual(obs['data'], exp['data'])
 
 
 class ArtifactAdminAJAXTestsReadOnly(TestHandlerBase):

--- a/qiita_pet/templates/analysis_selected.html
+++ b/qiita_pet/templates/analysis_selected.html
@@ -96,7 +96,7 @@ $(document).ready(function() {
     <h4>Processed Data</h4>
     <table class='table table-striped' id='study{{study.id}}-table'>
     <tr>
-      <th class="col-sm-1">id</th><th class="col-sm-1">Datatype</th><th class="col-sm-2">Processed Date</th><th class="col-sm-2">Algorithm</th><th class="col-sm-2">Parameters</th><th class="col-sm-1">Samples</th><th></th><th></th>
+      <th class="col-sm-1">id</th><th class="col-sm-1">Datatype</th><th class="col-sm-2">Processed Date</th><th class="col-sm-2">Algorithm</th><th class="col-sm-2">Parameters</th><th class="col-sm-1">Samples selected from Prep Info</th><th></th><th></th>
     </tr>
   {% for pid, samples in viewitems(proc_datas) %}
     <tr id="proc{{pid}}">

--- a/qiita_pet/templates/list_studies.html
+++ b/qiita_pet/templates/list_studies.html
@@ -90,6 +90,7 @@ $(document).ready(function() {
     proc_data_table += '<th>Data type</th>';
     proc_data_table += '<th>Processing method</th>';
     proc_data_table += '<th>Parameters</th>';
+    proc_data_table += '<th>Samples in Prep Info</th>';
     proc_data_table += '<th>Files</th>';
     proc_data_table += '</tr>';
 
@@ -106,6 +107,7 @@ $(document).ready(function() {
           params += '<i>' + key + '</i>: ' + info.parameters[key] + '<br/>';
         }
         proc_data_table += '<td><small>' + params + '</small></td>';
+        proc_data_table += '<td>' + info.prep_samples + '</td>';
         proc_data_table += '<td><small>' + info.files.join('<br/>')  + '</small></td>';
 
         proc_data_table += '</tr>';


### PR DESCRIPTION
Adds sample counts by prep in the listing. Deciding to go via PrepTemplate.keys() cause it and cache the values as it saves us some code/queries. 

Now, the study list looks like this:
![study_list](https://user-images.githubusercontent.com/2014559/29499445-b6233072-85ce-11e7-9acd-c8172c7682bc.png)

The study/sample selected like this:
![selected](https://user-images.githubusercontent.com/2014559/29499448-bd448838-85ce-11e7-8aa9-f61985f8ad46.png)

