### PR TITLE
P3.6 items equal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,13 @@ install:
     pyzmq networkx pyparsing natsort mock future libgfortran seaborn nltk pandas
     matplotlib scipy numpy h5py
   - source activate qiita
+  - 'echo "backend: Agg" > ~/matplotlibrc'
   - pip install sphinx sphinx-bootstrap-theme nose-timer codecov Click
   - git clone https://github.com/nicolasff/webdis
   - pushd webdis
   - make
   - ./webdis &
   - popd
-  # export PATH="$PATH:/Applications/Postgres.app/Contents/Versions/9.5/bin/"
   - travis_retry pip install . --process-dependency-links
   # loading redbiom with Qiita's test set
   # but first let's make sure redis is empty

--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -136,7 +136,7 @@ class ConfigurationManager(object):
 
         # Parse the configuration file
         config = ConfigParser()
-        with open(conf_fp, 'U') as conf_file:
+        with open(conf_fp, newline=None) as conf_file:
             config.readfp(conf_file)
 
         _required_sections = {'main', 'redis', 'postgres', 'smtp', 'ebi',

--- a/qiita_core/tests/test_configuration_manager.py
+++ b/qiita_core/tests/test_configuration_manager.py
@@ -138,7 +138,7 @@ class ConfigurationManagerTests(TestCase):
 
             obs_warns = [str(w.message) for w in warns]
             exp_warns = ['Random cookie secret generated.']
-            self.assertItemsEqual(obs_warns, exp_warns)
+            self.assertCountEqual(obs_warns, exp_warns)
 
         self.assertNotEqual(obs.cookie_secret, "SECRET")
         # Test default base_data_dir

--- a/qiita_core/tests/test_configuration_manager.py
+++ b/qiita_core/tests/test_configuration_manager.py
@@ -30,7 +30,7 @@ class ConfigurationManagerTests(TestCase):
         environ['QIITA_CONFIG_FP'] = self.conf_fp
 
         self.conf = ConfigParser()
-        with open(self.conf_fp, 'U') as f:
+        with open(self.conf_fp, newline=None) as f:
             self.conf.readfp(f)
 
     def tearDown(self):
@@ -136,7 +136,7 @@ class ConfigurationManagerTests(TestCase):
         with warnings.catch_warnings(record=True) as warns:
             obs._get_main(self.conf)
 
-            obs_warns = [str(w.message) for w in warns]
+            obs_warns = [str(w) for w in warns]
             exp_warns = ['Random cookie secret generated.']
             self.assertCountEqual(obs_warns, exp_warns)
 

--- a/qiita_core/tests/test_util.py
+++ b/qiita_core/tests/test_util.py
@@ -76,7 +76,7 @@ class UtilTests(TestCase):
         # and then we will test that at least the 2nd element is correct
         self.assertNotEqual(biom_metadata_release, ('', '', ''))
         self.assertEqual(biom_metadata_release[1],
-                         'releases/QIITA-private.tgz')
+                         b'releases/QIITA-private.tgz')
         self.assertEqual(archive_release, ('', '', ''))
 
         generate_plugin_releases()

--- a/qiita_db/environment_manager.py
+++ b/qiita_db/environment_manager.py
@@ -65,14 +65,14 @@ def create_layout(test=False, verbose=False):
         if verbose:
             print('Building SQL layout')
         # Create the schema
-        with open(LAYOUT_FP, 'U') as f:
+        with open(LAYOUT_FP, newline=None) as f:
             qdb.sql_connection.TRN.add(f.read())
         qdb.sql_connection.TRN.execute()
 
 
 def _populate_test_db():
     with qdb.sql_connection.TRN:
-        with open(POPULATE_FP, 'U') as f:
+        with open(POPULATE_FP, newline=None) as f:
             qdb.sql_connection.TRN.add(f.read())
         qdb.sql_connection.TRN.execute()
 
@@ -194,7 +194,7 @@ def make_environment(load_ontologies, download_reference, add_demo_user):
     except ValueError as error:
         # if database exists ignore
         msg = 'database "%s" already exists' % qiita_config.database
-        if msg in error.message:
+        if msg in str(error):
             print("Database exits, let's make sure it's test")
             with qdb.sql_connection.TRN:
                 # Insert the settings values to the database
@@ -218,7 +218,7 @@ def make_environment(load_ontologies, download_reference, add_demo_user):
         verbose = True
         if create_settings_table:
             # Build the SQL layout into the database
-            with open(SETTINGS_FP, 'U') as f:
+            with open(SETTINGS_FP, newline=None) as f:
                 qdb.sql_connection.TRN.add(f.read())
             qdb.sql_connection.TRN.execute()
 
@@ -425,7 +425,7 @@ def patch(patches_dir=PATCHES_DIR, verbose=False, test=False):
                 _populate_test_db()
 
         with qdb.sql_connection.TRN:
-            with open(sql_patch_fp, 'U') as patch_file:
+            with open(sql_patch_fp, newline=None) as patch_file:
                 if verbose:
                     print('\tApplying patch %s...' % sql_patch_filename)
                 qdb.sql_connection.TRN.add(patch_file.read())

--- a/qiita_db/handlers/oauth2.py
+++ b/qiita_db/handlers/oauth2.py
@@ -149,7 +149,7 @@ class OauthBaseHandler(RequestHandler):
                 'ERROR:\n%s\nTRACE:\n%s\nHTTP INFO:\n%s\n' %
                 (error, trace_info, request_info))
 
-        message = exc_info[1].message
+        message = str(exc_info[1])
         if hasattr(exc_info[1], 'log_message'):
             message = exc_info[1].log_message
 

--- a/qiita_db/handlers/processing_job.py
+++ b/qiita_db/handlers/processing_job.py
@@ -142,7 +142,8 @@ class CompleteHandler(OauthBaseHandler):
             cmd = qiita_plugin.get_command('complete_job')
             params = qdb.software.Parameters.load(
                 cmd, values_dict={'job_id': job_id,
-                                  'payload': self.request.body})
+                                  'payload': self.request.body.decode(
+                                      'ascii')})
             job = qdb.processing_job.ProcessingJob.create(job.user, params)
             job.submit()
 

--- a/qiita_db/handlers/tests/test_analysis.py
+++ b/qiita_db/handlers/tests/test_analysis.py
@@ -43,7 +43,7 @@ class APIAnalysisMetadataHandlerTests(OauthTestingBase):
         obs = loads(obs.body)
         exp = ['1.SKM4.640180', '1.SKB8.640193', '1.SKD8.640184',
                '1.SKM9.640192', '1.SKB7.640196']
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         exp = {'platform': 'Illumina', 'longitude': '95.5088566087',
                'experiment_center': 'ANL', 'center_name': 'ANL',

--- a/qiita_db/handlers/tests/test_prep_template.py
+++ b/qiita_db/handlers/tests/test_prep_template.py
@@ -87,7 +87,7 @@ class PrepTemplateDataHandlerTests(OauthTestingBase):
                '1.SKD3.640198', '1.SKB5.640181', '1.SKB4.640189',
                '1.SKB9.640200', '1.SKM9.640192', '1.SKD8.640184',
                '1.SKM5.640177', '1.SKM7.640188', '1.SKD7.640191']
-        self.assertItemsEqual(obs.keys(), exp)
+        self.assertCountEqual(obs.keys(), exp)
 
         obs = obs['1.SKB1.640202']
         exp = {
@@ -152,7 +152,7 @@ class PrepTemplateAPItestHandlerTests(OauthTestingBase):
         self.assertEqual(obs.keys(), ['prep'])
 
         pt = qdb.metadata_template.prep_template.PrepTemplate(obs['prep'])
-        self.assertItemsEqual(pt.keys(), ['1.SKB8.640193', '1.SKD8.640184'])
+        self.assertCountEqual(pt.keys(), ['1.SKB8.640193', '1.SKD8.640184'])
 
         # testing that a new prep doesn't break the call due to empty artifact
         obs = self.get('/qiita_db/prep_template/%d/' % pt.id,

--- a/qiita_db/handlers/tests/test_processing_job.py
+++ b/qiita_db/handlers/tests/test_processing_job.py
@@ -161,7 +161,7 @@ class CompleteHandlerTests(OauthTestingBase):
             '/qiita_db/jobs/063e553b-327c-4818-ab4a-adfe58e49860/complete/',
             payload, headers=self.header)
         self.assertEqual(obs.code, 403)
-        self.assertEqual(obs.body,
+        self.assertEqual(obs.body.decode('ascii'),
                          "Can't complete job: not in a running state")
 
     def test_post_job_failure(self):
@@ -280,7 +280,7 @@ class ProcessingJobAPItestHandlerTests(OauthTestingBase):
         self.assertEqual(obs.code, 200)
 
         obs = loads(obs.body)
-        self.assertEqual(obs.keys(), ['job'])
+        self.assertEqual(list(obs.keys()), ['job'])
         self.assertIsNotNone(obs['job'])
 
     def test_post_processing_job_status(self):
@@ -302,7 +302,7 @@ class ProcessingJobAPItestHandlerTests(OauthTestingBase):
         self.assertEqual(obs.code, 200)
 
         obs = loads(obs.body)
-        self.assertEqual(obs.keys(), ['job'])
+        self.assertEqual(list(obs.keys()), ['job'])
         job_id = obs['job']
         self.assertTrue(qdb.processing_job.ProcessingJob.exists(job_id))
         self.assertEqual(qdb.processing_job.ProcessingJob(job_id).status,

--- a/qiita_db/handlers/tests/test_sample_information.py
+++ b/qiita_db/handlers/tests/test_sample_information.py
@@ -42,7 +42,7 @@ class SampleInfoDBHandlerTests(OauthTestingBase):
                '1.SKD3.640198', '1.SKB5.640181', '1.SKB4.640189',
                '1.SKB9.640200', '1.SKM9.640192', '1.SKD8.640184',
                '1.SKM5.640177', '1.SKM7.640188', '1.SKD7.640191']
-        self.assertItemsEqual(obs.keys(), exp)
+        self.assertCountEqual(obs.keys(), exp)
 
         obs = obs['1.SKB1.640202']
         exp = {'qiita_study_id': '1', 'physical_specimen_location': 'ANL',

--- a/qiita_db/meta_util.py
+++ b/qiita_db/meta_util.py
@@ -455,7 +455,6 @@ def generate_biom_and_metadata_release(study_status='public'):
 
         txt_hd.seek(0)
         info = TarInfo(name='%s-%s-%s.txt' % (portal, study_status, ts))
-        info.size = len(txt_hd.buf)
         tgz.addfile(tarinfo=info, fileobj=txt_hd)
 
     with open(tgz_name, "rb") as f:

--- a/qiita_db/metadata_template/test/test_base_metadata_template.py
+++ b/qiita_db/metadata_template/test/test_base_metadata_template.py
@@ -73,7 +73,7 @@ class TestMetadataTemplateReadOnly(TestCase):
             'select',
             'column',
             'just_fine1'])
-        self.assertItemsEqual(set(results), {'column', 'select'})
+        self.assertCountEqual(set(results), {'column', 'select'})
 
     def test_identify_invalid_characters(self):
         MT = qdb.metadata_template.base_metadata_template.MetadataTemplate
@@ -87,7 +87,7 @@ class TestMetadataTemplateReadOnly(TestCase):
             'this|is',
             '4column',
             'just_fine2'])
