### PR TITLE
adding qiimp via iframes

### DIFF
--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -145,6 +145,7 @@ class ConfigurationManager(object):
         self._get_ebi(config)
         self._get_vamps(config)
         self._get_portal(config)
+        self._iframe(config)
 
     def _get_main(self, config):
         """Get the configuration of the main section"""
@@ -286,3 +287,6 @@ class ConfigurationManager(object):
                 self.portal_dir = self.portal_dir[:-1]
         else:
             self.portal_dir = ""
+
+    def _iframe(self, config):
+        self.iframe_qiimp = config.get('iframe', 'QIIMP')

--- a/qiita_core/support_files/config_test.cfg
+++ b/qiita_core/support_files/config_test.cfg
@@ -162,3 +162,8 @@ PORTAL_DIR =
 
 # Full path to portal styling config file
 PORTAL_FP =
+
+
+# ----------------------------- iframes settings ---------------------------
+[iframe]
+QIIMP = http://localhost:8898/

--- a/qiita_core/support_files/config_test.cfg
+++ b/qiita_core/support_files/config_test.cfg
@@ -166,4 +166,6 @@ PORTAL_FP =
 
 # ----------------------------- iframes settings ---------------------------
 [iframe]
-QIIMP = http://localhost:8898/
+# The real world QIIMP will always need to be accessed with https because Qiita
+# runs on https too
+QIIMP = https://localhost:8898/

--- a/qiita_core/tests/test_configuration_manager.py
+++ b/qiita_core/tests/test_configuration_manager.py
@@ -105,6 +105,9 @@ class ConfigurationManagerTests(TestCase):
         self.assertEqual(obs.portal, "QIITA")
         self.assertEqual(obs.portal_dir, "/portal")
 
+        # iframe section
+        self.assertEqual(obs.iframe_qiimp, "http://localhost:8898/")
+
     def test_init_error(self):
         with open(self.conf_fp, 'w') as f:
             f.write("\n")
@@ -347,6 +350,10 @@ PORTAL_DIR = /portal
 
 # Full path to portal styling config file
 PORTAL_FP = /tmp/portal.cfg
+
+# ----------------------------- iframes settings ---------------------------
+[iframe]
+QIIMP = http://localhost:8898/
 """
 
 if __name__ == '__main__':

--- a/qiita_core/tests/test_configuration_manager.py
+++ b/qiita_core/tests/test_configuration_manager.py
@@ -353,7 +353,7 @@ PORTAL_FP = /tmp/portal.cfg
 
 # ----------------------------- iframes settings ---------------------------
 [iframe]
-QIIMP = http://localhost:8898/
+QIIMP = https://localhost:8898/
 """
 
 if __name__ == '__main__':

--- a/qiita_core/tests/test_configuration_manager.py
+++ b/qiita_core/tests/test_configuration_manager.py
@@ -106,7 +106,7 @@ class ConfigurationManagerTests(TestCase):
         self.assertEqual(obs.portal_dir, "/portal")
 
         # iframe section
-        self.assertEqual(obs.iframe_qiimp, "http://localhost:8898/")
+        self.assertEqual(obs.iframe_qiimp, "https://localhost:8898/")
 
     def test_init_error(self):
         with open(self.conf_fp, 'w') as f:

--- a/qiita_pet/handlers/auth_handlers.py
+++ b/qiita_pet/handlers/auth_handlers.py
@@ -56,7 +56,7 @@ class AuthCreateHandler(BaseHandler):
                            "click the following link to verify email address: "
                            "%s/auth/verify/%s?email=%s\n\nBy clicking you are "
                            "accepting our term and conditions: "
-                           "%s/static/qiita_data_terms_of_use.html"
+                           "%s/iframe/?iframe=qiita-terms"
                            % (url, info['user_verify_code'],
                               url_escape(username), url))
             except Exception:

--- a/qiita_pet/handlers/base_handlers.py
+++ b/qiita_pet/handlers/base_handlers.py
@@ -7,6 +7,9 @@
 # -----------------------------------------------------------------------------
 
 from tornado.web import RequestHandler
+from tornado.gen import coroutine
+
+from qiita_core.util import execute_as_transaction
 from qiita_db.logger import LogEntry
 from qiita_db.user import User
 from qiita_pet.util import convert_text_html
@@ -76,6 +79,18 @@ class MainHandler(BaseHandler):
         msg = convert_text_html(msg)
         lvl = self.get_argument('level', '')
         self.render("index.html", message=msg, level=lvl)
