### PR TITLE
add qiita data disclaimer

### DIFF
--- a/qiita_pet/support_files/doc/source/faq.rst
+++ b/qiita_pet/support_files/doc/source/faq.rst
@@ -1,6 +1,29 @@
 Frequently Asked Questions
 ==========================
 
+Qiita data disclaimer
+---------------------
+
+Qiita is a research tool, and as such, is hosted on research computing resources
+maintained by the Knight Lab at the University of California San Diego.
+
+Data privacy is a key aspect of our operations, and is strictly adhered to at
+every step of the workflow. We are committed to protecting any and all
+information (including sequence data) submitted to Qiita. For example, your data
+is sandboxed by default upon upload, and remains private at the discretion of the
+Owner (i.e., you are the Owner) of the study.
+
+Authorizations and access associated with any given study is maintained and
+controlled by the Owner of the study; importantly, this means that sharing
+rights of a study within Qiita is determined solely by the Owner.
+
+Sample IDs, and any associated metadata must be de-identified prior to submission
+to Qiita. This is a requirement of our
+`Terms of Use <https://qiita.ucsd.edu/iframe/?iframe=qiita-terms>`__.
+
+A study within Qiita, and its associated sequence and metadata, can be
+permanently deleted by the Owner as long as it is not public.
+
 What kind of data can I upload to Qiita for processing?
 -------------------------------------------------------
 

--- a/qiita_pet/templates/sitebase.html
+++ b/qiita_pet/templates/sitebase.html
@@ -466,6 +466,30 @@
             </form>
             {% end %}
             <ul class="nav navbar-nav">
+              <li>
+                <a href="{% raw qiita_config.portal_dir %}/redbiom/">redbiom</a>
+              </li>
+            </ul>
+            <ul class="nav navbar-nav">
+              <li>
+                <a href="{% raw qiita_config.portal_dir %}/iframe/?iframe=qiimp">Qiimp</a>
+              </li>
+            </ul>
+            <ul class="nav navbar-nav">
+              <!-- downloads -->
+              <li class="dropdown">
+                <a href="#" data-toggle="dropdown" class="dropdown-toggle">Help<b class="caret"></b></a>
+                <ul class="dropdown-menu">
+                  <li>
+                    <a href="http://cmi-workshop.readthedocs.io/en/latest/">Tutorial</a>
+                  </li>
+                  <li>
+                    <a href="{% raw qiita_config.portal_dir %}/static/doc/html/index.html">Help</a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+            <ul class="nav navbar-nav">
               <!-- generic elements -->
               <li class="dropdown">
                 <a href="#" data-toggle="dropdown" class="dropdown-toggle">More Info<b class="caret"></b></a>
@@ -475,6 +499,9 @@
                   </li>
                   <li>
                     <a href="http://github.com/biocore/qiita">GitHub</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/biocore/qiita/blob/master/README.rst#current-features">Current and Future Features</a>
                   </li>
                   <li>
                     <a type="button" data-toggle="modal" data-target=".qiita_pet_download_confirm">
@@ -499,35 +526,6 @@
                     </a>
                   </li>
 
-                </ul>
-              </li>
-            </ul>
-            <ul class="nav navbar-nav">
-              <li>
-                <a href="https://github.com/biocore/qiita/blob/master/README.rst#current-features">Current and Future Features</a>
-              </li>
-            </ul>
-            <ul class="nav navbar-nav">
-              <li>
-                <a href="{% raw qiita_config.portal_dir %}/redbiom/">redbiom</a>
-              </li>
-            </ul>
-            <ul class="nav navbar-nav">
-              <li>
-                <a href="{% raw qiita_config.portal_dir %}/iframe/?iframe=qiimp">Qiimp</a>
-              </li>
-            </ul>
-            <ul class="nav navbar-nav">
-              <!-- downloads -->
-              <li class="dropdown">
-                <a href="#" data-toggle="dropdown" class="dropdown-toggle">Help<b class="caret"></b></a>
-                <ul class="dropdown-menu">
-                  <li>
-                    <a href="http://cmi-workshop.readthedocs.io/en/latest/">Tutorial</a>
-                  </li>
-                  <li>
-                    <a href="{% raw qiita_config.portal_dir %}/static/doc/html/index.html">Help</a>
-                  </li>
                 </ul>
               </li>
             </ul>


### PR DESCRIPTION
Adding qiita data disclaimer and merging "Current and Future Features" to more info and pushing to the left in the top menu (suggestion by @charles-cowart).

Now the menu looks like this
<img width="727" alt="screen shot 2018-09-23 at 11 10 17 am" src="https://user-images.githubusercontent.com/2014559/45930804-c1242e80-bf21-11e8-81f8-42c86c357bc2.png">
<img width="674" alt="screen shot 2018-09-23 at 11 10 38 am" src="https://user-images.githubusercontent.com/2014559/45930803-c1242e80-bf21-11e8-9438-7486c6ebbbd6.png">

... and the FAQ, note that I added `A study within Qiita, and its associated sequence and metadata, can be permanently deleted by the Owner as long as it is not public.`
<img width="738" alt="screen shot 2018-09-23 at 11 11 09 am" src="https://user-images.githubusercontent.com/2014559/45930802-c1242e80-bf21-11e8-9fed-841c723a2221.png">
