### PR TITLE
improve sample summary speed

### DIFF
--- a/qiita_pet/handlers/api_proxy/tests/test_sample_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_sample_template.py
@@ -173,7 +173,7 @@ class TestSampleAPI(TestCase):
         self.assertEqual(obs_at, "danger")
         self.assertEqual(obs_am, "Some</br>error")
 
-    def test_sample_template_summary_get_req_no_template(self):
+    def test_sample_template_columns_get_req_no_template(self):
         # Test sample template not existing
         obs = sample_template_get_req(self.new_study.id, 'test@foo.bar')
         exp = {'status': 'error',

--- a/qiita_pet/handlers/study_handlers/__init__.py
+++ b/qiita_pet/handlers/study_handlers/__init__.py
@@ -23,14 +23,14 @@ from .artifact import (ArtifactGraphAJAX, NewArtifactHandler,
                        ArtifactAdminAJAX, ArtifactGetSamples, ArtifactGetInfo)
 from .sample_template import (
     SampleTemplateHandler, SampleTemplateOverviewHandler,
-    SampleTemplateSummaryHandler, SampleAJAX)
+    SampleTemplateColumnsHandler, SampleAJAX)
 
 __all__ = ['ListStudiesHandler', 'StudyApprovalList', 'ShareStudyAJAX',
            'StudyEditHandler', 'CreateStudyAJAX', 'EBISubmitHandler',
            'VAMPSHandler', 'SearchStudiesAJAX', 'ArtifactGraphAJAX',
            'ArtifactAdminAJAX', 'StudyIndexHandler', 'StudyBaseInfoAJAX',
            'SampleTemplateHandler', 'SampleTemplateOverviewHandler',
-           'SampleTemplateSummaryHandler',
+           'SampleTemplateColumnsHandler',
            'PrepTemplateAJAX', 'NewArtifactHandler', 'PrepFilesHandler',
            'ListCommandsHandler', 'ListOptionsHandler', 'SampleAJAX',
            'StudyDeleteAjax', 'NewPrepTemplateAjax',

--- a/qiita_pet/webserver.py
+++ b/qiita_pet/webserver.py
@@ -29,7 +29,7 @@ from qiita_pet.handlers.analysis_handlers import (
     AnalysisJobsHandler, ShareAnalysisAJAX)
 from qiita_pet.handlers.study_handlers import (
     StudyIndexHandler, StudyBaseInfoAJAX, SampleTemplateHandler,
-    SampleTemplateOverviewHandler, SampleTemplateSummaryHandler,
+    SampleTemplateOverviewHandler, SampleTemplateColumnsHandler,
     StudyEditHandler, ListStudiesHandler, SearchStudiesAJAX, EBISubmitHandler,
     CreateStudyAJAX, ShareStudyAJAX, StudyApprovalList, ArtifactGraphAJAX,
     VAMPSHandler, StudyTags, StudyGetTags,
@@ -153,8 +153,8 @@ class Application(tornado.web.Application):
             # Same reasoning as below. /study/description/(.*) should be last.
             (r"/study/description/sample_template/overview/",
              SampleTemplateOverviewHandler),
-            (r"/study/description/sample_template/summary/",
-             SampleTemplateSummaryHandler),
+            (r"/study/description/sample_template/columns/",
+             SampleTemplateColumnsHandler),
             (r"/study/description/sample_template/", SampleTemplateHandler),
             (r"/study/description/sample_summary/", SampleAJAX),
             (r"/study/description/prep_summary/", PrepTemplateSummaryAJAX),


### PR DESCRIPTION
The reason why the sample summary is pretty slow (clear in studies with over 300 metadata columns) is because we display all columns, their values and summaries in a single go; which is extremely slow and not useful most of the time. 

This PR splits that functionality by only showing the sample headers, adding a button beside it to show the value summaries. Just as reference in qiita-rc the current method takes ~1.5 minutes, this now takes ~80ms.

New view:
![new-sample-summary](https://user-images.githubusercontent.com/2014559/40272118-8e197268-5b65-11e8-9bf4-82fe3d28fd95.gif)