+
+
+class IFrame(BaseHandler):
+    '''Open one of the IFrame pages'''
+    @coroutine
+    @execute_as_transaction
+    def get(self):
+        msg = self.get_argument('message', '')
+        msg = convert_text_html(msg)
+        lvl = self.get_argument('level', '')
+        iframe = self.get_argument('iframe', '')
+        self.render("iframe.html", iframe=iframe, message=msg, level=lvl)
 
 
 class MockupHandler(BaseHandler):

--- a/qiita_pet/handlers/base_handlers.py
+++ b/qiita_pet/handlers/base_handlers.py
@@ -7,9 +7,7 @@
 # -----------------------------------------------------------------------------
 
 from tornado.web import RequestHandler
-from tornado.gen import coroutine
 
-from qiita_core.util import execute_as_transaction
 from qiita_db.logger import LogEntry
 from qiita_db.user import User
 from qiita_pet.util import convert_text_html
@@ -83,8 +81,6 @@ class MainHandler(BaseHandler):
 
 class IFrame(BaseHandler):
     '''Open one of the IFrame pages'''
-    @coroutine
-    @execute_as_transaction
     def get(self):
         msg = self.get_argument('message', '')
         msg = convert_text_html(msg)

--- a/qiita_pet/static/qiita_data_terms_of_use.html
+++ b/qiita_pet/static/qiita_data_terms_of_use.html
@@ -8,15 +8,15 @@
     <h1>Qiita Data - Terms of Use</h1>
 
     <p>
-      Please read these terms of use (“Terms”) carefully before using Qiita,
+      Please read these terms of use ("Terms") carefully before using Qiita,
       directly or through our web services. By using Qiita, you signify that
       you have read, understood and are in agreement with these Terms and with
-      the University of California’s Terms and Conditions of Use posted at
+      the University of California's Terms and Conditions of Use posted at
       <a href="http://www.ucop.edu/terms">http://www.ucop.edu/terms</a>, which
       are incorporated by reference into these Terms as if set forth fully
       herein. You also represent that you are the representative of any entity
       for which you are using Qiita and that you are authorized by such entity
-      to enter into a legal agreement on that entity’s behalf. If you do not
+      to enter into a legal agreement on that entity's behalf. If you do not
       agree with any of these Terms, you are not permitted to use Qiita.
     </p>
 
@@ -32,13 +32,13 @@
           </li>
           <li>
             Qiita allows users to keep track of multiple studies with multiple
-            "'omics" data and Qiita’s main site provides database and compute
+            "'omics" data and Qiita's main site provides database and compute
             resources to the global community, alleviating the technical
             burdens, such as familiarity with the command line or access to
             compute power, that are typically limiting for researchers
-            studying microbial ecology. Qiita’s platform allows for quick
+            studying microbial ecology. Qiita's platform allows for quick
             reanalysis of the datasets that have been deposited using the
-            latests analytical technologies. This means that Qiita’s
+            latests analytical technologies. This means that Qiita's
             internal datasets are living data that is periodically re-annotated
             according to current best practices.
           </li>
@@ -50,7 +50,7 @@
             Knight Lab at the University of California, San Diego, including
             any service, application, data, information, technical assistance,
             software, algorithms or analytical tools accessible through the
-            Qiita website, related web properties, or Qiita’s GitHub page.
+            Qiita website, related web properties, or Qiita's GitHub page.
           </li>
           <li>
             "Data" means any and all information, in whatever form, that you
@@ -75,7 +75,7 @@
             Data you transfer to or from Qiita.
           </li>
         </ol>
-      <li><u>Qiita’s Data Rights.</u></li>
+      <li><u>Qiita's Data Rights.</u></li>
         <ol type="a">
           <li>
             You hereby grant to Qiita a non-exclusive, perpetual, global,

--- a/qiita_pet/templates/iframe.html
+++ b/qiita_pet/templates/iframe.html
@@ -1,0 +1,14 @@
+{% extends sitebase.html %}
+{% block content %}
+
+{% if iframe == 'qiita-terms' %}
+  <iframe style="margin: 0; padding: 0; width: 100%; height: 400px;" src="{% raw qiita_config.portal_dir %}/static/qiita_data_terms_of_use.html"></iframe>
+{% elif iframe == 'qiimp' %}
+  <iframe style="margin: 0; padding: 0; width: 100%; height: 400px;" src="{{qiita_config.iframe_qiimp}}"></iframe>
+{% else %}
+  <b>No content</b>
+{% end %}
+
+
+
+{% end %}

