### PR TITLE
Deleting jobs

### DIFF
--- a/qiita_db/test/test_processing_job.py
+++ b/qiita_db/test/test_processing_job.py
@@ -733,6 +733,32 @@ class ProcessingJobTest(TestCase):
         self.assertEqual(job.processing_job_workflow,
                          qdb.processing_job.ProcessingWorkflow(1))
 
+    def test_hidden(self):
+        self.assertTrue(self.tester1.hidden)
+        self.assertTrue(self.tester2.hidden)
+        self.assertFalse(self.tester3.hidden)
+        self.assertTrue(self.tester4.hidden)
+
+    def test_hide(self):
+        QE = qdb.exceptions
+        # It's in a queued state
+        with self.assertRaises(QE.QiitaDBOperationNotPermittedError):
+            self.tester1.hide()
+
+        # It's in a running state
+        with self.assertRaises(QE.QiitaDBOperationNotPermittedError):
+            self.tester2.hide()
+
+        # It's in a success state
+        with self.assertRaises(QE.QiitaDBOperationNotPermittedError):
+            self.tester3.hide()
+
+        job = _create_job()
+        job._set_error('Setting to error for testing')
+        self.assertFalse(job.hidden)
+        job.hide()
+        self.assertTrue(job.hidden)
+
 
 @qiita_test_checker()
 class ProcessingWorkflowTests(TestCase):

--- a/qiita_pet/handlers/api_proxy/__init__.py
+++ b/qiita_pet/handlers/api_proxy/__init__.py
@@ -36,7 +36,7 @@ from .ontology import ontology_patch_handler
 from .processing import (
     list_commands_handler_get_req, list_options_handler_get_req,
     workflow_handler_post_req, workflow_handler_patch_req,
-    workflow_run_post_req, job_ajax_get_req)
+    workflow_run_post_req, job_ajax_get_req, job_ajax_patch_req)
 from .user import (user_jobs_get_req)
 
 __version__ = "0.2.0-dev"
@@ -66,4 +66,5 @@ __all__ = ['prep_template_summary_get_req', 'sample_template_post_req',
            'workflow_handler_patch_req', 'workflow_run_post_req',
            'job_ajax_get_req', 'artifact_patch_request',
            'sample_template_patch_request',
-           'get_sample_template_processing_status', 'user_jobs_get_req']
+           'get_sample_template_processing_status', 'user_jobs_get_req',
+           'job_ajax_patch_req']

