### PR TITLE
fix #2125

### DIFF
--- a/qiita_pet/handlers/api_proxy/studies.py
+++ b/qiita_pet/handlers/api_proxy/studies.py
@@ -272,6 +272,7 @@ def study_files_get_req(user_id, study_id, prep_template_id, artifact_type):
     supp_file_types = supported_filepath_types(artifact_type)
     selected = []
     remaining = []
+    message = []
 
     uploaded = get_files_from_uploads_folders(study_id)
     pt = PrepTemplate(prep_template_id)
@@ -304,6 +305,7 @@ def study_files_get_req(user_id, study_id, prep_template_id, artifact_type):
             # the selected group
             if len_files > supp_file_types_len:
                 remaining.extend(v)
+                message.append("'%s' has %d matches." % (k, len_files))
             else:
                 v.sort()
                 selected.append(v)
@@ -329,8 +331,11 @@ def study_files_get_req(user_id, study_id, prep_template_id, artifact_type):
             artifact_options.append(
                 (a.id, "%s - %s (%d)" % (study_label, a.name, a.id)))
 
+    message = ('' if not message
+               else '\n'.join(['Check these run_prefix:'] + message))
+
     return {'status': 'success',
-            'message': '',
+            'message': message,
             'remaining': sorted(remaining),
             'file_types': file_types,
             'num_prefixes': num_prefixes,

--- a/qiita_pet/handlers/api_proxy/tests/test_studies.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_studies.py
@@ -462,7 +462,7 @@ class TestStudyAPI(TestCase):
         exp = {'status': 'success', 'num_prefixes': 2, 'artifacts': [],
                'remaining': ['test_1.R1.fastq.gz', 'test_1.R2.fastq.gz',
                              'test_1.R3.fastq.gz', 'uploaded_file.txt'],
-               'message': '',
+               'message':  "Check these run_prefix:\n'test_1' has 3 matches.",
                'file_types': [('raw_forward_seqs', True,
                                ['test_2.R1.fastq.gz']),
                               ('raw_reverse_seqs', False,

--- a/qiita_pet/templates/study_ajax/artifact_file_selector.html
+++ b/qiita_pet/templates/study_ajax/artifact_file_selector.html
@@ -206,6 +206,10 @@
         Please make sure that the correct files are in the correct column.<br/>
         Note: the system will try to auto select the files based on run_prefix, if that doesn't work, either the type you selected doesn't support
         the use of run_prefix or the run_prefix is wrong
+        {% if message %}
+          <hr/>
+          {% raw message.replace('\n', '<br/>') %}
+        {% end %}
       </div>
 
   </div>


### PR DESCRIPTION
https://github.com/biocore/qiita/issues/2125 it's an interesting issue cause the problem is that many of the files match the run_prefix and thus the system can't decide which is which. I think the best solution is documentation and letting the user know how many files match the error. @colinbrislawn, what do you think?

The current solution looks like this:
![2125](https://user-images.githubusercontent.com/2014559/31832156-328fda00-b583-11e7-8747-3593554acc51.gif)