--- a/qiita_pet/templates/iframe.html
+++ b/qiita_pet/templates/iframe.html
@@ -9,6 +9,4 @@
   <b>No content</b>
 {% end %}
 
-
-
 {% end %}

--- a/qiita_pet/templates/sitebase.html
+++ b/qiita_pet/templates/sitebase.html
@@ -483,7 +483,12 @@
             </ul>
             <ul class="nav navbar-nav">
               <li>
-                <a href="{% raw qiita_config.portal_dir %}/redbiom/">Redbiom</a>
+                <a href="{% raw qiita_config.portal_dir %}/redbiom/">redbiom</a>
+              </li>
+            </ul>
+            <ul class="nav navbar-nav">
+              <li>
+                <a href="{% raw qiita_config.portal_dir %}/iframe/?iframe=qiimp">Qiimp</a>
               </li>
             </ul>
             <ul class="nav navbar-nav">
@@ -549,7 +554,7 @@
         <br/>
         Questions? <a href="mailto:qiita.help@gmail.com">qiita.help@gmail.com</a>
         <br/>
-        Read our <a href="{% raw qiita_config.portal_dir %}/static/qiita_data_terms_of_use.html">terms and conditions</a>.
+        Read our <a href="{% raw qiita_config.portal_dir %}/iframe/?iframe=qiita-terms">terms and conditions</a>.
       </div>
       <div id="overlay" class="navbar-brand" style="visibility: hidden; position: absolute; left: 0px; top: 0px; width: 100%; height: 100%; font-size: 13px; text-align: center; z-index: 1000; background-color: #333333; color: #FFFFFF;">
           <img src="{% raw qiita_config.portal_dir %}{{portal_styling.logo}}" alt="Qiita logo" id="small-logo"/>

--- a/qiita_pet/test/test_base_handlers.py
+++ b/qiita_pet/test/test_base_handlers.py
@@ -22,5 +22,17 @@ class TestNoPageHandler(TestHandlerBase):
         self.assertEqual(response.code, 404)
 
 
+class TestIFrame(TestHandlerBase):
+    def test_get(self):
+        response = self.get('/iframe/')
+        self.assertEqual(response.code, 200)
+        self.assertIn("<b>No content</b>", response.body)
+
+        response = self.get('/iframe/?iframe=qiita-terms')
+        self.assertEqual(response.code, 200)
+        self.assertIn('src="/static/qiita_data_terms_of_use.html"',
+                      response.body)
+
+
 if __name__ == "__main__":
     main()

--- a/qiita_pet/webserver.py
+++ b/qiita_pet/webserver.py
@@ -17,7 +17,8 @@ from uuid import uuid4
 
 from qiita_core.qiita_settings import qiita_config
 from qiita_core.util import is_test_environment
-from qiita_pet.handlers.base_handlers import (MainHandler, NoPageHandler)
+from qiita_pet.handlers.base_handlers import (
+    MainHandler, NoPageHandler, IFrame)
 from qiita_pet.handlers.auth_handlers import (
     AuthCreateHandler, AuthLoginHandler, AuthLogoutHandler, AuthVerifyHandler)
 from qiita_pet.handlers.user_handlers import (
@@ -178,6 +179,7 @@ class Application(tornado.web.Application):
             (r"/release/download/(.*)", DownloadRelease),
             (r"/vamps/(.*)", VAMPSHandler),
             (r"/redbiom/(.*)", RedbiomPublicSearch),
+            (r"/iframe/", IFrame),
             # Plugin handlers - the order matters here so do not change
             # qiita_db/jobs/(.*) should go after any of the
             # qiita_db/jobs/(.*)/XXXX because otherwise it will match the


### PR DESCRIPTION
There are a few files changes but there are pretty small. The idea was to add QIIMP within an iframe and while working on this, I realized that the "Qiita terms of use" where not displayed nicely and had some "odd" chars. Also decided to make this a value in the config file so we can (a) change when needed and (b) add more iframes in the future.

Terms of use:
<img width="1572" alt="screen shot 2018-05-15 at 8 54 18 am" src="https://user-images.githubusercontent.com/2014559/40064850-9ae8685a-581d-11e8-919b-3172fc006b8d.png">
Also fixed the R in redbiom:
<img width="264" alt="screen shot 2018-05-15 at 8 54 48 am" src="https://user-images.githubusercontent.com/2014559/40064874-a9d08ee2-581d-11e8-9fd8-7441c7a765b8.png">