-        self.assertItemsEqual(set(results), {'tax on',
+        self.assertCountEqual(set(results), {'tax on',
                                              'bla.',
                                              '.',
                                              '{',

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -258,7 +258,7 @@ class TestPrepSample(TestCase):
                'primer', 'run_center', 'run_date', 'run_prefix', 'samp_size',
                'sample_center', 'sequencing_meth', 'study_center',
                'target_gene', 'target_subfragment']
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
     def test_setitem(self):
         with self.assertRaises(qdb.exceptions.QiitaDBColumnError):
@@ -877,7 +877,7 @@ class TestPrepTemplate(TestCase):
                           'instrument_model', 'experiment_design_description',
                           'library_construction_protocol', 'center_name',
                           'center_project_name', 'emp_status'}
-        self.assertItemsEqual(pt.categories(), exp_categories)
+        self.assertCountEqual(pt.categories(), exp_categories)
         exp_dict = {
             '%s.SKB7.640196' % self.test_study.id: {
                 'barcode': 'CCTCTGAGAGCT',
@@ -1010,7 +1010,7 @@ class TestPrepTemplate(TestCase):
                           'instrument_model', 'experiment_design_description',
                           'library_construction_protocol', 'center_name',
                           'center_project_name', 'emp_status'}
-        self.assertItemsEqual(pt.categories(), exp_categories)
+        self.assertCountEqual(pt.categories(), exp_categories)
         exp_dict = {
             '%s.SKB7.640196' % self.test_study.id: {
                 'ebi_submission_accession': None,
@@ -1329,7 +1329,7 @@ class TestPrepTemplate(TestCase):
                 'center_project_name': 'Test Project',
                 'emp_status': 'EMP',
                 'new_col': 'val3'}}
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
     def test_extend_update(self):
         pt = qdb.metadata_template.prep_template.PrepTemplate.create(
@@ -1388,7 +1388,7 @@ class TestPrepTemplate(TestCase):
                 'emp_status': 'EMP',
                 'new_col': 'val3'}}
 
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
     def test_ebi_experiment_accessions(self):
         obs = self.tester.ebi_experiment_accessions

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -1134,7 +1134,7 @@ class TestPrepTemplate(TestCase):
             self.metadata, self.test_study, self.data_type)
         pt.to_file(fp)
         self._clean_up_files.append(fp)
-        with open(fp, 'U') as f:
+        with open(fp, newline=None) as f:
             obs = f.read()
         self.assertEqual(obs, EXP_PREP_TEMPLATE.format(pt.id))
 

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -163,7 +163,7 @@ class TestSample(TestCase):
                'GAZ:United States of America', '6.94', 'SKB8', '5',
                'Burmese root', 'ENVO:plant-associated habitat',
                '74.0894932572', '65.3283470202', '1118232'}
-        self.assertItemsEqual(set(obs), exp)
+        self.assertCountEqual(set(obs), exp)
 
     def test_items(self):
         """items returns an iterator over the (key, value) tuples"""
@@ -486,7 +486,7 @@ class TestSampleTemplate(TestCase):
                'samp_salinity', 'sample_type', 'scientific_name',
                'season_environment', 'taxon_id', 'temp', 'texture',
                'tot_nitro', 'tot_org_carb', 'water_content_soil']
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
     def test_study_id(self):
         """Ensure that the correct study ID is returned"""
@@ -547,7 +547,7 @@ class TestSampleTemplate(TestCase):
                'sample_type', 'collection_timestamp', 'host_subject_id',
                'description', 'latitude', 'longitude', 'scientific_name'}
         obs = set(self.tester.categories())
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
     def test_iter(self):
         """iter returns an iterator over the sample ids"""
@@ -972,7 +972,7 @@ class TestSampleTemplate(TestCase):
                           'longitude', 'physical_specimen_location',
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id'}
-        self.assertItemsEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories(), exp_categories)
         exp_dict = {
             "%s.Sample1" % new_id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -1038,7 +1038,7 @@ class TestSampleTemplate(TestCase):
                           'longitude', 'physical_specimen_location',
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id'}
-        self.assertItemsEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories(), exp_categories)
         exp_dict = {
             "%s.12.Sample1" % new_id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -1104,7 +1104,7 @@ class TestSampleTemplate(TestCase):
                           'longitude', 'physical_specimen_location',
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id'}
-        self.assertItemsEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories(), exp_categories)
         exp_dict = {
             "%s.foo.Sample1" % new_id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -1170,7 +1170,7 @@ class TestSampleTemplate(TestCase):
                           'longitude', 'physical_specimen_location',
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id'}
-        self.assertItemsEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories(), exp_categories)
         exp_dict = {
             "%s.Sample1" % new_id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -1291,15 +1291,15 @@ class TestSampleTemplate(TestCase):
         # validating values
         exp = self.metadata_dict_updated_dict['Sample1'].values()
         obs = st.get('%s.Sample1' % self.new_study.id).values()
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         exp = self.metadata_dict_updated_dict['Sample2'].values()
         obs = st.get('%s.Sample2' % self.new_study.id).values()
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         exp = self.metadata_dict_updated_dict['Sample3'].values()
         obs = st.get('%s.Sample3' % self.new_study.id).values()
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         # checking errors
         with self.assertRaises(qdb.exceptions.QiitaDBError):
@@ -1444,7 +1444,7 @@ class TestSampleTemplate(TestCase):
                           'longitude', 'physical_specimen_location',
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id'}
-        self.assertItemsEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories(), exp_categories)
         exp_dict = {
             "%s.Sample1" % st.id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -1549,7 +1549,7 @@ class TestSampleTemplate(TestCase):
                           'longitude', 'physical_specimen_location',
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id'}
-        self.assertItemsEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories(), exp_categories)
         exp_dict = {
             "%s.Sample1" % st.id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -1631,7 +1631,7 @@ class TestSampleTemplate(TestCase):
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id',
                           'texture', 'tot_nitro'}
-        self.assertItemsEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories(), exp_categories)
         exp_dict = {
             "%s.Sample1" % st.id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -1717,7 +1717,7 @@ class TestSampleTemplate(TestCase):
                           'longitude', 'physical_specimen_location',
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id', 'tot_nitro'}
-        self.assertItemsEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories(), exp_categories)
         exp_dict = {
             "%s.Sample1" % st.id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -1812,7 +1812,7 @@ class TestSampleTemplate(TestCase):
                           'longitude', 'physical_specimen_location',
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id', 'tot_nitro'}
-        self.assertItemsEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories(), exp_categories)
         exp_dict = {
             "%s.Sample1" % st.id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -2186,7 +2186,7 @@ class TestSampleTemplate(TestCase):
             # warnings is a list of 1 element
             self.assertEqual(len(warn), 1)
             # the order might change so testing by elements
-            self.assertItemsEqual(str(warn[0].message).split('\n'),
+            self.assertCountEqual(str(warn[0].message).split('\n'),
                                   exp_message.split('\n'))
 
     def test_validate_errors_timestampB_year4digits(self):

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -1368,7 +1368,7 @@ class TestSampleTemplate(TestCase):
             self.metadata, self.new_study)
         st.to_file(fp)
         self._clean_up_files.append(fp)
-        with open(fp, 'U') as f:
+        with open(fp, newline=None) as f:
             obs = f.read()
         self.assertEqual(obs, EXP_SAMPLE_TEMPLATE.format(self.new_study.id))
 
@@ -1378,7 +1378,7 @@ class TestSampleTemplate(TestCase):
                         '%s.Sample3' % self.new_study.id})
         self._clean_up_files.append(fp)
 
-        with open(fp, 'U') as f:
+        with open(fp, newline=None) as f:
             obs = f.read()
         self.assertEqual(
             obs, EXP_SAMPLE_TEMPLATE_FEWER_SAMPLES.format(self.new_study.id))
@@ -2136,7 +2136,7 @@ class TestSampleTemplate(TestCase):
             # it should be QiitaDBWarning
             self.assertEqual(warn.category, qdb.exceptions.QiitaDBWarning)
             # it should contain this text
-            message = str(warn.message)
+            message = str(warn)
             exp_error = ('Sample "%s.Sample2", column "latitude", wrong value '
                          '"wrong latitude"' % self.new_study.id)
             self.assertIn(exp_error, message)
@@ -2186,7 +2186,7 @@ class TestSampleTemplate(TestCase):
             # warnings is a list of 1 element
             self.assertEqual(len(warn), 1)
             # the order might change so testing by elements
-            self.assertCountEqual(str(warn[0].message).split('\n'),
+            self.assertCountEqual(str(warn[0]).split('\n'),
                                   exp_message.split('\n'))
 
     def test_validate_errors_timestampB_year4digits(self):
@@ -2219,7 +2219,7 @@ class TestSampleTemplate(TestCase):
                 'of these fields.'.format(st.id))
             # warnings is a list of 1 element
             self.assertEqual(len(warn), 1)
