### PR TITLE
Fix 2190

### DIFF
--- a/qiita_db/processing_job.py
+++ b/qiita_db/processing_job.py
@@ -367,6 +367,7 @@ class ProcessingJob(qdb.base.QiitaObject):
                 parents = None
                 params = None
                 cmd_out_id = None
+                name = None
                 data_type = a_info['data_type']
                 analysis = qdb.analysis.Analysis(
                     job.parameters.values['analysis'])
@@ -376,6 +377,7 @@ class ProcessingJob(qdb.base.QiitaObject):
                 parents = job.input_artifacts
                 params = job.parameters
                 cmd_out_id = provenance['cmd_out_id']
+                name = provenance['name']
                 analysis = None
                 data_type = None
 
@@ -385,7 +387,7 @@ class ProcessingJob(qdb.base.QiitaObject):
             a = qdb.artifact.Artifact.create(
                 filepaths, atype, parents=parents,
                 processing_parameters=params,
-                analysis=analysis, data_type=data_type)
+                analysis=analysis, data_type=data_type, name=name)
 
             self._set_status('success')
 
@@ -540,7 +542,7 @@ class ProcessingJob(qdb.base.QiitaObject):
 
                 qdb.artifact.Artifact.create(
                     filepaths, atype, prep_template=pt, analysis=an,
-                    data_type=data_type)
+                    data_type=data_type, name=job_params['name'])
                 self._set_status('success')
 
     def _complete_artifact_transformation(self, artifacts_data):
@@ -612,7 +614,8 @@ class ProcessingJob(qdb.base.QiitaObject):
                 cmd_out_id = qdb.util.convert_to_id(
                     out_name, "command_output", "name")
                 provenance = {'job': self.id,
-                              'cmd_out_id': cmd_out_id}
+                              'cmd_out_id': cmd_out_id,
+                              'name': out_name}
 
                 # Get the validator command for the current artifact type and
                 # create a new job

--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -361,15 +361,17 @@ class Command(qdb.base.QiitaObject):
                                   for atid in supported_types]
                     qdb.sql_connection.TRN.add(sql, sql_params, many=True)
                 # If this is the validate command, we need to add the
-                # provenance parameter. This is used internally, that's why
-                # we are adding it here
+                # provenance and name parameters. These are used internally,
+                # that's why we are adding them here
                 if name == 'Validate':
                     sql = """INSERT INTO qiita.command_parameter
                                 (command_id, parameter_name, parameter_type,
                                  required, default_value)
-                             VALUES (%s, 'provenance', 'string', 'False', NULL)
+                             VALUES (%s, 'name', 'string', 'False', NULL),
+                                    (%s, 'provenance', 'string', 'False', NULL)
+
                              """
-                    qdb.sql_connection.TRN.add(sql, [c_id])
+                    qdb.sql_connection.TRN.add(sql, [c_id, c_id])
 
             # Add the outputs to the command
             if outputs:

--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -369,7 +369,6 @@ class Command(qdb.base.QiitaObject):
                                  required, default_value)
                              VALUES (%s, 'name', 'string', 'False', NULL),
                                     (%s, 'provenance', 'string', 'False', NULL)
-
                              """
                     qdb.sql_connection.TRN.add(sql, [c_id, c_id])
 

--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -367,7 +367,8 @@ class Command(qdb.base.QiitaObject):
                     sql = """INSERT INTO qiita.command_parameter
                                 (command_id, parameter_name, parameter_type,
                                  required, default_value)
