### PR TITLE
Fixing adding command problem

### DIFF
--- a/qiita_pet/templates/artifact_ajax/artifact_summary.html
+++ b/qiita_pet/templates/artifact_ajax/artifact_summary.html
@@ -104,7 +104,7 @@
     });
 
     $('#process-btn').on('click', function(){
-      processingNetwork.$refs.procGraph.loadArtifactType([{{artifact_id}}]);
+      processingNetwork.$refs.procGraph.loadArtifactType({{artifact_id}});
     });
 
     qiita_websocket.init(window.location.host + '{% raw qiita_config.portal_dir %}/study/list/socket/', error, error);


### PR DESCRIPTION
Carolina and Stephanie found an issue in the qiita-rc system: if you tried to add a command to an artifact that has not been generated and the job generating it has been already submitted (i.e. no longer in construction), the system failed with a really weird error. Adding a command to those types of artifacts is not easy, there are a lot of assumptions perform through the code that rely on this behavior not happening, and removing all them is complex. For the time being, I've disabled the ability to add commands to those type of artifacts (you can still add commands if the workflow is in construction). Instead it shows a little information about that (there is not too much to show, but at least it doesn't fail and you see something on the screen). GIF with the resulting changes:

![futureresult](https://user-images.githubusercontent.com/2501478/34057762-34772f0e-e18d-11e7-98d1-39e919293438.gif)