-            self.assertEqual(str(warn[0].message), exp_message)
+            self.assertEqual(str(warn[0]), exp_message)
 
     def test_delete_column(self):
         st = qdb.metadata_template.sample_template.SampleTemplate.create(

--- a/qiita_db/metadata_template/test/test_util.py
+++ b/qiita_db/metadata_template/test/test_util.py
@@ -59,7 +59,7 @@ class TestUtil(TestCase):
             qdb.metadata_template.util.prefix_sample_names_with_id(
                 metadata_map, 1)
             self.assertEqual(len(warn), 1)
-            self.assertEqual(str(warn[0].message), 'Some of the samples were '
+            self.assertEqual(str(warn[0]), 'Some of the samples were '
                              'already prefixed with the study id.')
         metadata_map.sort_index(inplace=True)
         assert_frame_equal(metadata_map, exp_df)

--- a/qiita_db/metadata_template/test/test_util.py
+++ b/qiita_db/metadata_template/test/test_util.py
@@ -264,21 +264,21 @@ class TestUtil(TestCase):
         one_invalid = ['2.sample.1', 'foo.bar.baz', 'roses', 'are', 'red',
                        'I am the chosen one', 'v10l3t5', '4r3', '81u3']
         obs = qdb.metadata_template.util.get_invalid_sample_names(one_invalid)
-        self.assertItemsEqual(obs, ['I am the chosen one'])
+        self.assertCountEqual(obs, ['I am the chosen one'])
 
         one_invalid = ['2.sample.1', 'foo.bar.baz', 'roses', 'are', 'red',
                        ':L{=<', ':L}=<', '4r3', '81u3']
         obs = qdb.metadata_template.util.get_invalid_sample_names(one_invalid)
-        self.assertItemsEqual(obs, [':L{=<', ':L}=<'])
+        self.assertCountEqual(obs, [':L{=<', ':L}=<'])
 
     def test_get_get_invalid_sample_names_mixed(self):
         one_invalid = ['.', '1', '2']
         obs = qdb.metadata_template.util.get_invalid_sample_names(one_invalid)
-        self.assertItemsEqual(obs, [])
+        self.assertCountEqual(obs, [])
 
         one_invalid = [' ', ' ', ' ']
         obs = qdb.metadata_template.util.get_invalid_sample_names(one_invalid)
-        self.assertItemsEqual(obs, [' ', ' ', ' '])
+        self.assertCountEqual(obs, [' ', ' ', ' '])
 
     def test_looks_like_qiime_mapping_file(self):
         obs = qdb.metadata_template.util.looks_like_qiime_mapping_file(

--- a/qiita_db/metadata_template/util.py
+++ b/qiita_db/metadata_template/util.py
@@ -94,7 +94,7 @@ def load_template_to_dataframe(fn, index='sample_name'):
     """
     # Load in file lines
     holdfile = None
-    with qdb.util.open_file(fn, mode='U') as f:
+    with qdb.util.open_file(fn, newline=None) as f:
         errors = defaultdict(list)
         holdfile = f.readlines()
         # here we are checking for non UTF-8 chars
@@ -269,7 +269,7 @@ def looks_like_qiime_mapping_file(fp):
     some other different column.
     """
     first_line = None
-    with qdb.util.open_file(fp, mode='U') as f:
+    with qdb.util.open_file(fp, newline=None) as f:
         first_line = f.readline()
     if not first_line:
         return False

--- a/qiita_db/processing_job.py
+++ b/qiita_db/processing_job.py
@@ -535,7 +535,7 @@ class ProcessingJob(qdb.base.QiitaObject):
 
             if params:
                 # divided by 2 as we have key-value pairs
-                len_params = len(params)/2
+                len_params = int(len(params)/2)
                 sql = sql.format(' AND ' + ' AND '.join(
                     ["command_parameters->>%s ILIKE %s"] * len_params))
                 params = [command.id] + params
@@ -1660,10 +1660,13 @@ class ProcessingWorkflow(qdb.base.QiitaObject):
 
             # We can potentially access this information from the nodes
             # multiple times, so caching in here
-            all_nodes = {n: (n.command, n.parameters)
-                         for n in in_degrees}
-            roots = {n: (n.command, n.parameters)
-                     for n, d in viewitems(in_degrees) if d == 0}
+            # [0] in_degrees returns a tuple, where [0] is the element we want
+            all_nodes = {}
+            roots = {}
+            for node, position in in_degrees:
+                if position == 0:
+                    roots[node] = (node.command, node.parameters)
+                all_nodes[node] = (node.command, node.parameters)
 
             # Check that we have all the required parameters
             root_cmds = set(c for c, _ in viewvalues(roots))

--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -783,7 +783,7 @@ class Software(qdb.base.QiitaObject):
             file doesn't match
         """
         config = ConfigParser()
-        with open(fp, 'U') as conf_file:
+        with open(fp, newline=None) as conf_file:
             config.readfp(conf_file)
 
         name = config.get('main', 'NAME')

--- a/qiita_db/sql_connection.py
+++ b/qiita_db/sql_connection.py
@@ -142,7 +142,7 @@ class SQLConnectionHandler(object):
         except OperationalError as e:
             # catch threee known common exceptions and raise runtime errors
             try:
-                etype = e.message.split(':')[1].split()[0]
+                etype = str(e).split(':')[1].split()[0]
             except IndexError:
                 # we recieved a really unanticipated error without a colon
                 etype = ''
@@ -165,7 +165,7 @@ class SQLConnectionHandler(object):
             ebase = ('An OperationalError with the following message occured'
                      '\n\n\t%s\n%s For more information, review `INSTALL.md`'
                      ' in the Qiita installation base directory.')
-            raise RuntimeError(ebase % (e.message, etext))
+            raise RuntimeError(ebase % (str(e), etext))
         else:
             self._connection = getattr(SQLConnectionHandler, self._conn_attr)
 
@@ -285,7 +285,7 @@ class SQLConnectionHandler(object):
             except PostgresError as e:
                 self._connection.rollback()
                 raise ValueError("Error running SQL: %s. MSG: %s\n" % (
-                    errorcodes.lookup(e.pgcode), e.message))
+                    errorcodes.lookup(e.pgcode), str(e)))
             else:
                 self._connection.commit()
 
@@ -450,7 +450,7 @@ class Transaction(object):
         except OperationalError as e:
             # catch three known common exceptions and raise runtime errors
             try:
-                etype = e.message.split(':')[1].split()[0]
+                etype = str(e).split(':')[1].split()[0]
             except IndexError:
                 # we recieved a really unanticipated error without a colon
                 etype = ''
@@ -473,7 +473,7 @@ class Transaction(object):
             ebase = ('An OperationalError with the following message occured'
                      '\n\n\t%s\n%s For more information, review `INSTALL.md`'
                      ' in the Qiita installation base directory.')
-            raise RuntimeError(ebase % (e.message, etext))
+            raise RuntimeError(ebase % (str(e), etext))
 
     def close(self):
         if self._connection is not None:
@@ -550,9 +550,9 @@ class Transaction(object):
         try:
             ec_lu = errorcodes.lookup(error.pgcode)
             raise ValueError(
-                "Error running SQL: %s. MSG: %s\n" % (ec_lu, error.message))
+                "Error running SQL: %s. MSG: %s\n" % (ec_lu, str(error)))
         except (KeyError, AttributeError):
-            raise ValueError("Error running SQL query: %s" % error.message)
+            raise ValueError("Error running SQL query: %s" % str(error))
 
     @_checker
     def add(self, sql, sql_args=None, many=False):

--- a/qiita_db/test/test_analysis.py
+++ b/qiita_db/test/test_analysis.py
@@ -192,7 +192,7 @@ class TestAnalysis(TestCase):
             qdb.user.User("admin@foo.bar"), "newAnalysis", "A New Analysis")
 
         # make sure portal is associated
-        self.assertItemsEqual(obs._portals, ["QIITA", "EMP"])
+        self.assertCountEqual(obs._portals, ["QIITA", "EMP"])
 
     def test_create_from_default(self):
         with qdb.sql_connection.TRN:
@@ -209,8 +209,8 @@ class TestAnalysis(TestCase):
         self.assertEqual(obs._portals, ["QIITA"])
         self.assertLess(time1, obs.timestamp)
         self.assertEqual(obs.description, "A New Analysis")
-        self.assertItemsEqual(obs.samples, [4])
-        self.assertItemsEqual(
+        self.assertCountEqual(obs.samples, [4])
+        self.assertCountEqual(
             obs.samples[4], ['1.SKD8.640184', '1.SKB7.640196',
                              '1.SKM9.640192', '1.SKM4.640180'])
         self.assertEqual(obs.data_types, ['18S'])
@@ -266,14 +266,14 @@ class TestAnalysis(TestCase):
                    '1.SKM9.640192', '1.SKM4.640180'],
                6: ['1.SKB8.640193', '1.SKD8.640184', '1.SKB7.640196',
                    '1.SKM9.640192', '1.SKM4.640180']}
-        self.assertItemsEqual(self.analysis.samples, exp)
+        self.assertCountEqual(self.analysis.samples, exp)
 
     def test_retrieve_portal(self):
         self.assertEqual(self.analysis._portals, ["QIITA"])
 
     def test_retrieve_data_types(self):
         exp = ['18S', '16S']
-        self.assertItemsEqual(self.analysis.data_types, exp)
+        self.assertCountEqual(self.analysis.data_types, exp)
 
     def test_retrieve_shared_with(self):
         self.assertEqual(self.analysis.shared_with,
@@ -329,9 +329,9 @@ class TestAnalysis(TestCase):
                    '1.SKM4.640180', '1.SKB8.640193']}
         analysis.add_samples(exp)
         obs = analysis.samples
-        self.assertItemsEqual(obs.keys(), exp.keys())
+        self.assertCountEqual(obs.keys(), exp.keys())
         for k in obs:
-            self.assertItemsEqual(obs[k], exp[k])
+            self.assertCountEqual(obs[k], exp[k])
 
         analysis.remove_samples(artifacts=(qdb.artifact.Artifact(4), ),
                                 samples=('1.SKB8.640193', ))
@@ -342,9 +342,9 @@ class TestAnalysis(TestCase):
                6: ['1.SKD8.640184', '1.SKB7.640196', '1.SKM9.640192',
                    '1.SKM4.640180', '1.SKB8.640193']}
         obs = analysis.samples
-        self.assertItemsEqual(obs.keys(), exp.keys())
+        self.assertCountEqual(obs.keys(), exp.keys())
         for k in obs:
-            self.assertItemsEqual(obs[k], exp[k])
+            self.assertCountEqual(obs[k], exp[k])
 
         analysis.remove_samples(samples=('1.SKD8.640184', ))
         exp = {4: ['1.SKB7.640196', '1.SKM9.640192', '1.SKM4.640180'],
@@ -352,13 +352,13 @@ class TestAnalysis(TestCase):
                    '1.SKM4.640180'],
                6: ['1.SKB8.640193', '1.SKB7.640196', '1.SKM9.640192',
                    '1.SKM4.640180']}
-        self.assertItemsEqual(analysis.samples, exp)
+        self.assertCountEqual(analysis.samples, exp)
 
         analysis.remove_samples(
             artifacts=(qdb.artifact.Artifact(4), qdb.artifact.Artifact(5)))
         exp = {6: {'1.SKB7.640196', '1.SKB8.640193',
                    '1.SKM4.640180', '1.SKM9.640192'}}
-        self.assertItemsEqual(analysis.samples, exp)
+        self.assertCountEqual(analysis.samples, exp)
 
     def test_share_unshare(self):
         analysis = self._create_analyses_with_samples()
@@ -509,7 +509,7 @@ class TestAnalysis(TestCase):
         obs = set(table.ids(axis='sample'))
         exp = {'4.1.SKD8.640184', '4.1.SKB7.640196', '4.1.SKB8.640193',
                '5.1.SKB8.640193', '5.1.SKB7.640196', '5.1.SKD8.640184'}
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
     def test_build_biom_tables_raise_error_due_to_sample_selection(self):
         grouped_samples = {
@@ -531,12 +531,12 @@ class TestAnalysis(TestCase):
         mf_ids = qdb.metadata_template.util.load_template_to_dataframe(
             mapping_fp, index='#SampleID').index
 
-        self.assertItemsEqual(biom_ids, mf_ids)
+        self.assertCountEqual(biom_ids, mf_ids)
 
         # now that the samples have been prefixed
         exp = ['1.SKM9.640192', '1.SKM4.640180', '1.SKD8.640184',
                '1.SKB8.640193', '1.SKB7.640196']
-        self.assertItemsEqual(biom_ids, exp)
+        self.assertCountEqual(biom_ids, exp)
 
     def test_build_files_post_processing_cmd(self):
         tmp = qdb.artifact.Artifact(4).processing_parameters.command
@@ -617,7 +617,7 @@ class TestAnalysis(TestCase):
         mf_ids = qdb.metadata_template.util.load_template_to_dataframe(
             mapping_fp, index='#SampleID').index
 
-        self.assertItemsEqual(biom_ids, mf_ids)
+        self.assertCountEqual(biom_ids, mf_ids)
 
         # now that the samples have been prefixed
         exp = ['4.1.SKM9.640192', '4.1.SKM4.640180', '4.1.SKD8.640184',
@@ -626,7 +626,7 @@ class TestAnalysis(TestCase):
                '5.1.SKB8.640193', '5.1.SKB7.640196',
                '6.1.SKM9.640192', '6.1.SKM4.640180', '6.1.SKD8.640184',
                '6.1.SKB8.640193', '6.1.SKB7.640196']
-        self.assertItemsEqual(biom_ids, exp)
+        self.assertCountEqual(biom_ids, exp)
 
     def test_add_file(self):
         # Tested indirectly through build_files

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -59,7 +59,7 @@ class ArtifactTestsReadOnly(TestCase):
                ['rarefaction_curves', 'Rarefaction curves', False, False,
                 False],
                ['taxa_summary', 'Taxa summary plots', False, False, False]]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         qdb.artifact.Artifact.create_type(
             "NewType", "NewTypeDesc", False, False, False,
@@ -80,7 +80,7 @@ class ArtifactTestsReadOnly(TestCase):
                 False],
                ['taxa_summary', 'Taxa summary plots', False, False, False],
                ['NewType', 'NewTypeDesc', False, False, False]]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
         self.assertTrue(exists(qdb.util.get_mountpoint('NewType')[0][1]))
 
         with self.assertRaises(qdb.exceptions.QiitaDBDuplicateError):
@@ -245,7 +245,7 @@ class ArtifactTestsReadOnly(TestCase):
         obs = tester._create_lineage_graph_from_edge_list([])
         self.assertTrue(isinstance(obs, nx.DiGraph))
         self.assertEqual(obs.nodes(), [tester])
-        self.assertEqual(obs.edges(), [])
+        self.assertEqual(list(obs.edges()), [])
 
     def test_create_lineage_graph_from_edge_list(self):
         tester = qdb.artifact.Artifact(1)
@@ -254,12 +254,12 @@ class ArtifactTestsReadOnly(TestCase):
         self.assertTrue(isinstance(obs, nx.DiGraph))
         exp = [qdb.artifact.Artifact(1), qdb.artifact.Artifact(2),
                qdb.artifact.Artifact(3), qdb.artifact.Artifact(4)]
-        self.assertItemsEqual(obs.nodes(), exp)
+        self.assertCountEqual(obs.nodes(), exp)
         exp = [(qdb.artifact.Artifact(1), qdb.artifact.Artifact(2)),
                (qdb.artifact.Artifact(2), qdb.artifact.Artifact(4)),
                (qdb.artifact.Artifact(1), qdb.artifact.Artifact(3)),
                (qdb.artifact.Artifact(3), qdb.artifact.Artifact(4))]
-        self.assertItemsEqual(obs.edges(), exp)
+        self.assertCountEqual(obs.edges(), exp)
 
     def test_ancestors(self):
         obs = qdb.artifact.Artifact(1).ancestors
@@ -273,30 +273,30 @@ class ArtifactTestsReadOnly(TestCase):
         self.assertTrue(isinstance(obs, nx.DiGraph))
         obs_nodes = obs.nodes()
         exp_nodes = [qdb.artifact.Artifact(1), qdb.artifact.Artifact(2)]
-        self.assertItemsEqual(obs_nodes, exp_nodes)
+        self.assertCountEqual(obs_nodes, exp_nodes)
         obs_edges = obs.edges()
         exp_edges = [(qdb.artifact.Artifact(1), qdb.artifact.Artifact(2))]
-        self.assertItemsEqual(obs_edges, exp_edges)
+        self.assertCountEqual(obs_edges, exp_edges)
 
         obs = qdb.artifact.Artifact(3).ancestors
         self.assertTrue(isinstance(obs, nx.DiGraph))
         obs_nodes = obs.nodes()
         exp_nodes = [qdb.artifact.Artifact(1), qdb.artifact.Artifact(3)]
-        self.assertItemsEqual(obs_nodes, exp_nodes)
+        self.assertCountEqual(obs_nodes, exp_nodes)
         obs_edges = obs.edges()
         exp_edges = [(qdb.artifact.Artifact(1), qdb.artifact.Artifact(3))]
-        self.assertItemsEqual(obs_edges, exp_edges)
+        self.assertCountEqual(obs_edges, exp_edges)
 
         obs = qdb.artifact.Artifact(4).ancestors
         self.assertTrue(isinstance(obs, nx.DiGraph))
         obs_nodes = obs.nodes()
         exp_nodes = [qdb.artifact.Artifact(1), qdb.artifact.Artifact(2),
                      qdb.artifact.Artifact(4)]
-        self.assertItemsEqual(obs_nodes, exp_nodes)
+        self.assertCountEqual(obs_nodes, exp_nodes)
         obs_edges = obs.edges()
         exp_edges = [(qdb.artifact.Artifact(1), qdb.artifact.Artifact(2)),
                      (qdb.artifact.Artifact(2), qdb.artifact.Artifact(4))]
-        self.assertItemsEqual(obs_edges, exp_edges)
+        self.assertCountEqual(obs_edges, exp_edges)
 
     def test_descendants(self):
         obs = qdb.artifact.Artifact(1).descendants
@@ -305,40 +305,40 @@ class ArtifactTestsReadOnly(TestCase):
         exp_nodes = [qdb.artifact.Artifact(1), qdb.artifact.Artifact(2),
                      qdb.artifact.Artifact(3), qdb.artifact.Artifact(4),
                      qdb.artifact.Artifact(5), qdb.artifact.Artifact(6)]
-        self.assertItemsEqual(obs_nodes, exp_nodes)
+        self.assertCountEqual(obs_nodes, exp_nodes)
         obs_edges = obs.edges()
         exp_edges = [(qdb.artifact.Artifact(1), qdb.artifact.Artifact(2)),
                      (qdb.artifact.Artifact(1), qdb.artifact.Artifact(3)),
                      (qdb.artifact.Artifact(2), qdb.artifact.Artifact(4)),
                      (qdb.artifact.Artifact(2), qdb.artifact.Artifact(5)),
                      (qdb.artifact.Artifact(2), qdb.artifact.Artifact(6))]
-        self.assertItemsEqual(obs_edges, exp_edges)
+        self.assertCountEqual(obs_edges, exp_edges)
 
         obs = qdb.artifact.Artifact(2).descendants
         self.assertTrue(isinstance(obs, nx.DiGraph))
         obs_nodes = obs.nodes()
         exp_nodes = [qdb.artifact.Artifact(2), qdb.artifact.Artifact(4),
                      qdb.artifact.Artifact(5), qdb.artifact.Artifact(6)]
-        self.assertItemsEqual(obs_nodes, exp_nodes)
+        self.assertCountEqual(obs_nodes, exp_nodes)
         obs_edges = obs.edges()
         exp_edges = [(qdb.artifact.Artifact(2), qdb.artifact.Artifact(4)),
                      (qdb.artifact.Artifact(2), qdb.artifact.Artifact(5)),
                      (qdb.artifact.Artifact(2), qdb.artifact.Artifact(6))]
-        self.assertItemsEqual(obs_edges, exp_edges)
+        self.assertCountEqual(obs_edges, exp_edges)
 
         obs = qdb.artifact.Artifact(3).descendants
         self.assertTrue(isinstance(obs, nx.DiGraph))
         obs_nodes = obs.nodes()
-        self.assertItemsEqual(obs_nodes, [qdb.artifact.Artifact(3)])
+        self.assertCountEqual(obs_nodes, [qdb.artifact.Artifact(3)])
         obs_edges = obs.edges()
-        self.assertItemsEqual(obs_edges, [])
+        self.assertCountEqual(obs_edges, [])
 
         obs = qdb.artifact.Artifact(4).descendants
         self.assertTrue(isinstance(obs, nx.DiGraph))
         obs_nodes = obs.nodes()
-        self.assertItemsEqual(obs_nodes, [qdb.artifact.Artifact(4)])
+        self.assertCountEqual(obs_nodes, [qdb.artifact.Artifact(4)])
         obs_edges = obs.edges()
-        self.assertItemsEqual(obs_edges, [])
+        self.assertCountEqual(obs_edges, [])
 
     def test_descendants_with_jobs(self):
         A = qdb.artifact.Artifact
@@ -384,9 +384,9 @@ class ArtifactTestsReadOnly(TestCase):
         obs = A(3).descendants
         self.assertTrue(isinstance(obs, nx.DiGraph))
         obs_nodes = obs.nodes()
-        self.assertItemsEqual(obs_nodes, [A(3)])
+        self.assertCountEqual(obs_nodes, [A(3)])
         obs_edges = obs.edges()
-        self.assertItemsEqual(obs_edges, [])
+        self.assertCountEqual(obs_edges, [])
 
         # Create a workflow starting in the artifact 1, so we can test that
         # "in construction" jobs also show up correctly
@@ -402,7 +402,7 @@ class ArtifactTestsReadOnly(TestCase):
         user = qdb.user.User('test@foo.bar')
         wf = qdb.processing_job.ProcessingWorkflow.from_scratch(
             user, params, name='Test WF')
-        parent = wf.graph.nodes()[0]
+        parent = list(wf.graph.nodes())[0]
         wf.add(qdb.software.DefaultParameters(10),
                connections={parent: {'demultiplexed': 'input_data'}})
         obs = A(1).descendants_with_jobs

--- a/qiita_db/test/test_meta_util.py
+++ b/qiita_db/test/test_meta_util.py
@@ -155,7 +155,7 @@ class MetaUtilTests(TestCase):
     def test_get_lat_longs(self):
         # no public studies should return an empty array
         obs = qdb.meta_util.get_lat_longs()
-        self.assertItemsEqual(obs, [])
+        self.assertCountEqual(obs, [])
 
         old_visibility = {}
         for pt in qdb.study.Study(1).prep_templates():
@@ -188,7 +188,7 @@ class MetaUtilTests(TestCase):
             [1, 78.3634273709, 74.423907894],
             [1, 38.2627021402, 3.48274264219]]
         obs = qdb.meta_util.get_lat_longs()
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         for k, v in old_visibility.iteritems():
             k.artifact.visibility = v
@@ -234,7 +234,7 @@ class MetaUtilTests(TestCase):
         obs = qdb.meta_util.get_lat_longs()
         exp = []
 
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
         qdb.metadata_template.sample_template.SampleTemplate.delete(st.id)
         qdb.study.Study.delete(study.id)
 

--- a/qiita_db/test/test_portal.py
+++ b/qiita_db/test/test_portal.py
@@ -40,13 +40,13 @@ class TestPortal(TestCase):
                 'in database.'],
                [2, 'EMP', 'EMP portal'],
                [4, 'NEWPORTAL', 'SOMEDESC']]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         obs = self.conn_handler.execute_fetchall(
             "SELECT * FROM qiita.analysis_portal")
         exp = [[1, 1], [2, 1], [3, 1], [4, 1], [5, 1], [6, 1], [7, 2], [8, 2],
                [9, 2], [10, 2], [11, 4], [12, 4], [13, 4], [14, 4]]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         with self.assertRaises(qdb.exceptions.QiitaDBDuplicateError):
             qdb.portal.Portal.create("EMP", "DOESNTMATTERFORDESC")
@@ -66,13 +66,13 @@ class TestPortal(TestCase):
         exp = [[1, 'QIITA', 'QIITA portal. Access to all data stored '
                 'in database.'],
                [2, 'EMP', 'EMP portal']]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         obs = self.conn_handler.execute_fetchall(
             "SELECT * FROM qiita.analysis_portal")
         exp = [[1, 1], [2, 1], [3, 1], [4, 1], [5, 1], [6, 1], [7, 2], [8, 2],
                [9, 2], [10, 2]]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         with self.assertRaises(qdb.exceptions.QiitaDBLookupError):
             qdb.portal.Portal.delete("NOEXISTPORTAL")
@@ -126,7 +126,7 @@ class TestPortal(TestCase):
     def test_add_study_portals(self):
         obs = qdb.portal.Portal.create("NEWPORTAL4", "SOMEDESC")
         obs.add_studies([self.study.id])
-        self.assertItemsEqual(self.study._portals, ['NEWPORTAL4', 'QIITA'])
+        self.assertCountEqual(self.study._portals, ['NEWPORTAL4', 'QIITA'])
 
         npt.assert_warns(qdb.exceptions.QiitaDBWarning, obs.add_studies,
                          [self.study.id])
@@ -142,13 +142,13 @@ class TestPortal(TestCase):
         # Set up the analysis in EMP portal
         self.emp_portal.add_analyses([self.analysis.id])
         obs = self.analysis._portals
-        self.assertItemsEqual(obs, ['QIITA', 'EMP'])
+        self.assertCountEqual(obs, ['QIITA', 'EMP'])
 
         # Test study removal failure
         with self.assertRaises(qdb.exceptions.QiitaDBError):
             self.emp_portal.remove_studies([self.study.id])
         obs = self.study._portals
-        self.assertItemsEqual(obs, ['QIITA', 'EMP'])
+        self.assertCountEqual(obs, ['QIITA', 'EMP'])
 
         # Test study removal
         self.emp_portal.remove_analyses([self.analysis.id])
@@ -202,7 +202,7 @@ class TestPortal(TestCase):
         self.emp_portal.add_studies([1])
         self.emp_portal.add_analyses([self.analysis.id])
         obs = self.analysis._portals
-        self.assertItemsEqual(obs, ['QIITA', 'EMP'])
+        self.assertCountEqual(obs, ['QIITA', 'EMP'])
         # Test removal
         self.emp_portal.remove_analyses([self.analysis.id])
         obs = self.analysis._portals

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -44,11 +44,11 @@ class CommandTests(TestCase):
         cmd.activate()
         obs = list(qdb.software.Command.get_commands_by_input_type(['FASTQ']))
         exp = [cmd]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         obs = list(qdb.software.Command.get_commands_by_input_type(
             ['FASTQ', 'per_sample_FASTQ']))
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         obs = list(qdb.software.Command.get_commands_by_input_type(
             ['FASTQ', 'SFF']))
@@ -57,7 +57,7 @@ class CommandTests(TestCase):
         obs = list(qdb.software.Command.get_commands_by_input_type(
             ['FASTQ', 'SFF'], active_only=False))
         exp = [qdb.software.Command(1), qdb.software.Command(2)]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         new_cmd = qdb.software.Command.create(
             self.software, "Analysis Only Command",
@@ -67,12 +67,12 @@ class CommandTests(TestCase):
         obs = list(qdb.software.Command.get_commands_by_input_type(
             ['FASTQ', 'SFF'], active_only=False))
         exp = [qdb.software.Command(1), qdb.software.Command(2)]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         obs = list(qdb.software.Command.get_commands_by_input_type(
             ['FASTQ', 'SFF'], active_only=False, exclude_analysis=False))
         exp = [qdb.software.Command(1), qdb.software.Command(2), new_cmd]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
     def test_get_html_artifact(self):
         with self.assertRaises(qdb.exceptions.QiitaDBError):
@@ -212,17 +212,17 @@ class CommandTests(TestCase):
         exp_params = {
             'input_data': ('artifact', ['FASTQ', 'per_sample_FASTQ'])}
         obs = qdb.software.Command(1).required_parameters
-        self.assertItemsEqual(obs.keys(), exp_params.keys())
+        self.assertCountEqual(obs.keys(), exp_params.keys())
         self.assertEqual(obs['input_data'][0],  exp_params['input_data'][0])
-        self.assertItemsEqual(obs['input_data'][1],
+        self.assertCountEqual(obs['input_data'][1],
                               exp_params['input_data'][1])
 
         exp_params = {
             'input_data': ('artifact', ['SFF', 'FASTA', 'FASTA_Sanger'])}
         obs = qdb.software.Command(2).required_parameters
-        self.assertItemsEqual(obs.keys(), exp_params.keys())
+        self.assertCountEqual(obs.keys(), exp_params.keys())
         self.assertEqual(obs['input_data'][0],  exp_params['input_data'][0])
-        self.assertItemsEqual(obs['input_data'][1],
+        self.assertCountEqual(obs['input_data'][1],
                               exp_params['input_data'][1])
 
     def test_optional_parameters(self):
@@ -603,7 +603,7 @@ class SoftwareTests(TestCase):
                          ' or run "qiita plugin update" to update the plugin '
                          'information. Offending values: description, '
                          'environment_script, start_script']
-            self.assertItemsEqual(obs_warns, exp_warns)
+            self.assertCountEqual(obs_warns, exp_warns)
 
         self.assertEqual(obs, exp)
         self.assertEqual(
@@ -667,7 +667,7 @@ class SoftwareTests(TestCase):
             obs = qdb.software.Software.from_file(fp)
             obs_warns = [str(w.message) for w in warns]
             exp_warns = []
-            self.assertItemsEqual(obs_warns, exp_warns)
+            self.assertCountEqual(obs_warns, exp_warns)
 
         self.assertEqual(obs, qdb.software.Software(3))
         self.assertEqual(obs.publications, [])
@@ -775,11 +775,11 @@ class SoftwareTests(TestCase):
         self.assertEqual(obs.publications, [])
         obs.add_publications([['10.1000/nmeth.f.101', '12345678']])
         exp = [['10.1000/nmeth.f.101', '12345678']]
-        self.assertItemsEqual(obs.publications, exp)
+        self.assertCountEqual(obs.publications, exp)
 
         # Add a publication that already exists
         obs.add_publications([['10.1000/nmeth.f.101', '12345678']])
-        self.assertItemsEqual(obs.publications, exp)
+        self.assertCountEqual(obs.publications, exp)
 
     def test_activate(self):
         qdb.software.Software.deactivate_all()
@@ -1056,21 +1056,21 @@ class DefaultWorkflowTests(TestCase):
         self.assertTrue(isinstance(obs, nx.DiGraph))
         exp = [qdb.software.DefaultWorkflowNode(1),
                qdb.software.DefaultWorkflowNode(2)]
-        self.assertItemsEqual(obs.nodes(), exp)
+        self.assertCountEqual(obs.nodes(), exp)
         exp = [(qdb.software.DefaultWorkflowNode(1),
                 qdb.software.DefaultWorkflowNode(2),
                 {'connections': qdb.software.DefaultWorkflowEdge(1)})]
-        self.assertItemsEqual(obs.edges(data=True), exp)
+        self.assertCountEqual(obs.edges(data=True), exp)
 
         obs = qdb.software.DefaultWorkflow(2).graph
         self.assertTrue(isinstance(obs, nx.DiGraph))
         exp = [qdb.software.DefaultWorkflowNode(3),
                qdb.software.DefaultWorkflowNode(4)]
-        self.assertItemsEqual(obs.nodes(), exp)
+        self.assertCountEqual(obs.nodes(), exp)
         exp = [(qdb.software.DefaultWorkflowNode(3),
                 qdb.software.DefaultWorkflowNode(4),
                 {'connections': qdb.software.DefaultWorkflowEdge(2)})]
-        self.assertItemsEqual(obs.edges(data=True), exp)
+        self.assertCountEqual(obs.edges(data=True), exp)
 
 
 CONF_TEMPLATE = """[main]

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -597,7 +597,7 @@ class SoftwareTests(TestCase):
                      client_secret))
         with warnings.catch_warnings(record=True) as warns:
             obs = qdb.software.Software.from_file(fp)
-            obs_warns = [str(w.message) for w in warns]
+            obs_warns = [str(w) for w in warns]
             exp_warns = ['Plugin "QIIME" version "1.9.1" config file does not '
                          'match with stored information. Check the config file'
                          ' or run "qiita plugin update" to update the plugin '
@@ -665,7 +665,7 @@ class SoftwareTests(TestCase):
                      '20rNMhmqN'))
         with warnings.catch_warnings(record=True) as warns:
             obs = qdb.software.Software.from_file(fp)
