### PR TITLE
fix artifact listing

### DIFF
--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -909,7 +909,7 @@ class UtilTests(TestCase):
         snew_info = {
             'status': 'sandbox', 'study_title': 'test_study_1',
             'metadata_complete': True, 'publication_pid': [],
-            'artifact_biom_ids': None,
+            'artifact_biom_ids': [],
             'ebi_submission_status': 'not submitted',
             'study_id': new_study.id, 'ebi_study_accession': None,
             'owner': 'Shared', 'shared': [],
@@ -1074,13 +1074,13 @@ class UtilTests(TestCase):
            {'files': [], 'artifact_id': 7, 'data_type': '16S',
             'target_gene': '16S rRNA', 'name': 'BIOM',
             'target_subfragment': ['V4'], 'parameters': {}, 'algorithm': '',
-            'deprecated': True, 'platform': 'Illumina', 'algorithm_az': '',
+            'deprecated': False, 'platform': 'Illumina', 'algorithm_az': '',
             'prep_samples': 27},
            {'files': ['biom_table.biom'], 'artifact_id': 8, 'data_type': '18S',
             'target_gene': 'not provided', 'name': 'noname',
             'target_subfragment': [], 'parameters': {}, 'algorithm': '',
-            'deprecated': True, 'platform': 'not provided', 'algorithm_az': '',
-            'prep_samples': 0}]
+            'deprecated': False, 'platform': 'not provided',
+            'algorithm_az': '', 'prep_samples': 0}]
         self.assertItemsEqual(obs, exp)
 
         # now let's test that the order given by the commands actually give the

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -1342,13 +1342,18 @@ def generate_study_list(user, visibility):
             (SELECT COUNT(sample_id) FROM qiita.study_sample
                 WHERE study_id=qiita.study.study_id)
                 AS number_samples_collected]
-    - all the BIOM artifact_ids sorted by artifact_id that belong to the study
-            (SELECT array_agg(artifact_id ORDER BY artifact_id)
+    - all the BIOM artifact_ids sorted by artifact_id that belong to the study,
+      including their software deprecated value
+            (SELECT array_agg(row_to_json((artifact_id, qs.deprecated), true)
+                              ORDER BY artifact_id)
                 FROM qiita.study_artifact
                 LEFT JOIN qiita.artifact USING (artifact_id)
+                LEFT JOIN qiita.visibility USING (visibility_id)
                 LEFT JOIN qiita.artifact_type USING (artifact_type_id)
-                WHERE artifact_type='BIOM' AND
-                study_id = qiita.study.study_id) AS artifact_biom_ids,
+                LEFT JOIN qiita.software_command USING (command_id)
+                LEFT JOIN qiita.software qs USING (software_id)
+                WHERE artifact_type='BIOM' AND {0}
+                    study_id = qiita.study.study_id) AS aids_with_deprecation,
     - all the publications that belong to the study
             (SELECT array_agg((publication, is_doi)))
                 FROM qiita.study_publication
@@ -1391,13 +1396,16 @@ def generate_study_list(user, visibility):
             (SELECT COUNT(sample_id) FROM qiita.study_sample
                 WHERE study_id=qiita.study.study_id)
                 AS number_samples_collected,
-            (SELECT array_agg(artifact_id ORDER BY artifact_id)
+            (SELECT array_agg(row_to_json((artifact_id, qs.deprecated), true)
+                              ORDER BY artifact_id)
                 FROM qiita.study_artifact
                 LEFT JOIN qiita.artifact USING (artifact_id)
                 LEFT JOIN qiita.visibility USING (visibility_id)
                 LEFT JOIN qiita.artifact_type USING (artifact_type_id)
+                LEFT JOIN qiita.software_command USING (command_id)
+                LEFT JOIN qiita.software qs USING (software_id)
                 WHERE artifact_type='BIOM' AND {0}
-                    study_id = qiita.study.study_id) AS artifact_biom_ids,
+                    study_id = qiita.study.study_id) AS aids_with_deprecation,
             (SELECT array_agg(row_to_json((publication, is_doi), true))
                 FROM qiita.study_publication
                 WHERE study_id=qiita.study.study_id) AS publications,
