### PR TITLE
Fixing Validator/Summary retrieval

### DIFF
--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -104,7 +104,8 @@ class Command(qdb.base.QiitaObject):
                         JOIN qiita.software_artifact_type USING (software_id)
                         JOIN qiita.artifact_type USING (artifact_type_id)
                      WHERE artifact_type = %s
-                        AND name = 'Generate HTML summary'"""
+                        AND name = 'Generate HTML summary'
+                        AND active = true"""
             qdb.sql_connection.TRN.add(sql, [artifact_type])
             try:
                 res = qdb.sql_connection.TRN.execute_fetchlast()
@@ -139,7 +140,8 @@ class Command(qdb.base.QiitaObject):
                         JOIN qiita.software_artifact_type USING (software_id)
                         JOIN qiita.artifact_type USING (artifact_type_id)
                      WHERE artifact_type = %s
-                        AND name = 'Validate'"""
+                        AND name = 'Validate'
+                        AND active = true"""
             qdb.sql_connection.TRN.add(sql, [artifact_type])
             try:
                 res = qdb.sql_connection.TRN.execute_fetchlast()

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -73,28 +73,42 @@ class CommandTests(TestCase):
         self.assertItemsEqual(obs, exp)
 
     def test_get_html_artifact(self):
-        obs = qdb.software.Command.get_html_generator('BIOM')
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.software.Command.get_html_generator('BIOM')
+
         exp = qdb.software.Command(5)
+        exp.activate()
+        obs = qdb.software.Command.get_html_generator('BIOM')
         self.assertEqual(obs, exp)
 
-        obs = qdb.software.Command.get_html_generator('Demultiplexed')
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.software.Command.get_html_generator('Demultiplexed')
+
         exp = qdb.software.Command(7)
+        exp.activate()
+        obs = qdb.software.Command.get_html_generator('Demultiplexed')
         self.assertEqual(obs, exp)
 
-    def test_get_html_artifact_error(self):
         with self.assertRaises(qdb.exceptions.QiitaDBError):
             qdb.software.Command.get_html_generator('Unknown')
 
     def test_get_validator(self):
-        obs = qdb.software.Command.get_validator('BIOM')
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.software.Command.get_validator('BIOM')
+
         exp = qdb.software.Command(4)
+        exp.activate()
+        obs = qdb.software.Command.get_validator('BIOM')
         self.assertEqual(obs, exp)
 
-        obs = qdb.software.Command.get_validator('Demultiplexed')
+        with self.assertRaises(qdb.exceptions.QiitaDBError):
+            qdb.software.Command.get_validator('Demultiplexed')
+
         exp = qdb.software.Command(6)
+        exp.activate()
+        obs = qdb.software.Command.get_validator('Demultiplexed')
         self.assertEqual(obs, exp)
 
-    def test_get_validator_error(self):
         with self.assertRaises(qdb.exceptions.QiitaDBError):
             qdb.software.Command.get_validator('Unknown')
 


### PR DESCRIPTION
Make sure that only returns the commands that are actually active.

@antgonza this will fix the issue that we are seeing with generating BIOM summaries