-            obs_warns = [str(w.message) for w in warns]
+            obs_warns = [str(w) for w in warns]
             exp_warns = []
             self.assertCountEqual(obs_warns, exp_warns)
 

--- a/qiita_db/test/test_sql.py
+++ b/qiita_db/test/test_sql.py
@@ -138,7 +138,7 @@ class TestSQL(TestCase):
         self._files_to_remove.extend([afp for _, afp, _ in new.filepaths])
         obs = self.conn_handler.execute_fetchall(sql, [new.id])
         exp = [[1], [new_root.id]]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
     def test_artifact_ancestry_root(self):
         """Correctly returns the ancestry of a root artifact"""
@@ -152,7 +152,7 @@ class TestSQL(TestCase):
         sql = "SELECT * FROM qiita.artifact_ancestry(%s)"
         obs = self.conn_handler.execute_fetchall(sql, [4])
         exp = [[4, 2], [2, 1]]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
     def test_artifact_ancestry_leaf_multiple_parents(self):
         """Correctly returns the ancestry of a leaf artifact w multiple parents
@@ -166,7 +166,7 @@ class TestSQL(TestCase):
         obs = self.conn_handler.execute_fetchall(sql, [child.id])
         exp = [[child.id, parent1.id], [child.id, parent2.id],
                [parent1.id, root.id], [parent2.id, root.id]]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
     def test_artifact_ancestry_middle(self):
         """Correctly returns the ancestry of an artifact in the middle of the