@@ -1423,13 +1431,21 @@ def generate_study_list(user, visibility):
             qdb.sql_connection.TRN.add(sql, [tuple(sids)])
             for info in qdb.sql_connection.TRN.execute_fetchindex():
                 info = dict(info)
+                # cleaning aids_with_deprecation
+                info['artifact_biom_ids'] = []
+                if info['aids_with_deprecation'] is not None:
+                    for x in info['aids_with_deprecation']:
+                        # f1-2 are the default names given by pgsql
+                        if not x['f2']:
+                            info['artifact_biom_ids'].append(x['f1'])
+                del info['aids_with_deprecation']
 
                 # publication info
                 info['publication_doi'] = []
                 info['publication_pid'] = []
                 if info['publications'] is not None:
                     for p in info['publications']:
-                        # f1-2 are the default names given
+                        # f1-2 are the default names given by pgsql
                         pub = p['f1']
                         is_doi = p['f2']
                         if is_doi:
@@ -1666,7 +1682,9 @@ def get_artifacts_information(artifact_ids, only_biom=True):
 
                 # generating algorithm, by default is ''
                 algorithm = ''
-                deprecated = True
+                # set to False because if there is no cid, it means that it
+                # was a direct upload
+                deprecated = False
                 if cid is not None:
                     ms = commands[cid]['merging_scheme']
                     deprecated = commands[cid]['deprecated']

--- a/qiita_pet/handlers/api_proxy/tests/test_artifact.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_artifact.py
@@ -251,7 +251,7 @@ class TestArtifactAPI(TestCase):
           {'files': [], 'artifact_id': 7, 'data_type': '16S',
            'timestamp': '2012-10-02 17:30:00', 'target_gene': '16S rRNA',
            'name': 'BIOM', 'target_subfragment': ['V4'], 'parameters': {},
-           'algorithm': '', 'deprecated': True, 'platform': 'Illumina',
+           'algorithm': '', 'deprecated': False, 'platform': 'Illumina',
            'algorithm_az': '', 'prep_samples': 27}]
         exp = {'status': 'success', 'msg': '', 'data': data}
         self.assertItemsEqual(obs.keys(), exp.keys())

--- a/qiita_pet/handlers/study_handlers/tests/test_artifact.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_artifact.py
@@ -178,7 +178,7 @@ class ArtifactGetInfoTest(TestHandlerBase):
             {'files': [], 'target_subfragment': ['V4'], 'artifact_id': 7,
              'data_type': '16S', 'timestamp': '2012-10-02 17:30:00',
              'platform': 'Illumina', 'algorithm_az': '', 'prep_samples': 27,
-             'deprecated': True, 'algorithm': '', 'parameters': {},
+             'deprecated': False, 'algorithm': '', 'parameters': {},
              'target_gene': '16S rRNA', u'name': u'BIOM'}]
         exp = {'status': 'success', 'msg': '', 'data': data}
         obs = loads(response.body)

--- a/qiita_pet/handlers/upload.py
+++ b/qiita_pet/handlers/upload.py
@@ -137,6 +137,9 @@ class StudyUploadViaRemote(BaseHandler):
         upload_folder = join(upload_folder, study_id)
         ssh_key_fp = join(upload_folder, '.key.txt')
 
+        if not isdir(upload_folder):
+            makedirs(upload_folder)
+
         with open(ssh_key_fp, 'w') as f:
             f.write(ssh_key)
 

--- a/qiita_pet/static/js/qiita.js
+++ b/qiita_pet/static/js/qiita.js
@@ -315,7 +315,7 @@ function format_biom_rows(data, row, for_study_list = true, samples = null) {
   // grouping by processing_method, data_type and parameters
   $.each(data, function (idx, info) {
     // ignore the artifacts that were generated with software that is deprecated
-    if (info['deprecated']) {
+    if (!info['deprecated']) {
       if (typeof info !== 'string' && !(info instanceof String)) {
         var algorithm = info.algorithm;
         if (!(algorithm in processing_method)) {


### PR DESCRIPTION
The error has 3 parts: 
- on one side the default report of artifacts without a command was True but it should be False; this is because if an artifact without command means that it was uploaded directly. Added a comment about this in the code
- the study listing was retrieving and listing all artifacts, now it only displays the no deprecated, as previously decided
- JS was checking for info['deprecated'] while it should have been !info['deprecated']