### PR TITLE
Fix rm sample

### DIFF
--- a/qiita_pet/handlers/websocket_handlers.py
+++ b/qiita_pet/handlers/websocket_handlers.py
@@ -43,6 +43,12 @@ class MessageHandler(WebSocketHandler):
         else:
             return user.strip('" ')
 
+    # Open allows for any number arguments, unlike what pylint thinks.
+    # pylint: disable=W0221
+    @authenticated
+    def open(self):
+        self.write_message('hello')
+
     @authenticated
     def on_message(self, msg):
         # When the websocket receives a message from the javascript client,
@@ -97,8 +103,8 @@ class SelectedSocketHandler(WebSocketHandler, BaseHandler):
 
         if 'remove_sample' in msginfo:
             data = msginfo['remove_sample']
-            artifacts = [Artifact(_id) for _id in data['proc_data']]
-            default.remove_samples(artifacts, data['samples'])
+            artifact = Artifact(data['proc_data'])
+            default.remove_samples([artifact], data['samples'])
         elif 'remove_pd' in msginfo:
             data = msginfo['remove_pd']
             default.remove_samples([Artifact(data['proc_data'])])
@@ -107,6 +113,13 @@ class SelectedSocketHandler(WebSocketHandler, BaseHandler):
             artifacts = [Artifact(_id) for _id in data['pids']]
             default.remove_samples(artifacts)
         self.write_message(msg)
+
+    # Open allows for any number arguments, unlike what pylint thinks.
+    # pylint: disable=W0221
+    @authenticated
+    @execute_as_transaction
+    def open(self):
+        self.write_message('hello')
 
 
 class SelectSamplesHandler(WebSocketHandler, BaseHandler):

--- a/qiita_pet/test/test_websocket_handlers.py
+++ b/qiita_pet/test/test_websocket_handlers.py
@@ -1,0 +1,59 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014--, The Qiita Development Team.
+#
+# Distributed under the terms of the BSD 3-clause License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# -----------------------------------------------------------------------------
+
+from unittest import main
+
+from qiita_pet.test.tornado_test_base import TestHandlerWebSocketBase
+from json import dumps, loads
+
+from tornado.testing import gen_test
+from tornado.gen import coroutine, Return
+
+
+# adapted from: https://gist.github.com/crodjer/1e9989ab30fdc32db926
+class TestSelectedSocketHandler(TestHandlerWebSocketBase):
+
+    @coroutine
+    def _mk_client(self):
+        c = yield self._mk_connection()
+
+        # Discard the hello
+        # This could be any initial handshake, which needs to be generalized
+        # for most of the tests.
+        yield c.read_message()
+
+        raise Return(c)
+
+    @gen_test
+    def test_socket(self):
+        # A client with the hello taken care of.
+        c = yield self._mk_client()
+
+        msg = {'remove_sample': {'proc_data': 2, 'samples': ['A', 'B']}}
+        c.write_message(dumps(msg))
+        response = yield c.read_message()
+        self.assertEqual(loads(response), msg)
+
+        msg = {'remove_pd': {'proc_data': 2}}
+        c.write_message(dumps(msg))
+        response = yield c.read_message()
+        self.assertEqual(loads(response), msg)
+
+        msg = {'clear': {'pids': [2]}}
+        c.write_message(dumps(msg))
+        response = yield c.read_message()
+        self.assertEqual(loads(response), msg)
+
+        msg = {'clear': {'pids': [2, 3, 4]}}
+        c.write_message(dumps(msg))
+        response = yield c.read_message()
+        self.assertEqual(loads(response), msg)
+
+
+if __name__ == "__main__":
+    main()

--- a/qiita_pet/test/tornado_test_base.py
+++ b/qiita_pet/test/tornado_test_base.py
@@ -83,6 +83,7 @@ class TestHandlerBase(AsyncHTTPTestCase):
         return self.wait(timeout=15)
 
 
+# adapted from: https://gist.github.com/crodjer/1e9989ab30fdc32db926
 class TestHandlerWebSocketBase(TestHandlerBase):
     def setUp(self):
         super(TestHandlerWebSocketBase, self).setUp()

--- a/qiita_pet/test/tornado_test_base.py
+++ b/qiita_pet/test/tornado_test_base.py
@@ -12,8 +12,9 @@ try:
 except ImportError:  # py3
     from urllib.parse import urlencode
 
-from tornado.testing import AsyncHTTPTestCase
+from tornado.testing import AsyncHTTPTestCase, bind_unused_port
 from tornado.escape import json_encode
+from tornado.websocket import websocket_connect
 from qiita_pet.webserver import Application
 from qiita_pet.handlers.base_handlers import BaseHandler
 from qiita_db.environment_manager import clean_test_environment
@@ -80,3 +81,15 @@ class TestHandlerBase(AsyncHTTPTestCase):
         self.http_client.fetch(self.get_url(url), self.stop, method=method,
                                body=data, headers=headers)
         return self.wait(timeout=15)
+
+
+class TestHandlerWebSocketBase(TestHandlerBase):
+    def setUp(self):
+        super(TestHandlerWebSocketBase, self).setUp()
+        socket, self.port = bind_unused_port()
+        self.http_server.add_socket(socket)
+
+    def _mk_connection(self):
+        return websocket_connect(
+            'ws://localhost:{}/analysis/selected/socket/'.format(self.port)
+        )


### PR DESCRIPTION
A user reported that it couldn't remove samples from the creation of the analysis and then @adswafford confirmed it. Fix here also adding tests to those calls. 

Now it works:
![delete-samples](https://user-images.githubusercontent.com/2014559/34079695-d4671228-e2ef-11e7-8b42-ae0a525146a2.gif)