@@ -188,7 +188,7 @@ class TestSQL(TestCase):
         sql = "SELECT * FROM qiita.artifact_descendants(%s)"
         obs = self.conn_handler.execute_fetchall(sql, [1])
         exp = [[2, 1], [3, 1], [4, 2], [5, 2], [6, 2]]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
     def test_artifact_descendants_middle(self):
         """Correctly returns the descendants of an artifact in the middle of
@@ -196,7 +196,7 @@ class TestSQL(TestCase):
         sql = "SELECT * FROM qiita.artifact_descendants(%s)"
         obs = self.conn_handler.execute_fetchall(sql, [2])
         exp = [[4, 2], [5, 2], [6, 2]]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
     def test_isnumeric(self):
         """Test SQL function isnumeric"""

--- a/qiita_db/test/test_study.py
+++ b/qiita_db/test/test_study.py
@@ -874,11 +874,11 @@ class TestStudy(TestCase):
         study = qdb.study.Study(1)
         tags = ['this is my tag', 'actual GOLD!']
         message = study.update_tags(user, tags)
-        self.assertItemsEqual(study.tags, tags[:1])
+        self.assertCountEqual(study.tags, tags[:1])
         self.assertEqual(message, 'Only admins can assign: actual GOLD!')
         # now like admin
         message = study.update_tags(admin, tags)
-        self.assertItemsEqual(study.tags, tags)
+        self.assertCountEqual(study.tags, tags)
         self.assertEqual(message, '')
 
         # cleaning tags

--- a/qiita_db/test/test_user.py
+++ b/qiita_db/test/test_user.py
@@ -402,7 +402,7 @@ class UserTest(TestCase):
             'sit amet, venenatis bibendum sem. Curabitur vel odio sed est '
             'rutrum rutrum. Quisque efficitur ut purus in ultrices. '
             'Pellentesque eu auctor justo.', 'message <a href="#">3</a>']
-        self.assertItemsEqual([(x[1]) for x in obs], exp_msg)
+        self.assertCountEqual([(x[1]) for x in obs], exp_msg)
         self.assertTrue(all(x[2] < datetime.now() for x in obs))
         self.assertFalse(all(x[3] for x in obs))
         self.assertEqual([x[4] for x in obs], [True, False, False, False])

--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -762,7 +762,7 @@ class DBUtilTests(TestCase):
                                     datetime(2015, 8, 5, 19, 41))
         obs = [[x[0], x[1]] for x in user.messages()]
         exp = [[message_id, 'SYS MESSAGE']]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         qdb.util.clear_system_messages()
         obs = [[x[0], x[1]] for x in user.messages()]
@@ -776,11 +776,11 @@ class DBUtilTests(TestCase):
         obs = qdb.util.supported_filepath_types("FASTQ")
         exp = [["raw_forward_seqs", True], ["raw_reverse_seqs", False],
                ["raw_barcodes", True]]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         obs = qdb.util.supported_filepath_types("BIOM")
         exp = [["biom", True], ["directory", False], ["log", False]]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
     def test_generate_analysis_list(self):
         self.assertEqual(qdb.util.generate_analysis_list([]), [])
@@ -1068,7 +1068,7 @@ class UtilTests(TestCase):
              'name': 'noname', 'target_subfragment': [], 'parameters': {},
              'algorithm': '', 'deprecated': None, 'platform': 'not provided',
              'algorithm_az': '', 'prep_samples': 0}]
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         # now let's test that the order given by the commands actually give the
         # correct results
@@ -1087,7 +1087,7 @@ class UtilTests(TestCase):
             exp[0]['algorithm'] = ('Pick closed-reference OTUs (reference: 1) '
                                    '| Split libraries FASTQ')
             exp[0]['algorithm_az'] = '33fed1b35728417d7ba4139b8f817d44'
-            self.assertItemsEqual(obs, exp)
+            self.assertCountEqual(obs, exp)
 
             # setting up database changes for also command output
             qdb.sql_connection.TRN.add(
@@ -1101,7 +1101,7 @@ class UtilTests(TestCase):
                                    'BIOM: 1_study_1001_closed_reference_'
                                    'otu_table.biom) | Split libraries FASTQ')
             exp[0]['algorithm_az'] = 'de5b794a2cacd428f36fea86df196bfd'
-            self.assertItemsEqual(obs, exp)
+            self.assertCountEqual(obs, exp)
 
             # let's test that we ignore the parent_info
             qdb.sql_connection.TRN.add("""UPDATE qiita.software_command
