### PR TITLE
fix #2333

### DIFF
--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -926,8 +926,8 @@ class UtilTests(TestCase):
         exp = [
             {'files': ['1_study_1001_closed_reference_otu_table.biom'],
              'target_subfragment': ['V4'], 'artifact_id': 4,
-             'algorithm': ('Pick closed-reference OTUs, QIIMEv1.9.1 |'
-                           ' barcode_type 8, defaults'),
+             'algorithm': (
+                'Pick closed-reference OTUs, QIIMEv1.9.1 | Defaults'),
              'data_type': '18S', 'prep_samples': 27,
              'parameters': {
                 'reference': 1, 'similarity': 0.97, 'sortmerna_e_value': 1,

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -42,7 +42,6 @@ Methods
 
 from __future__ import division
 from future.builtins import zip
-from future.utils import viewitems
 from random import SystemRandom
 from string import ascii_letters, digits, punctuation
 from binascii import crc32
@@ -56,6 +55,7 @@ from datetime import datetime
 from itertools import chain
 from contextlib import contextmanager
 from future.builtins import bytes, str
+from collections import defaultdict
 import h5py
 
 from qiita_core.exceptions import IncompetentQiitaDeveloperError
@@ -1466,9 +1466,10 @@ def get_artifacts_information(artifact_ids, only_biom=True):
 
         sql = """
             WITH main_query AS (
-                SELECT a.artifact_id, a.name, a.command_id,
+                SELECT a.artifact_id, a.name, a.command_id as cid,
                        a.generated_timestamp, array_agg(a.command_parameters),
                        dt.data_type, parent_id,
+                       parent_info.command_id,
                        array_agg(parent_info.command_parameters),
                        array_agg(filepaths.filepath),
                        qiita.find_artifact_roots(a.artifact_id) AS root_id
@@ -1483,7 +1484,8 @@ def get_artifacts_information(artifact_ids, only_biom=True):
                     a.artifact_id = pa.artifact_id)
                 LEFT JOIN qiita.data_type dt USING (data_type_id)
                 LEFT OUTER JOIN LATERAL (
-                    SELECT command_parameters FROM qiita.artifact ap
+                    SELECT command_id, command_parameters
+                    FROM qiita.artifact ap
                     WHERE ap.artifact_id = pa.parent_id) parent_info ON true
                 LEFT OUTER JOIN LATERAL (
                     SELECT filepath
@@ -1492,8 +1494,9 @@ def get_artifacts_information(artifact_ids, only_biom=True):
                     WHERE af.artifact_id = a.artifact_id) filepaths ON true
                 WHERE a.artifact_id IN %s
                 GROUP BY a.artifact_id, a.name, a.command_id,
-                         a.generated_timestamp, dt.data_type, parent_id
-                ORDER BY command_id, artifact_id),
+                         a.generated_timestamp, dt.data_type, parent_id,
+                         parent_info.command_id
+                ORDER BY a.command_id, artifact_id),
               has_target_subfragment AS (
                 SELECT main_query.*, CASE WHEN (
                         SELECT true FROM information_schema.columns
@@ -1506,13 +1509,15 @@ def get_artifacts_information(artifact_ids, only_biom=True):
                     main_query.root_id = pt.artifact_id)
             )
             SELECT * FROM has_target_subfragment
-            ORDER BY command_id, data_type, artifact_id
+            ORDER BY cid, data_type, artifact_id
             """
 
-        sql_params = """
-            SELECT parameter_set_name, array_agg(parameter_set) AS param_set
-            FROM qiita.default_parameter_set
-            GROUP BY parameter_set_name"""
+        sql_params = """SELECT default_parameter_set_id, command_id,
+                            parameter_set_name,
+                            array_agg(parameter_set) AS param_set
+                        FROM qiita.default_parameter_set
+                        GROUP BY default_parameter_set_id, command_id,
+                            parameter_set_name"""
 
         sql_ts = """SELECT DISTINCT target_subfragment FROM qiita.prep_%s"""
 
@@ -1523,8 +1528,9 @@ def get_artifacts_information(artifact_ids, only_biom=True):
             # they are not that many (~40) and we don't expect
             # to have a huge growth in the near future
             qdb.sql_connection.TRN.add(sql_params)
-            params = {name: set(params[0].iteritems()) for name, params in
-                      qdb.sql_connection.TRN.execute_fetchindex()}
+            params = defaultdict(list)
+            for _, cid, n, p in qdb.sql_connection.TRN.execute_fetchindex():
+                params[cid].append((n, list(p[0].iteritems())))
 
             # now let's get the actual artifacts
             ts = {}
@@ -1532,21 +1538,22 @@ def get_artifacts_information(artifact_ids, only_biom=True):
             PT = qdb.metadata_template.prep_template.PrepTemplate
             qdb.sql_connection.TRN.add(sql, [tuple(artifact_ids)])
             for row in qdb.sql_connection.TRN.execute_fetchindex():
-                aid, name, cid, gt, aparams, dt, pid, pparams, filepaths, _, \
-                    target, prep_template_id = row
+                aid, name, cid, gt, aparams, dt, pid, pcid, pparams, \
+                    filepaths, _, target, prep_template_id = row
 
                 # cleaning fields:
                 # - [0] due to the array_agg
                 pparams = pparams[0]
                 if pparams is not None:
+                    pparams = list(pparams.iteritems())
                     # [-1] taking the last cause it's sorted by
                     #      the number of overlapping parameters
                     # [0] then taking the first element that is
                     # the name of the parameter set
-                    pparams = sorted([
-                        [k, len(v & set(pparams.iteritems()))]
-                        for k, v in viewitems(params)],
-                        key=lambda x: x[1])[-1][0]
+                    pparams = sorted(
+                        [(pn, len([vv for vv in v if vv in pparams]))
+                         for pn, v in params[pcid]], key=lambda x: x[1])[-1]
+                    pparams = 'N/A' if pparams[1] == 0 else pparams[0]
                 else:
                     pparams = 'N/A'
                 # - [0] due to the array_agg

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -1513,11 +1513,8 @@ def get_artifacts_information(artifact_ids, only_biom=True):
             """
 
         sql_params = """SELECT default_parameter_set_id, command_id,
-                            parameter_set_name,
-                            array_agg(parameter_set) AS param_set
-                        FROM qiita.default_parameter_set
-                        GROUP BY default_parameter_set_id, command_id,
-                            parameter_set_name"""
+                            parameter_set_name, parameter_set AS param_set
+                        FROM qiita.default_parameter_set"""
 
         sql_ts = """SELECT DISTINCT target_subfragment FROM qiita.prep_%s"""
 
@@ -1530,7 +1527,7 @@ def get_artifacts_information(artifact_ids, only_biom=True):
             qdb.sql_connection.TRN.add(sql_params)
             params = defaultdict(list)
             for _, cid, n, p in qdb.sql_connection.TRN.execute_fetchindex():
-                params[cid].append((n, list(p[0].iteritems())))
+                params[cid].append((n, list(p.iteritems())))
 
             # now let's get the actual artifacts
             ts = {}

--- a/qiita_pet/handlers/api_proxy/tests/test_artifact.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_artifact.py
@@ -224,8 +224,8 @@ class TestArtifactAPI(TestCase):
         data = [
             {'files': ['1_study_1001_closed_reference_otu_table_Silva.biom'],
              'target_subfragment': ['V4'],
-             'algorithm': ('Pick closed-reference OTUs, QIIMEv1.9.1 | '
-                           'barcode_type 8, defaults'),
+             'algorithm': (
+                'Pick closed-reference OTUs, QIIMEv1.9.1 | Defaults'),
              'artifact_id': 6, 'data_type': '16S',
              'timestamp': '2012-10-02 17:30:00', 'prep_samples': 27,
              'parameters': {
@@ -234,8 +234,8 @@ class TestArtifactAPI(TestCase):
                 'sortmerna_coverage': 0.97}, 'name': 'BIOM'},
             {'files': ['1_study_1001_closed_reference_otu_table.biom'],
              'target_subfragment': ['V4'],
-             'algorithm': ('Pick closed-reference OTUs, QIIMEv1.9.1 | '
-                           'barcode_type 8, defaults'),
+             'algorithm': (
+                'Pick closed-reference OTUs, QIIMEv1.9.1 | Defaults'),
              'artifact_id': 5, 'data_type': '18S',
              'timestamp': '2012-10-02 17:30:00', 'prep_samples': 27,
              'parameters': {

--- a/qiita_pet/handlers/study_handlers/tests/test_artifact.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_artifact.py
@@ -167,8 +167,7 @@ class ArtifactGetInfoTest(TestHandlerBase):
              'target_subfragment': ['V4'], 'artifact_id': 6,
              'data_type': '16S', 'timestamp': '2012-10-02 17:30:00',
              'prep_samples': 27,
-             'algorithm': 'Pick closed-reference OTUs, QIIMEv1.9.1 | '
-                          'barcode_type 8, defaults',
+             'algorithm': 'Pick closed-reference OTUs, QIIMEv1.9.1 | Defaults',
              'parameters': {
                 'reference': 2, 'similarity': 0.97, 'sortmerna_e_value': 1,
                 'sortmerna_max_pos': 10000, 'input_data': 2, 'threads': 1,


### PR DESCRIPTION
This definitely wasn't an easy fix: @adswafford. 

Displaying the parent's processing name beside the artifacts was already implemented. However, the implementation assumed that each default_parameter_set was unique, which is not true (lots of 'Defaults') and the code was "getting confused" between them. This is solved in these code changes. I also made the search/match of parameters per command so that steps happens faster.

Additionally, we realized that for some reason (still looking into this) there is a difference between the trimming version in Qiita. The difference is that the length is being stored as string/int - this is the only command in the full database that has this problem (checked several times, this morning again). Thus, we need to discuss this during tomorrow's meeting.