### PR TITLE
fix #1105

### DIFF
--- a/qiita_db/metadata_template/test/test_util.py
+++ b/qiita_db/metadata_template/test/test_util.py
@@ -81,9 +81,26 @@ class TestUtil(TestCase):
         assert_frame_equal(obs, exp)
 
     def test_load_template_to_dataframe_duplicate_cols(self):
+        LTTD = qdb.metadata_template.util.load_template_to_dataframe
+
         with self.assertRaises(qdb.exceptions.QiitaDBDuplicateHeaderError):
-            qdb.metadata_template.util.load_template_to_dataframe(
-                StringIO(EXP_SAMPLE_TEMPLATE_DUPE_COLS))
+            LTTD(StringIO(EXP_SAMPLE_TEMPLATE_DUPE_COLS))
+
+        # testing duplicated empty headers
+        test = (
+            "sample_name\tdescription\t   \t  \t\t \t\n"
+            "sample1\tsample1\t   \t    \t\t\n"
+            "sample2\tsample2\t\t\t\t  \t")
+        with self.assertRaises(ValueError):
+            LTTD(StringIO(test))
+
+        # testing empty columns
+        test = (
+            "sample_name\tdescription\tcol1\ttcol2\n"
+            "sample1\tsample1\t   \t    \n"
+            "sample2\tsample2\t  \t")
+        df = LTTD(StringIO(test))
+        self.assertEqual(df.columns.values, ['description'])
 
     def test_load_template_to_dataframe_scrubbing(self):
         obs = qdb.metadata_template.util.load_template_to_dataframe(

--- a/qiita_db/metadata_template/util.py
+++ b/qiita_db/metadata_template/util.py
@@ -144,7 +144,11 @@ def load_template_to_dataframe(fn, index='sample_name'):
                 for c in cols]
 
             # while we are here, let's check for duplicate columns headers
-            if len(set(newcols)) != len(newcols):
+            ncols = set(newcols)
+            if len(ncols) != len(newcols):
+                if '' in ncols:
+                    raise ValueError(
+                        'Your file has empty columns headers.')
                 raise qdb.exceptions.QiitaDBDuplicateHeaderError(
                     find_duplicates(newcols))
         else:
@@ -176,6 +180,8 @@ def load_template_to_dataframe(fn, index='sample_name'):
     # remove newlines and tabs from fields
     template.replace(to_replace='[\t\n\r\x0b\x0c]+', value='',
                      regex=True, inplace=True)
+    # removing columns with empty values
+    template.dropna(axis='columns', how='all', inplace=True)
 
     initial_columns = set(template.columns)
 


### PR DESCRIPTION
This is an "interesting" issue because it's pretty hard to identify empty columns that have no header. Remember that the issue is that some of these columns/rows have spaces, which is what makes it hard. Anyway, the solution here is 2 part:
1. Check if some of the headers are empty/have empty values
2. Remove empty columns with headers <- this is not actually necessary but thought it was nice