### PR TITLE
Fixes #1802 #2579

### DIFF
--- a/qiita_pet/static/js/password_validation.js
+++ b/qiita_pet/static/js/password_validation.js
@@ -6,29 +6,39 @@ function dualpass_validator() {
     $(this).popover('show');
   });
 
+  function validatePasswordIsASCIIOnly(value)
+  {
+    if(value.match(/^[\x20-\x7E]{1,}$/)) {
+        return true;
+    }
+    return false;
+  }
+
+  jQuery.validator.addMethod("validate_password_is_ascii",validatePasswordIsASCIIOnly,"Passwords may only include printable ASCII characters; e.g., A-Z, a-z, 0-9, space, _, -, @, etc.");
+
   // Validation
   $(".dualpass").validate({
     rules:{
       username:{required:true,email: true},
       email:{required:true, email: true},
       oldpass:{required:true},
-      newpass:{required:true,minlength: 8},
-      newpass2:{required:true,minlength: 8,equalTo: "#newpass"},
+      newpass:{required:true, minlength: 8, validate_password_is_ascii:'sel'},
+      newpass2:{required:true, minlength: 8, validate_password_is_ascii:'sel', equalTo: "#newpass"},
     },
 
     messages:{
       email:{
         required:"Enter your email address",
-        email:"Enter valid email address"},
+        email:"Enter a valid email address"},
       oldpass:{
-        required:"Enter your old password"},
+        required:"Enter your current password"},
       newpass:{
-        required:"Enter your password",
-        minlength:"Password must be minimum 8 characters"},
+        required:"Enter your new password",
+        minlength:"Password must be a minimum of 8 characters"},
       newpass2:{
-        required:"Enter password again",
-        minlength:"Password must be minimum 8 characters",
-        equalTo:"Password and Confirm Password must match"}
+        required:"Enter your new password again",
+        minlength:"Password must be a minimum of 8 characters",
+        equalTo:"'Password' and 'Confirm Password' fields must match"}
     }
   });
 }


### PR DESCRIPTION
Password validation extended to allow only printable ASCII characters
A custom validator was written to check whether a password string contains any UTF-8 characters that are not also printable ASCII characters and return false. if true.