-                             VALUES (%s, 'name', 'string', 'False', NULL),
+                             VALUES (%s, 'name', 'string', 'False',
+                                     'dflt_name'),
                                     (%s, 'provenance', 'string', 'False', NULL)
                              """
                     qdb.sql_connection.TRN.add(sql, [c_id, c_id])

--- a/qiita_db/support_files/patches/42.sql
+++ b/qiita_db/support_files/patches/42.sql
@@ -9,7 +9,7 @@ BEGIN
         SELECT command_id FROM qiita.software_command WHERE name = 'Validate'
     LOOP
         INSERT INTO qiita.command_parameter (command_id, parameter_name, parameter_type, required, default_value)
-            VALUES (cmd.command_id, 'provenance', 'string', 'False', 'dflt_name');
+            VALUES (cmd.command_id, 'provenance', 'string', 'False', NULL);
 
     END LOOP;
 END $do$

--- a/qiita_db/support_files/patches/42.sql
+++ b/qiita_db/support_files/patches/42.sql
@@ -9,7 +9,7 @@ BEGIN
         SELECT command_id FROM qiita.software_command WHERE name = 'Validate'
     LOOP
         INSERT INTO qiita.command_parameter (command_id, parameter_name, parameter_type, required, default_value)
-            VALUES (cmd.command_id, 'provenance', 'string', 'False', NULL);
+            VALUES (cmd.command_id, 'provenance', 'string', 'False', 'dflt_name');
 
     END LOOP;
 END $do$

--- a/qiita_db/support_files/patches/59.sql
+++ b/qiita_db/support_files/patches/59.sql
@@ -9,6 +9,6 @@ BEGIN
         SELECT command_id FROM qiita.software_command WHERE name = 'Validate'
     LOOP
         INSERT INTO qiita.command_parameter (command_id, parameter_name, parameter_type, required, default_value)
-            VALUES (cmd.command_id, 'name', 'string', 'False', NULL);
+            VALUES (cmd.command_id, 'name', 'string', 'False', 'default_name');
     END LOOP;
 END $do$

--- a/qiita_db/support_files/patches/59.sql
+++ b/qiita_db/support_files/patches/59.sql
@@ -1,0 +1,14 @@
+-- Sep 15, 2017
+-- Adding "name" parameter to validate commands
+
+DO $do$
+DECLARE
+    cmd     RECORD;
+BEGIN
+    FOR cmd IN
+        SELECT command_id FROM qiita.software_command WHERE name = 'Validate'
+    LOOP
+        INSERT INTO qiita.command_parameter (command_id, parameter_name, parameter_type, required, default_value)
+            VALUES (cmd.command_id, 'name', 'string', 'False', NULL);
+    END LOOP;
+END $do$

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -1004,7 +1004,7 @@ class ArtifactTests(TestCase):
                              'template': 1,
                              'provenance': dumps(
                                 {'job': "bcc7ebcd-39c1-43e4-af2d-822e3589f14d",
-                                 'cmd_out_id': 3})}
+                                 'cmd_out_id': 3, 'name': 'test-delete'})}
             )
         )
         parent = qdb.processing_job.ProcessingJob(

--- a/qiita_db/test/test_processing_job.py
+++ b/qiita_db/test/test_processing_job.py
@@ -325,7 +325,8 @@ class ProcessingJobTest(TestCase):
                          'provenance': dumps(
                             {'job': job.id,
                              'cmd_out_id': qdb.util.convert_to_id(
-                                'out1', "command_output", "name")})})
+                                'out1', "command_output", "name"),
+                             'name': 'out1'})})
         user = qdb.user.User('test@foo.bar')
         obs1 = qdb.processing_job.ProcessingJob.create(user, params)
         obs1._set_status('running')
@@ -336,7 +337,8 @@ class ProcessingJobTest(TestCase):
                          'provenance': dumps(
                             {'job': job.id,
                              'cmd_out_id': qdb.util.convert_to_id(
-                                'out1', "command_output", "name")})})
+                                'out1', "command_output", "name"),
+                             'name': 'out1'})})
         obs2 = qdb.processing_job.ProcessingJob.create(user, params)
         obs2._set_status('running')
         # Make sure that we link the original job with its validator jobs
@@ -635,7 +637,8 @@ class ProcessingJobTest(TestCase):
                          'artifact_type': 'BIOM',
                          'provenance': dumps(
                             {'job': job.id,
-                             'cmd_out_id': 3})}
+                             'cmd_out_id': 3,
+                             'name': 'outArtifact'})}
         )
         obs = qdb.processing_job.ProcessingJob.create(
             qdb.user.User('test@foo.bar'), params)
@@ -645,12 +648,11 @@ class ProcessingJobTest(TestCase):
         job.release_validators()
         self.assertEqual(job.status, 'success')
 
+        artifact = qdb.artifact.Artifact(exp_artifact_count)
         obs = job.outputs
-        self.assertEqual(
-            obs, {'OTU table': qdb.artifact.Artifact(exp_artifact_count)})
-        self._clean_up_files.extend(
-            [afp for _, afp, _ in
-                qdb.artifact.Artifact(exp_artifact_count).filepaths])
+        self.assertEqual(obs, {'OTU table': artifact})
+        self._clean_up_files.extend([afp for _, afp, _ in artifact.filepaths])
+        self.assertEqual(artifact.name, 'outArtifact')
 
     def test_processing_job_worflow(self):
         # testing None

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -330,7 +330,7 @@ class CommandTests(TestCase):
             'files': ('string', [None]),
             'artifact_type': ('string', [None])}
         self.assertEqual(obs.required_parameters, exp_required)
-        exp_optional = {'name': ['string', None],
+        exp_optional = {'name': ['string', 'dflt_name'],
                         'provenance': ['string', None]}
         self.assertEqual(obs.optional_parameters, exp_optional)
         self.assertFalse(obs.analysis_only)

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -308,6 +308,33 @@ class CommandTests(TestCase):
         self.assertEqual(obs.optional_parameters, exp_optional)
         self.assertTrue(obs.analysis_only)
 
+        # Test that the internal parameters in "Validate"
+        # are created automatically
+        software = qdb.software.Software.create(
+            "New Type Software", "1.0.0",
+            "This is adding a new software for testing", "env_name",
+            "start_plugin", "artifact definition")
+        parameters = {
+            'template': ('prep_template', None),
+            'analysis': ('analysis', None),
+            'files': ('string', None),
+            'artifact_type': ('string', None)}
+        obs = qdb.software.Command.create(
+            software, "Validate", "Test creating a validate command",
+            parameters)
+        self.assertEqual(obs.name, "Validate")
+        self.assertEqual(obs.description, "Test creating a validate command")
+        exp_required = {
+            'template': ('prep_template', [None]),
+            'analysis': ('analysis', [None]),
+            'files': ('string', [None]),
+            'artifact_type': ('string', [None])}
+        self.assertEqual(obs.required_parameters, exp_required)
+        exp_optional = {'name': ['string', None],
+                        'provenance': ['string', None]}
+        self.assertEqual(obs.optional_parameters, exp_optional)
+        self.assertFalse(obs.analysis_only)
+
     def test_activate(self):
         qdb.software.Software.deactivate_all()
         tester = qdb.software.Command(1)

--- a/qiita_pet/handlers/api_proxy/artifact.py
+++ b/qiita_pet/handlers/api_proxy/artifact.py
@@ -217,7 +217,8 @@ def artifact_post_req(user_id, filepaths, artifact_type, name,
             Parameters.load(command, values_dict={
                 'template': prep_template_id,
                 'files': dumps(cleaned_filepaths),
-                'artifact_type': artifact_type
+                'artifact_type': artifact_type,
+                'name': name
                 }))
 
     # Submit the job


### PR DESCRIPTION
This PR uses the name that the user provided when uploading and artifact and it uses the default output command name to name the artifact when a job completes.