### PR TITLE
redbiom nice display of 504

### DIFF
--- a/qiita_pet/templates/redbiom.html
+++ b/qiita_pet/templates/redbiom.html
@@ -121,15 +121,15 @@
   $("#submitForm").submit(function(event){
     event.preventDefault();
 
-    show_loading("redbiom-info");
+    show_loading("redbiom-info", true);
 
     var search = $("#search").val();
     var search_on = $("#search_on").val();
+    var redbiom_info = $('#redbiom-info');
 
     $.post("{% raw qiita_config.portal_dir %}/redbiom/", {'search': search, 'search_on': search_on})
       .done(function ( data ){
         var redbiom_table = $('#redbiom-table').DataTable();
-        var redbiom_info = $('#redbiom-info');
         // the next 4 lines reset the column filtering
         var placer = $(".ps");
         redbiom_table.column(3).search("").draw();
@@ -148,7 +148,17 @@
             redbiom_info.html('');
           }
         }
-      });
+      })
+    .fail(function(response, status, error) {
+      var text = 'The query response is larger than is currently allowed, please try another.';
+      if (response.status != 504) {
+        text = 'Status code: "' + response.status + '" - ' + error + '.<br/>Please send a screenshot to <a href="qiita.help@gmail.com">qiita.help@gmail.com</a>.';
+      }
+      redbiom_info.html(
+        `<div class="alert alert-danger alert-dismissible" role="alert">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <strong>Error!</strong> ` + text + `</div><br/>`)
+    })
     });
   });
 </script>

--- a/qiita_pet/templates/redbiom.html
+++ b/qiita_pet/templates/redbiom.html
@@ -150,7 +150,7 @@
         }
       })
     .fail(function(response, status, error) {
-      var text = 'The query response is larger than is currently allowed, please try another.';
+      var text = 'The query response is larger than is currently allowed, please try another. <a href="https://github.com/biocore/qiita/issues/2312" target="_blank">Track progress on this issue.</a>';
       if (response.status != 504) {
         text = 'Status code: "' + response.status + '" - ' + error + '.<br/>Please send a screenshot to <a href="qiita.help@gmail.com">qiita.help@gmail.com</a>.';
       }

--- a/qiita_pet/templates/sitebase.html
+++ b/qiita_pet/templates/sitebase.html
@@ -71,8 +71,12 @@
        * gif to show that the section of page is loading
        *
        */
-      function show_loading(div_name) {
-        $("#" + div_name).html("<img src='{% raw qiita_config.portal_dir %}/static/img/waiting.gif' style='display:block;margin-left: auto;margin-right: auto'/>");
+      function show_loading(div_name, show_text = false) {
+        var text = "<img src='{% raw qiita_config.portal_dir %}/static/img/waiting.gif' style='display:block;margin-left: auto;margin-right: auto'/>";
+        if (show_text) {
+          text += '<br/><center><b>This task might take a long time (up to 5 minutes), please do not close this page.</center></b>';
+        }
+        $("#" + div_name).html(text);
       }
 
       function overlay_check() {


### PR DESCRIPTION
After doing some more tests with qiita/redbiom, I realized that if you retrieve a lot of results, the server will send a 504 (timeout) and this wasn't being caught by JS. Obviously, this is not a solution but the solution is something that might take some discussion of how to better implement + implementation time. So for the time being this PR adds a "nice" error message.

If timeout:
![504](https://user-images.githubusercontent.com/2014559/30860053-15a85c22-a283-11e7-8dea-ebfc9e728420.png)

if something else,
![500](https://user-images.githubusercontent.com/2014559/30860068-1c032fc0-a283-11e7-8a77-59489c960637.png)

Additionally, decided to improve the show_loading by adding a flag to show some extra text: "This task might take a long time (up to 5 minutes), please do not close this page.". This feature is currently only being used by redbiom but this might be useful for others in the future. Note that 5 min is just a number based on what I was seeing in my tests.