@@ -1115,7 +1115,7 @@ class UtilTests(TestCase):
                                    'BIOM: 1_study_1001_closed_reference_'
                                    'otu_table.biom)')
             exp[0]['algorithm_az'] = '7f59a45b2f0d30cd1ed1929391c26e07'
-            self.assertItemsEqual(obs, exp)
+            self.assertCountEqual(obs, exp)
 
             # let's test that we ignore the parent_info
             qdb.sql_connection.TRN.add("""UPDATE qiita.software_command
@@ -1129,7 +1129,7 @@ class UtilTests(TestCase):
                                    'BIOM: 1_study_1001_closed_reference_'
                                    'otu_table.biom)')
             exp[0]['algorithm_az'] = '7f59a45b2f0d30cd1ed1929391c26e07'
-            self.assertItemsEqual(obs, exp)
+            self.assertCountEqual(obs, exp)
 
             # returning database as it was
             qdb.sql_connection.TRN.add(

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -434,7 +434,7 @@ def compute_checksum(path):
         filepaths.append(path)
 
     for fp in filepaths:
-        with open(fp, "Ub") as f:
+        with open(fp, 'rb', newline=None) as f:
             # Go line by line so we don't need to load the entire file
             for line in f:
                 if crc is None:

--- a/qiita_pet/handlers/analysis_handlers/tests/test_base_handlers.py
+++ b/qiita_pet/handlers/analysis_handlers/tests/test_base_handlers.py
@@ -79,22 +79,22 @@ class TestBaseHandlersUtils(TestCase):
                     ('artifact', 'BIOM', 9, 'noname\n(BIOM)', 'artifact'),
                     ('artifact', 'BIOM',   8, 'noname\n(BIOM)', 'artifact')],
                'workflow': None}
-        self.assertItemsEqual(obs, exp)
-        self.assertItemsEqual(obs['edges'], exp['edges'])
-        self.assertItemsEqual(obs['nodes'], exp['nodes'])
+        self.assertCountEqual(obs, exp)
+        self.assertCountEqual(obs['edges'], exp['edges'])
+        self.assertCountEqual(obs['nodes'], exp['nodes'])
         self.assertIsNone(obs['workflow'])
 
         # An admin has full access to the analysis
         obs = analyisis_graph_handler_get_request(1, User('admin@foo.bar'))
-        self.assertItemsEqual(obs, exp)
-        self.assertItemsEqual(obs['edges'], exp['edges'])
-        self.assertItemsEqual(obs['nodes'], exp['nodes'])
+        self.assertCountEqual(obs, exp)
+        self.assertCountEqual(obs['edges'], exp['edges'])
+        self.assertCountEqual(obs['nodes'], exp['nodes'])
 
         # If the analysis is shared with the user he also has access
         obs = analyisis_graph_handler_get_request(1, User('shared@foo.bar'))
-        self.assertItemsEqual(obs, exp)
-        self.assertItemsEqual(obs['edges'], exp['edges'])
-        self.assertItemsEqual(obs['nodes'], exp['nodes'])
+        self.assertCountEqual(obs, exp)
+        self.assertCountEqual(obs['edges'], exp['edges'])
+        self.assertCountEqual(obs['nodes'], exp['nodes'])
 
         # The user doesn't have access to the analysis
         with self.assertRaises(HTTPError):
@@ -163,9 +163,9 @@ class TestAnalysisGraphHandler(TestHandlerBase):
                     ['artifact', 'BIOM', 9, 'noname\n(BIOM)', 'artifact'],
                     ['artifact', 'BIOM', 8, 'noname\n(BIOM)', 'artifact']],
                'workflow': None}
-        self.assertItemsEqual(obs, exp)
-        self.assertItemsEqual(obs['edges'], exp['edges'])
-        self.assertItemsEqual(obs['nodes'], exp['nodes'])
+        self.assertCountEqual(obs, exp)
+        self.assertCountEqual(obs['edges'], exp['edges'])
+        self.assertCountEqual(obs['nodes'], exp['nodes'])
         self.assertIsNone(obs['workflow'])
 
         # Create a new analysis with 2 starting BIOMs to be able to test
@@ -197,7 +197,7 @@ class TestAnalysisGraphHandler(TestHandlerBase):
         wf = ProcessingWorkflow.from_scratch(user, params)
 
         # There is only one job in the workflow
-        job_id = wf.graph.nodes()[0].id
+        job_id = list(wf.graph.nodes())[0].id
 
         response = self.get('/analysis/description/%s/graph/' % new_id)
         self.assertEqual(response.code, 200)
@@ -215,11 +215,11 @@ class TestAnalysisGraphHandler(TestHandlerBase):
                      'taxa_summary\n(taxa_summary)', 'type']],
                'workflow': wf.id}
         # Check that the keys are the same
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
         # Check the edges
-        self.assertItemsEqual(obs['edges'], exp['edges'])
+        self.assertCountEqual(obs['edges'], exp['edges'])
         # Check the edges
-        self.assertItemsEqual(obs['nodes'], exp['nodes'])
+        self.assertCountEqual(obs['nodes'], exp['nodes'])
         # Check the edges
         self.assertEqual(obs['workflow'], exp['workflow'])
 
@@ -252,11 +252,11 @@ class TestAnalysisGraphHandler(TestHandlerBase):
                      'rarefied_table\n(BIOM)', 'type']],
                'workflow': wf.id}
         # Check that the keys are the same
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
         # Check the edges
-        self.assertItemsEqual(obs['edges'], exp['edges'])
+        self.assertCountEqual(obs['edges'], exp['edges'])
         # Check the edges
-        self.assertItemsEqual(obs['nodes'], exp['nodes'])
+        self.assertCountEqual(obs['nodes'], exp['nodes'])
         # Check the edges
         self.assertEqual(obs['workflow'], exp['workflow'])
 

--- a/qiita_pet/handlers/api_proxy/prep_template.py
+++ b/qiita_pet/handlers/api_proxy/prep_template.py
@@ -372,7 +372,7 @@ def prep_template_post_req(study_id, user_id, prep_template, data_type,
             # join all the warning messages into one. Note that this info
             # will be ignored if an exception is raised
             if warns:
-                msg = '\n'.join(set(str(w.message) for w in warns))
+                msg = '\n'.join(set(str(w) for w in warns))
                 status = 'warning'
     except Exception as e:
         # Some error occurred while processing the prep template

--- a/qiita_pet/handlers/api_proxy/processing.py
+++ b/qiita_pet/handlers/api_proxy/processing.py
@@ -104,7 +104,7 @@ def workflow_handler_post_req(user_id, command_id, params):
         wf_id = None
         job_info = None
         status = 'error'
-        message = str(exc.message)
+        message = str(exc)
 
     if wf is not None:
         # this is safe as we are creating the workflow for the first time

--- a/qiita_pet/handlers/api_proxy/processing.py
+++ b/qiita_pet/handlers/api_proxy/processing.py
@@ -110,7 +110,7 @@ def workflow_handler_post_req(user_id, command_id, params):
         # this is safe as we are creating the workflow for the first time
         # and there is only one node. Remember networkx doesn't assure order
         # of nodes
-        job = wf.graph.nodes()[0]
+        job = list(wf.graph.nodes())[0]
         inputs = [a.id for a in job.input_artifacts]
         job_cmd = job.command
         wf_id = wf.id

--- a/qiita_pet/handlers/api_proxy/tests/test_artifact.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_artifact.py
@@ -80,8 +80,8 @@ class TestArtifactAPIReadOnly(TestCase):
                'edge_list': [(1, 3), (1, 2), (2, 5), (2, 4), (2, 6)]}
         self.assertEqual(obs['message'], exp['message'])
         self.assertEqual(obs['status'], exp['status'])
-        self.assertItemsEqual(obs['node_labels'], exp['node_labels'])
-        self.assertItemsEqual(obs['edge_list'], exp['edge_list'])
+        self.assertCountEqual(obs['node_labels'], exp['node_labels'])
+        self.assertCountEqual(obs['edge_list'], exp['edge_list'])
 
     def test_artifact_graph_get_req_no_access(self):
         obs = artifact_graph_get_req(1, 'ancestors', 'demo@microbio.me')
@@ -115,7 +115,7 @@ class TestArtifactAPIReadOnly(TestCase):
 
         self.assertEqual(obs['message'], exp['message'])
         self.assertEqual(obs['status'], exp['status'])
-        self.assertItemsEqual(obs['types'], exp['types'])
+        self.assertCountEqual(obs['types'], exp['types'])
 
 
 @qiita_test_checker()
@@ -257,10 +257,10 @@ class TestArtifactAPI(TestCase):
              'deprecated': None, 'platform': 'Illumina', 'algorithm_az': '',
              'prep_samples': 27}]
         exp = {'status': 'success', 'msg': '', 'data': data}
-        self.assertItemsEqual(obs.keys(), exp.keys())
+        self.assertCountEqual(obs.keys(), exp.keys())
         self.assertEqual(obs['status'], exp['status'])
         self.assertEqual(obs['msg'], exp['msg'])
-        self.assertItemsEqual(obs['data'], exp['data'])
+        self.assertCountEqual(obs['data'], exp['data'])
 
     def test_artifact_post_req(self):
         # Create new prep template to attach artifact to

--- a/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
@@ -115,7 +115,7 @@ class TestPrepAPIReadOnly(TestCase):
 
     def test_prep_template_get_req(self):
         obs = prep_template_get_req(1, 'test@foo.bar')
-        self.assertItemsEqual(obs.keys(), ['status', 'message', 'template'])
+        self.assertCountEqual(obs.keys(), ['status', 'message', 'template'])
         self.assertEqual(obs['status'], 'success')
         self.assertEqual(obs['message'], '')
         self.assertEqual(obs['template'].keys(), [
@@ -183,7 +183,7 @@ class TestPrepAPIReadOnly(TestCase):
         self.assertEqual(obs['message'], '')
         # [0] the fp_id is the first element, that should change
         fp_ids = [fp[0] for fp in obs['filepaths']]
-        self.assertItemsEqual(fp_ids, [18, 19, 20, 21, 24, 25])
+        self.assertCountEqual(fp_ids, [18, 19, 20, 21, 24, 25])
 
     def test_prep_template_filepaths_get_req_no_access(self):
         obs = prep_template_filepaths_get_req(1, 'demo@microbio.me')
@@ -452,7 +452,7 @@ class TestPrepAPI(TestCase):
                'file': 'update.txt',
                'id': 'ignored in test'}
 
-        self.assertItemsEqual(obs['message'].split('\n'), exp['message'])
+        self.assertCountEqual(obs['message'].split('\n'), exp['message'])
         self.assertEqual(obs['status'], exp['status'])
         self.assertEqual(obs['file'], exp['file'])
         self.assertIsInstance(obs['id'], int)

--- a/qiita_pet/handlers/api_proxy/tests/test_processing.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_processing.py
@@ -47,7 +47,7 @@ class TestProcessingAPIReadOnly(TestCase):
                     {'command': 'Single Rarefaction', 'id': 12,
                      'output': [['rarefied_table', 'BIOM']]}]}
         # since the order of the commands can change, test them separately
-        self.assertItemsEqual(obs.pop('commands'), exp.pop('commands'))
+        self.assertCountEqual(obs.pop('commands'), exp.pop('commands'))
         self.assertEqual(obs, exp)
 
     def test_list_options_handler_get_req(self):
@@ -70,7 +70,7 @@ class TestProcessingAPIReadOnly(TestCase):
                                'sortmerna_max_pos': ['integer', '10000'],
                                'threads': ['integer', '1']}}
         # First check that the keys are the same
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
         self.assertEqual(obs['status'], exp['status'])
         self.assertEqual(obs['message'], exp['message'])
         self.assertEqual(obs['options'], exp['options'])

--- a/qiita_pet/handlers/api_proxy/tests/test_sample_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_sample_template.py
@@ -264,7 +264,7 @@ class TestSampleAPI(TestCase):
         self.assertEqual(obs['message'], '')
         # [0] the fp_id is the first element, that should change
         fp_ids = [fp[0] for fp in obs['filepaths']]
-        self.assertItemsEqual(fp_ids, [17, 23])
+        self.assertCountEqual(fp_ids, [17, 23])
 
     def test_sample_template_filepaths_get_req_no_access(self):
         obs = sample_template_filepaths_get_req(1, 'demo@microbio.me')

--- a/qiita_pet/handlers/api_proxy/tests/test_studies.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_studies.py
@@ -44,7 +44,7 @@ class TestStudyAPI(TestCase):
             'message': '',
             'data_types': ['16S', '18S', 'ITS', 'Proteomic', 'Metagenomic',
                            'Metabolomic']}
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
     def test_study_get_req(self):
         obs = study_get_req(1, 'test@foo.bar')
@@ -132,8 +132,8 @@ class TestStudyAPI(TestCase):
             'ebi_study_accession': None, 'specimen_id_column': None,
             'study_title': 'Some New Study for test',
             'number_samples_collected': 25}, 'message': '', 'editable': True}
-        self.assertItemsEqual(obs, exp)
-        self.assertItemsEqual(obs['study_info'], exp['study_info'])
+        self.assertCountEqual(obs, exp)
+        self.assertCountEqual(obs['study_info'], exp['study_info'])
 
     def test_study_get_req_no_access(self):
         obs = study_get_req(1, 'demo@microbio.me')

--- a/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
+++ b/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
@@ -284,7 +284,7 @@ class TestBaseHandlersUtils(TestCase):
             artifact_post_req(User('demo@microbio.me'), 1)
 
         obs = artifact_post_req(User('test@foo.bar'), 2)
-        self.assertEqual(obs.keys(), ['job'])
+        self.assertEqual(list(obs.keys()), ['job'])
         # Wait until the job is completed
         wait_for_prep_information_job(1)
         # Check that the delete function has been actually called

--- a/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
+++ b/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
@@ -71,10 +71,10 @@ class TestBaseHandlersUtils(TestCase):
         "Utility function for testing the artifact summary get request"
         obs_files = obs.pop('files')
         exp_files = exp.pop('files')
-        self.assertItemsEqual(obs_files, exp_files)
+        self.assertCountEqual(obs_files, exp_files)
         obs_jobs = obs.pop('processing_jobs')
         exp_jobs = obs.pop('processing_jobs')
-        self.assertItemsEqual(obs_jobs, exp_jobs)
+        self.assertCountEqual(obs_jobs, exp_jobs)
         self.assertEqual(obs, exp)
 
     def test_artifact_summary_get_request(self):

--- a/qiita_pet/handlers/portal.py
+++ b/qiita_pet/handlers/portal.py
@@ -80,7 +80,7 @@ class StudyPortalHandler(PortalEditBase):
                 self.write(action.upper() + " ERROR:<br/>" + str(e))
                 return
 
-        msg = '; '.join([str(w.message) for w in warns])
+        msg = '; '.join([str(w) for w in warns])
         self.write(action + " completed successfully<br/>" + msg)
 
 

--- a/qiita_pet/handlers/study_handlers/tests/test_artifact.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_artifact.py
@@ -51,8 +51,8 @@ class ArtifactGraphAJAXTests(TestHandlerBase):
         obs = loads(response.body)
         self.assertEqual(obs['status'], exp['status'])
         self.assertEqual(obs['message'], exp['message'])
-        self.assertItemsEqual(obs['node_labels'], exp['node_labels'])
-        self.assertItemsEqual(obs['edge_list'], exp['edge_list'])
+        self.assertCountEqual(obs['node_labels'], exp['node_labels'])
+        self.assertCountEqual(obs['edge_list'], exp['edge_list'])
 
     def test_get_unknown(self):
         response = self.get('/artifact/graph/', {'direction': 'BAD',
@@ -182,10 +182,10 @@ class ArtifactGetInfoTest(TestHandlerBase):
              'parameters': {}, 'target_gene': '16S rRNA', 'name': 'BIOM'}]
         exp = {'status': 'success', 'msg': '', 'data': data}
         obs = loads(response.body)
-        self.assertItemsEqual(obs.keys(), exp.keys())
+        self.assertCountEqual(obs.keys(), exp.keys())
         self.assertEqual(obs['status'], exp['status'])
         self.assertEqual(obs['msg'], exp['msg'])
-        self.assertItemsEqual(obs['data'], exp['data'])
+        self.assertCountEqual(obs['data'], exp['data'])
 
 
 class ArtifactAdminAJAXTestsReadOnly(TestHandlerBase):

--- a/qiita_pet/handlers/study_handlers/tests/test_sample_template.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_sample_template.py
@@ -128,7 +128,7 @@ class TestHelpers(TestHandlerBase):
         # Test success
         obs = sample_template_handler_post_request(
             1, user, 'uploaded_file.txt')
-        self.assertEqual(obs.keys(), ['job'])
+        self.assertEqual(list(obs.keys()), ['job'])
         job_info = r_client.get('sample_template_1')
         self.assertIsNotNone(job_info)
 
@@ -187,7 +187,7 @@ class TestHelpers(TestHandlerBase):
         obs = sample_template_handler_patch_request(
             user, "remove", "/%s/columns/col2/"
                             % new_study.id)
-        self.assertEqual(obs.keys(), ['job'])
+        self.assertEqual(list(obs.keys()), ['job'])
         job_info = r_client.get('sample_template_%s' % new_study.id)
         self.assertIsNotNone(job_info)
 
@@ -218,7 +218,7 @@ class TestHelpers(TestHandlerBase):
         # Test success
         obs = sample_template_handler_patch_request(
             user, "replace", "/1/data", req_value='uploaded_file.txt')
-        self.assertEqual(obs.keys(), ['job'])
+        self.assertEqual(list(obs.keys()), ['job'])
         job_info = r_client.get('sample_template_1')
         self.assertIsNotNone(job_info)
 
@@ -246,7 +246,7 @@ class TestHelpers(TestHandlerBase):
         # Test success
         user = User('test@foo.bar')
         obs = sample_template_handler_delete_request(1, user)
-        self.assertEqual(obs.keys(), ['job'])
+        self.assertEqual(list(obs.keys()), ['job'])
         job_info = r_client.get('sample_template_1')
         self.assertIsNotNone(job_info)
 
@@ -445,7 +445,7 @@ class TestSampleTemplateHandler(TestHandlerBase):
         self.assertEqual(response.code, 200)
         self.assertIsNotNone(response.body)
         obs = loads(response.body)
-        self.assertEqual(obs.keys(), ['job'])
+        self.assertEqual(list(obs.keys()), ['job'])
         # Wait until the job is done
         wait_for_processing_job(obs['job'])
 
@@ -457,7 +457,7 @@ class TestSampleTemplateHandler(TestHandlerBase):
         self.assertEqual(response.code, 200)
         self.assertIsNotNone(response.body)
         obs = loads(response.body)
-        self.assertEqual(obs.keys(), ['job'])
+        self.assertEqual(list(obs.keys()), ['job'])
         # Wait until the job is done
         wait_for_processing_job(obs['job'])
 
@@ -467,7 +467,7 @@ class TestSampleTemplateHandler(TestHandlerBase):
         self.assertEqual(response.code, 200)
         self.assertIsNotNone(response.body)
         obs = loads(response.body)
-        self.assertEqual(obs.keys(), ['job'])
+        self.assertEqual(list(obs.keys()), ['job'])
         # Wait until the job is done
         wait_for_processing_job(obs['job'])
 

--- a/qiita_pet/portal.py
+++ b/qiita_pet/portal.py
@@ -51,7 +51,7 @@ class PortalStyleManager(object):
 
         # Parse the configuration file
         config = ConfigParser()
-        with open(self.conf_fp, 'U') as conf_file:
+        with open(self.conf_fp, newline=None) as conf_file:
             config.readfp(conf_file)
 
         _required_sections = {'sitebase', 'index', 'study_list'}
@@ -63,7 +63,7 @@ class PortalStyleManager(object):
         # Load the custom CSS if needed
         self.custom_css = ''
         if self.css_fp:
-            with open(self.css_fp, 'U') as f:
+            with open(self.css_fp, newline=None) as f:
                 self.custom_css = f.read()
 
         self._get_sitebase(config)

--- a/qiita_pet/test/rest/test_study_person.py
+++ b/qiita_pet/test/rest/test_study_person.py
@@ -22,7 +22,7 @@ class StudyPersonHandlerTests(RESTHandlerTestCase):
         response = self.get('/api/v1/person', headers=self.headers)
         self.assertEqual(response.code, 200)
         obs = json_decode(response.body)
-        self.assertItemsEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
     def test_exist(self):
         exp = {'email': 'lab_dude@foo.bar', 'phone': '121-222-3333',

--- a/qiita_pet/test/rest/test_study_samples.py
+++ b/qiita_pet/test/rest/test_study_samples.py
@@ -209,7 +209,7 @@ class StudySamplesInfoHandlerTests(RESTHandlerTestCase):
         obs = json_decode(response.body)
         self.assertEqual(obs.keys(), exp.keys())
         self.assertEqual(obs['number-of-samples'], exp['number-of-samples'])
-        self.assertItemsEqual(obs['categories'], exp['categories'])
+        self.assertCountEqual(obs['categories'], exp['categories'])
 
     def test_get_study_does_not_exist(self):
         exp = {'message': 'Study not found'}

--- a/qiita_pet/webserver.py
+++ b/qiita_pet/webserver.py
@@ -239,7 +239,6 @@ class Application(tornado.web.Application):
 
         # 404 PAGE MUST BE LAST IN THIS LIST!
         handlers.append((r".*", NoPageHandler))
-        handlers.append((r"/.*", NoPageHandler))
 
         settings = {
             "template_path": TEMPLATE_PATH,

--- a/qiita_pet/webserver.py
+++ b/qiita_pet/webserver.py
@@ -239,6 +239,7 @@ class Application(tornado.web.Application):
 
         # 404 PAGE MUST BE LAST IN THIS LIST!
         handlers.append((r".*", NoPageHandler))
+        handlers.append((r"/.*", NoPageHandler))
 
         settings = {
             "template_path": TEMPLATE_PATH,

--- a/qiita_ware/private_plugin.py
+++ b/qiita_ware/private_plugin.py
@@ -173,7 +173,7 @@ def create_sample_template(job):
             remove(fp)
 
             if warns:
-                msg = '\n'.join(set(str(w.message) for w in warns))
+                msg = '\n'.join(set(str(w) for w in warns))
                 r_client.set("sample_template_%s" % study.id,
                              dumps({'job_id': job.id, 'alert_type': 'warning',
                                     'alert_msg': msg}))
@@ -202,7 +202,7 @@ def update_sample_template(job):
             # Join all the warning messages into one. Note that this info
             # will be ignored if an exception is raised
             if warns:
-                msg = '\n'.join(set(str(w.message) for w in warns))
+                msg = '\n'.join(set(str(w) for w in warns))
                 r_client.set("sample_template_%s" % study_id,
                              dumps({'job_id': job.id, 'alert_type': 'warning',
                                     'alert_msg': msg}))
@@ -246,7 +246,7 @@ def update_prep_template(job):
             # Join all the warning messages into one. Note that this info
             # will be ignored if an exception is raised
             if warns:
-                msg = '\n'.join(set(str(w.message) for w in warns))
+                msg = '\n'.join(set(str(w) for w in warns))
                 r_client.set("prep_template_%s" % prep_id,
                              dumps({'job_id': job.id, 'alert_type': 'warning',
                                     'alert_msg': msg}))

--- a/qiita_ware/test/test_ebi.py
+++ b/qiita_ware/test/test_ebi.py
@@ -86,8 +86,8 @@ class TestEBISubmission(TestCase):
                           'different time points in the plant lifecycle.'))
         self.assertEqual(e.investigation_type, 'Metagenomics')
         self.assertIsNone(e.new_investigation_type)
-        self.assertItemsEqual(e.sample_template, e.samples)
-        self.assertItemsEqual(e.publications, [
+        self.assertCountEqual(e.sample_template, e.samples)
+        self.assertCountEqual(e.publications, [
             ['10.100/123456', True], ['123456', False],
             ['10.100/7891011', True], ['7891011', False]])
         self.assertEqual(e.action, action)
@@ -491,7 +491,7 @@ class TestEBISubmission(TestCase):
         e = EBISubmission(artifact.id, 'ADD')
         self.files_to_remove.append(e.full_ebi_dir)
         exp = ['1.SKD6.640190', '1.SKM6.640187', '1.SKD9.640182']
-        self.assertItemsEqual(exp, e.samples)
+        self.assertCountEqual(exp, e.samples)
 
     def test_generate_experiment_xml(self):
         artifact = self.generate_new_study_with_preprocessed_data()
@@ -663,10 +663,10 @@ class TestEBISubmission(TestCase):
             rewrite_fastq=True)
 
         self.files_to_remove.append(ebi_submission.full_ebi_dir)
-        self.assertItemsEqual(obs_demux_samples, exp_demux_samples)
+        self.assertCountEqual(obs_demux_samples, exp_demux_samples)
         # testing that the samples/samples_prep and demux_samples are the same
-        self.assertItemsEqual(obs_demux_samples, ebi_submission.samples.keys())
-        self.assertItemsEqual(obs_demux_samples,
+        self.assertCountEqual(obs_demux_samples, ebi_submission.samples.keys())
+        self.assertCountEqual(obs_demux_samples,
                               ebi_submission.samples_prep.keys())
 
         # If the last test passed then we can test that the folder already
@@ -674,10 +674,10 @@ class TestEBISubmission(TestCase):
         ebi_submission = EBISubmission(artifact.id, 'ADD')
         obs_demux_samples = ebi_submission.generate_demultiplexed_fastq()
         self.files_to_remove.append(ebi_submission.full_ebi_dir)
-        self.assertItemsEqual(obs_demux_samples, exp_demux_samples)
+        self.assertCountEqual(obs_demux_samples, exp_demux_samples)
         # testing that the samples/samples_prep and demux_samples are the same
-        self.assertItemsEqual(obs_demux_samples, ebi_submission.samples.keys())
-        self.assertItemsEqual(obs_demux_samples,
+        self.assertCountEqual(obs_demux_samples, ebi_submission.samples.keys())
+        self.assertCountEqual(obs_demux_samples,
                               ebi_submission.samples_prep.keys())
 
     def _generate_per_sample_FASTQs(self, prep_template, sequences):
@@ -763,9 +763,9 @@ class TestEBISubmission(TestCase):
         self.files_to_remove.append(ebi_submission.full_ebi_dir)
 
         obs_demux_samples = ebi_submission.generate_demultiplexed_fastq()
-        self.assertItemsEqual(obs_demux_samples, exp_samples)
-        self.assertItemsEqual(ebi_submission.samples.keys(), exp_samples)
-        self.assertItemsEqual(ebi_submission.samples_prep.keys(), exp_samples)
+        self.assertCountEqual(obs_demux_samples, exp_samples)
+        self.assertCountEqual(ebi_submission.samples.keys(), exp_samples)
+        self.assertCountEqual(ebi_submission.samples_prep.keys(), exp_samples)
 
         ebi_submission.generate_xml_files()
         obs_run_xml = open(ebi_submission.run_xml_fp).read()
@@ -788,9 +788,9 @@ class TestEBISubmission(TestCase):
         # the ADD actually works without rewriting the files
         ebi_submission = EBISubmission(artifact.id, 'ADD')
         obs_demux_samples = ebi_submission.generate_demultiplexed_fastq()
-        self.assertItemsEqual(obs_demux_samples, exp_samples)
-        self.assertItemsEqual(ebi_submission.samples.keys(), exp_samples)
-        self.assertItemsEqual(ebi_submission.samples_prep.keys(), exp_samples)
+        self.assertCountEqual(obs_demux_samples, exp_samples)
+        self.assertCountEqual(ebi_submission.samples.keys(), exp_samples)
+        self.assertCountEqual(ebi_submission.samples_prep.keys(), exp_samples)
 
         ebi_submission.generate_xml_files()
         obs_run_xml = open(ebi_submission.run_xml_fp).read()
@@ -858,9 +858,9 @@ class TestEBISubmission(TestCase):
 
         obs_demux_samples = ebi_submission.generate_demultiplexed_fastq()
         exp_samples = ['1.SKM4.640180', '1.SKB2.640194']
-        self.assertItemsEqual(obs_demux_samples, exp_samples)
-        self.assertItemsEqual(ebi_submission.samples.keys(), exp_samples)
-        self.assertItemsEqual(ebi_submission.samples_prep.keys(), exp_samples)
+        self.assertCountEqual(obs_demux_samples, exp_samples)
+        self.assertCountEqual(ebi_submission.samples.keys(), exp_samples)
+        self.assertCountEqual(ebi_submission.samples_prep.keys(), exp_samples)
 
         ebi_submission.generate_xml_files()
         obs_run_xml = open(ebi_submission.run_xml_fp).read()
@@ -884,9 +884,9 @@ class TestEBISubmission(TestCase):
         ebi_submission = EBISubmission(artifact.id, 'ADD')
         obs_demux_samples = ebi_submission.generate_demultiplexed_fastq()
         exp_samples = ['1.SKM4.640180', '1.SKB2.640194']
-        self.assertItemsEqual(obs_demux_samples, exp_samples)
-        self.assertItemsEqual(ebi_submission.samples.keys(), exp_samples)
-        self.assertItemsEqual(ebi_submission.samples_prep.keys(), exp_samples)
+        self.assertCountEqual(obs_demux_samples, exp_samples)
+        self.assertCountEqual(ebi_submission.samples.keys(), exp_samples)
+        self.assertCountEqual(ebi_submission.samples_prep.keys(), exp_samples)
 
         ebi_submission.generate_xml_files()
         obs_run_xml = open(ebi_submission.run_xml_fp).read()

--- a/qiita_ware/test/test_private_plugin.py
+++ b/qiita_ware/test/test_private_plugin.py
@@ -145,7 +145,7 @@ class TestPrivatePlugin(BaseTestPrivatePlugin):
         obs = r_client.get("sample_template_%d" % study.id)
         self.assertIsNotNone(obs)
         obs = loads(obs)
-        self.assertItemsEqual(obs, ['job_id', 'alert_type', 'alert_msg'])
+        self.assertCountEqual(obs, ['job_id', 'alert_type', 'alert_msg'])
         self.assertEqual(obs['job_id'], job.id)
         self.assertEqual(obs['alert_type'], 'warning')
         self.assertIn(
@@ -183,7 +183,7 @@ class TestPrivatePlugin(BaseTestPrivatePlugin):
         obs = r_client.get("sample_template_1")
         self.assertIsNotNone(obs)
         obs = loads(obs)
-        self.assertItemsEqual(obs, ['job_id', 'alert_type', 'alert_msg'])
+        self.assertCountEqual(obs, ['job_id', 'alert_type', 'alert_msg'])
         self.assertEqual(obs['job_id'], job.id)
         self.assertEqual(obs['alert_type'], 'warning')
         self.assertIn('The following columns have been added to the existing '
@@ -243,7 +243,7 @@ class TestPrivatePlugin(BaseTestPrivatePlugin):
         obs = r_client.get("prep_template_1")
         self.assertIsNotNone(obs)
         obs = loads(obs)
-        self.assertItemsEqual(obs, ['job_id', 'alert_type', 'alert_msg'])
+        self.assertCountEqual(obs, ['job_id', 'alert_type', 'alert_msg'])
         self.assertEqual(obs['job_id'], job.id)
         self.assertEqual(obs['alert_type'], 'warning')
         self.assertIn('The following columns have been added to the existing '

--- a/scripts/all-qiita-cron-job
+++ b/scripts/all-qiita-cron-job
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-qiita-cron-job empty_trash_upload_folder
-qiita-cron-job generate_biom_and_metadata_release
-qiita-cron-job purge_filepaths
-qiita-cron-job purge_files_from_filesystem
-qiita-cron-job update_redis_stats
-qiita-cron-job generate_plugin_releases
+qiita-cron-job empty-trash-upload-folder
+qiita-cron-job generate-biom-and-metadata-release
+qiita-cron-job purge-filepaths
+qiita-cron-job purge-files-from-filesystem
+qiita-cron-job update-redis-stats
+qiita-cron-job generate-plugin-releases

--- a/scripts/qiita
+++ b/scripts/qiita
@@ -417,7 +417,7 @@ def start(port, master):
                 try:
                     s.register_commands()
                 except ValueError as e:
-                    print(e.message)
+                    print(e)
                 # sleep is required as we don't want to saturate workers with
                 # lots of requests
                 sleep(1)
@@ -431,7 +431,7 @@ def start(port, master):
                 try:
                     s.register_commands()
                 except ValueError as e:
-                    print(e.message)
+                    print(e)
                 # sleep is required as we don't want to saturate workers with
                 # lots of requests
                 sleep(1)


### PR DESCRIPTION
In this PR:
- re-add line so matplotlib works fine
- self.assertItemsEqual -> self.assertCountEqual
- fix all qiita_core
- fix all processing_job

Note that the biggest differences in networkx versions are:
- before when calling edges/nodes/etc it used to return a dict and now returns a tuple
- all the lists are of the type vs. just a list, for example: nodes, returns NodeView(()) vs []