--- a/qiita_pet/handlers/api_proxy/processing.py
+++ b/qiita_pet/handlers/api_proxy/processing.py
@@ -234,9 +234,88 @@ def job_ajax_get_req(job_id):
          'job_parameters': dict of {str: str}}
     """
     job = ProcessingJob(job_id)
+    cmd = job.command
+    sw = cmd.software
     return {'status': 'success',
             'message': '',
             'job_id': job.id,
             'job_status': job.status,
             'job_step': job.step,
-            'job_parameters': job.parameters.values}
+            'job_parameters': job.parameters.values,
+            'command': cmd.name,
+            'command_description': cmd.description,
+            'software': sw.name,
+            'software_version': sw.version}
+
+
+def job_ajax_patch_req(req_op, req_path, req_value=None, req_from=None):
+    """Patches a job
+
+    Parameters
+    ----------
+    req_op : str
+        The operation to perform on the job
+    req_path : str
+        Path parameter with the job to patch
+    req_value : str, optional
+        The value that needs to be modified
+    req_from : str, optional
+        The original path of the element
+
+    Returns
+    -------
+    dict of {str: str}
+        A dictionary of the form: {'status': str, 'message': str} in which
+        status is the status of the request ('error' or 'success') and message
+        is a human readable string with the error message in case that status
+        is 'error'.
+    """
+    if req_op == 'remove':
+        req_path = [v for v in req_path.split('/') if v]
+        if len(req_path) != 1:
+            return {'status': 'error',
+                    'message': 'Incorrect path parameter: missing job id'}
+
+        # We have ensured that we only have one element on req_path
+        job_id = req_path[0]
+        try:
+            job = ProcessingJob(job_id)
+        except QiitaDBUnknownIDError as e:
+            return {'status': 'error',
+                    'message': 'Incorrect path parameter: '
+                               '%s is not a recognized job id' % job_id}
+        except Exception as e:
+            e = str(e)
+            if "invalid input syntax for uuid" in e:
+                return {'status': 'error',
+                        'message': 'Incorrect path parameter: '
+                                   '%s is not a recognized job id' % job_id}
+            else:
+                return {'status': 'error',
+                        'message': 'An error occured while accessing the '
+                                   'job: %s' % e}
+
+        job_status = job.status
+
+        if job_status == 'in_construction':
+            # A job that is in construction is in a workflow. Use the methods
+            # defined for workflows to keep everything consistent. This message
+            # should never be presented to the user, but rather to the
+            # developer if it makes a mistake during changes in the interface
+            return {'status': 'error',
+                    'message': "Can't delete job %s. It is 'in_construction' "
+                               "status. Please use /study/process/workflow/"
+                               % job_id}
+        elif job_status == 'error':
+            # When the job is in error status, we just need to hide it
+            job.hide()
+            return {'status': 'success', 'message': ''}
+        else:
+            # In any other state, we currently fail. Adding the else here
+            # because it can be useful to have it for fixing issue #2307
+            return {'status': 'error',
+                    'message': 'Only jobs in "error" status can be deleted.'}
+    else:
+        return {'status': 'error',
+                'message': 'Operation "%s" not supported. Current supported '
+                           'operations: remove' % req_op}

--- a/qiita_pet/handlers/study_handlers/processing.py
+++ b/qiita_pet/handlers/study_handlers/processing.py
@@ -14,7 +14,7 @@ from qiita_pet.handlers.base_handlers import BaseHandler
 from qiita_pet.handlers.api_proxy import (
     list_commands_handler_get_req, list_options_handler_get_req,
     workflow_handler_post_req, workflow_handler_patch_req, job_ajax_get_req,
-    workflow_run_post_req)
+    workflow_run_post_req, job_ajax_patch_req)
 
 
 class ListCommandsHandler(BaseHandler):
@@ -71,3 +71,16 @@ class JobAJAX(BaseHandler):
     def get(self):
         job_id = self.get_argument('job_id')
         self.write(job_ajax_get_req(job_id))
+
+    @authenticated
+    def patch(self):
+        req_op = self.get_argument('op')
+        req_path = self.get_argument('path')
+        req_value = self.get_argument('value', None)
+        req_from = self.get_argument('from', None)
+
+        try:
+            res = job_ajax_patch_req(req_op, req_path, req_value, req_from)
+            self.write(res)
+        except Exception as e:
+            self.write({'status': 'error', 'message': str(e)})

--- a/qiita_pet/handlers/study_handlers/tests/test_processing.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_processing.py
@@ -6,18 +6,91 @@
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
 from unittest import main
+from json import loads
 
 from qiita_pet.test.tornado_test_base import TestHandlerBase
+from qiita_db.software import Command, Parameters
+from qiita_db.user import User
+from qiita_db.processing_job import ProcessingWorkflow, ProcessingJob
 
 
-class ListCommandsHandler(TestHandlerBase):
+class TestListCommandsHandler(TestHandlerBase):
     # TODO: Missing tests
     pass
 
 
-class ListOptionsHandler(TestHandlerBase):
+class TestListOptionsHandler(TestHandlerBase):
     # TODO: Missing tests
     pass
+
+
+class TestJobAJAX(TestHandlerBase):
+    def test_get(self):
+        response = self.get('/study/process/job/',
+                            {'job_id': '063e553b-327c-4818-ab4a-adfe58e49860'})
+        self.assertEqual(response.code, 200)
+        exp = {'status': 'success',
+               'message': '',
+               'job_id': "063e553b-327c-4818-ab4a-adfe58e49860",
+               'job_status': "queued",
+               'job_step': None,
+               'job_parameters': {'barcode_type': u'golay_12',
+                                  'input_data': 1,
+                                  'max_bad_run_length': 3,
+                                  'max_barcode_errors': 1.5,
+                                  'min_per_read_length_fraction': 0.75,
+                                  'phred_quality_threshold': 3,
+                                  'rev_comp': False,
+                                  'rev_comp_barcode': False,
+                                  'rev_comp_mapping_barcodes': False,
+                                  'sequence_max_n': 0,
+                                  'phred_offset': 'auto'},
+               'command': 'Split libraries FASTQ',
+               'command_description': 'Demultiplexes and applies quality '
+                                      'control to FASTQ data',
+               'software': 'QIIME',
+               'software_version': '1.9.1'}
+        self.assertEqual(loads(response.body), exp)
+
+    def test_patch(self):
+        # Create a new job - through a workflow since that is the only way
+        # of creating jobs in the interface
+        exp_command = Command(1)
+        json_str = (
+            '{"input_data": 1, "max_barcode_errors": 1.5, '
+            '"barcode_type": "golay_12", "max_bad_run_length": 3, '
+            '"rev_comp": false, "phred_quality_threshold": 3, '
+            '"rev_comp_barcode": false, "rev_comp_mapping_barcodes": false, '
+            '"min_per_read_length_fraction": 0.75, "sequence_max_n": 0}')
+        exp_params = Parameters.load(exp_command, json_str=json_str)
+        exp_user = User('test@foo.bar')
+        name = "Test processing workflow"
+
+        # tests success
+        wf = ProcessingWorkflow.from_scratch(
+            exp_user, exp_params, name=name, force=True)
+
+        graph = wf.graph
+        nodes = graph.nodes()
+        job_id = nodes[0].id
+
+        response = self.patch('/study/process/job/',
+                              {'op': 'remove', 'path': job_id})
+        self.assertEqual(response.code, 200)
+        exp = {'status': 'error',
+               'message': "Can't delete job %s. It is 'in_construction' "
+                          "status. Please use /study/process/workflow/"
+                          % job_id}
+        self.assertEqual(loads(response.body), exp)
+
+        # Test success
+        ProcessingJob(job_id)._set_error('Killed for testing')
+        response = self.patch('/study/process/job/',
+                              {'op': 'remove', 'path': job_id})
+        self.assertEqual(response.code, 200)
+        exp = {'status': 'success',
+               'message': ''}
+        self.assertEqual(loads(response.body), exp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allows to delete a job from the GUI if the job is "in_construction" or "errored".
It also adds a link to allow updating the graph w/o needing to reload the entire page.
The job description page has also been improved.

Here is a gif showing the changes (I know it's a long one but it shows all the functionality...):

![deletejob](https://user-images.githubusercontent.com/2501478/33741435-316a477c-db59-11e7-9352-bb9a625e4fc2.gif)
