### PR TITLE
fix test_artifact and test_analysis

### DIFF
--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -137,7 +137,7 @@ class ConfigurationManager(object):
         # Parse the configuration file
         config = ConfigParser()
         with open(conf_fp, newline=None) as conf_file:
-            config.readfp(conf_file)
+            config.read_file(conf_file)
 
         _required_sections = {'main', 'redis', 'postgres', 'smtp', 'ebi',
                               'portal'}

--- a/qiita_db/analysis.py
+++ b/qiita_db/analysis.py
@@ -1044,7 +1044,7 @@ class Analysis(qdb.base.QiitaObject):
                     cmd = "%s %s %s" % (
                         pp_cmd['script_env'], pp_cmd['script_path'], params)
                     p_out, p_err, rv = qdb.processing_job._system_call(cmd)
-                    p_out = p_out.decode("utf-8").rstrip()
+                    p_out = p_out.rstrip()
                     # based on the set of commands ran, we could get a
                     # rv !=0 but still have a successful return from the
                     # command, thus checking both rv and p_out. Note that

--- a/qiita_db/artifact.py
+++ b/qiita_db/artifact.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from os import remove
 from os.path import isfile, relpath
 from shutil import rmtree
-from functools import partial
 from collections import namedtuple
 from qiita_db.util import create_nested_path
 
@@ -1028,13 +1027,17 @@ class Artifact(qdb.base.QiitaObject):
                 # And from the filesystem only after the transaction is
                 # successfully completed (after commit)
 
-                def path_cleaner(fp):
-                    if isfile(fp):
-                        remove(fp)
-                    else:
-                        rmtree(fp)
+                def path_cleaner(fps):
+                    for fp in fps:
+                        if isfile(fp):
+                            remove(fp)
+                        else:
+                            rmtree(fp)
+
+                # qdb.sql_connection.TRN.add_post_commit_func(
+                #     partial(map, path_cleaner, to_delete_fps))
                 qdb.sql_connection.TRN.add_post_commit_func(
-                    partial(map, path_cleaner, to_delete_fps))
+                    path_cleaner, to_delete_fps)
 
             # Add the new HTML summary
             filepaths = [(html_fp, 'html_summary')]

--- a/qiita_db/handlers/tests/test_artifact.py
+++ b/qiita_db/handlers/tests/test_artifact.py
@@ -226,7 +226,7 @@ class ArtifactAPItestHandlerTests(OauthTestingBase):
         obs = self.post('/apitest/artifact/', headers=self.header, data=data)
         self.assertEqual(obs.code, 200)
         obs = loads(obs.body)
-        self.assertEqual(obs.keys(), ['artifact'])
+        self.assertCountEqual(obs.keys(), ['artifact'])
 
         a = qdb.artifact.Artifact(obs['artifact'])
         self._clean_up_files.extend([fp for _, fp, _ in a.filepaths])
@@ -247,7 +247,7 @@ class ArtifactAPItestHandlerTests(OauthTestingBase):
         obs = self.post('/apitest/artifact/', headers=self.header, data=data)
         self.assertEqual(obs.code, 200)
         obs = loads(obs.body)
-        self.assertEqual(obs.keys(), ['artifact'])
+        self.assertCountEqual(obs.keys(), ['artifact'])
 
         a = qdb.artifact.Artifact(obs['artifact'])
         self._clean_up_files.extend([afp for _, afp, _ in a.filepaths])
@@ -261,7 +261,7 @@ class ArtifactAPItestHandlerTests(OauthTestingBase):
         obs = self.post('/apitest/artifact/', headers=self.header, data=data)
         self.assertEqual(obs.code, 500)
         self.assertIn("Prep template 1 already has an artifact associated",
-                      obs.body)
+                      obs.body.decode('ascii'))
 
 
 class ArtifactTypeHandlerTests(OauthTestingBase):

--- a/qiita_db/handlers/tests/test_prep_template.py
+++ b/qiita_db/handlers/tests/test_prep_template.py
@@ -75,7 +75,7 @@ class PrepTemplateDataHandlerTests(OauthTestingBase):
         self.assertEqual(obs.code, 200)
 
         obs = loads(obs.body)
-        self.assertEqual(obs.keys(), ['data'])
+        self.assertCountEqual(obs.keys(), ['data'])
 
         obs = obs['data']
         exp = ['1.SKB2.640194', '1.SKM4.640180', '1.SKB3.640195',
@@ -87,7 +87,7 @@ class PrepTemplateDataHandlerTests(OauthTestingBase):
                '1.SKD3.640198', '1.SKB5.640181', '1.SKB4.640189',
                '1.SKB9.640200', '1.SKM9.640192', '1.SKD8.640184',
                '1.SKM5.640177', '1.SKM7.640188', '1.SKD7.640191']
-        self.assertCountEqual(obs.keys(), exp)
+        self.assertCountEqual(list(obs.keys()), exp)
 
         obs = obs['1.SKB1.640202']
         exp = {
@@ -149,7 +149,7 @@ class PrepTemplateAPItestHandlerTests(OauthTestingBase):
                         data=data)
         self.assertEqual(obs.code, 200)
         obs = loads(obs.body)
-        self.assertEqual(obs.keys(), ['prep'])
+        self.assertCountEqual(obs.keys(), ['prep'])
 
         pt = qdb.metadata_template.prep_template.PrepTemplate(obs['prep'])
         self.assertCountEqual(pt.keys(), ['1.SKB8.640193', '1.SKD8.640184'])

--- a/qiita_db/handlers/tests/test_processing_job.py
+++ b/qiita_db/handlers/tests/test_processing_job.py
@@ -280,7 +280,7 @@ class ProcessingJobAPItestHandlerTests(OauthTestingBase):
         self.assertEqual(obs.code, 200)
 
         obs = loads(obs.body)
-        self.assertEqual(list(obs.keys()), ['job'])
+        self.assertCountEqual(obs.keys(), ['job'])
         self.assertIsNotNone(obs['job'])
 
     def test_post_processing_job_status(self):
@@ -302,7 +302,7 @@ class ProcessingJobAPItestHandlerTests(OauthTestingBase):
         self.assertEqual(obs.code, 200)
 
         obs = loads(obs.body)
-        self.assertEqual(list(obs.keys()), ['job'])
+        self.assertCountEqual(obs.keys(), ['job'])
         job_id = obs['job']
         self.assertTrue(qdb.processing_job.ProcessingJob.exists(job_id))
         self.assertEqual(qdb.processing_job.ProcessingJob(job_id).status,

--- a/qiita_db/handlers/tests/test_sample_information.py
+++ b/qiita_db/handlers/tests/test_sample_information.py
@@ -28,7 +28,7 @@ class SampleInfoDBHandlerTests(OauthTestingBase):
         self.assertEqual(obs.code, 200)
 
         obs = loads(obs.body)
-        self.assertEqual(obs.keys(), ['data'])
+        self.assertCountEqual(obs.keys(), ['data'])
 
         # for simplicity we will only test that the keys are the same
         # and that one of the key's info is correct
@@ -42,7 +42,7 @@ class SampleInfoDBHandlerTests(OauthTestingBase):
                '1.SKD3.640198', '1.SKB5.640181', '1.SKB4.640189',
                '1.SKB9.640200', '1.SKM9.640192', '1.SKD8.640184',
                '1.SKM5.640177', '1.SKM7.640188', '1.SKD7.640191']
-        self.assertCountEqual(obs.keys(), exp)
+        self.assertCountEqual(list(obs.keys()), exp)
 
         obs = obs['1.SKB1.640202']
         exp = {'qiita_study_id': '1', 'physical_specimen_location': 'ANL',

--- a/qiita_db/handlers/tests/test_user.py
+++ b/qiita_db/handlers/tests/test_user.py
@@ -28,7 +28,7 @@ class UserInfoDBHandlerTests(OauthTestingBase):
         self.assertEqual(obs.code, 200)
 
         obs = loads(obs.body)
-        self.assertEqual(obs.keys(), ['data'])
+        self.assertCountEqual(obs.keys(), ['data'])
 
         # for simplicity we will only test that the keys are the same
         # and that one of the key's info is correct

--- a/qiita_db/meta_util.py
+++ b/qiita_db/meta_util.py
@@ -521,7 +521,7 @@ def generate_plugin_releases():
             ppc_cmd = "%s %s %s" % (
                 ppc['script_env'], ppc['script_path'], params)
             p_out, p_err, rv = qdb.processing_job._system_call(ppc_cmd)
-            p_out = p_out.decode("utf-8").rstrip()
+            p_out = p_out.rstrip()
             if rv != 0:
                 raise ValueError('Error %d: %s' % (rv, p_out))
             p_out = loads(p_out)

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -739,7 +739,7 @@ class TestPrepTemplate(TestCase):
         obs.sort_index(axis=1, inplace=True)
         exp.sort_index(axis=0, inplace=True)
         exp.sort_index(axis=1, inplace=True)
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_clean_validate_template_no_forbidden_words1(self):
         PT = qdb.metadata_template.prep_template.PrepTemplate
@@ -972,10 +972,10 @@ class TestPrepTemplate(TestCase):
         exp = pd.read_csv(
             exp_fp, sep='\t', infer_datetime_format=False,
             parse_dates=False, index_col=False, comment='\t')
-        obs = obs.reindex_axis(sorted(obs.columns), axis=1)
-        exp = exp.reindex_axis(sorted(exp.columns), axis=1)
+        obs = obs.reindex(sorted(obs.columns), axis=1)
+        exp = exp.reindex(sorted(exp.columns), axis=1)
 
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_create_data_type_id(self):
         """Creates a new PrepTemplate passing the data_type_id"""
@@ -1510,7 +1510,7 @@ class TestPrepTemplate(TestCase):
         obs.sort_index(axis=1, inplace=True)
         exp.sort_index(axis=0, inplace=True)
         exp.sort_index(axis=1, inplace=True)
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_delete_column(self):
         QE = qdb.exceptions

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -765,7 +765,7 @@ class TestSampleTemplate(TestCase):
         obs.sort_index(axis=1, inplace=True)
         exp.sort_index(axis=0, inplace=True)
         exp.sort_index(axis=1, inplace=True)
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_clean_validate_template(self):
         ST = qdb.metadata_template.sample_template.SampleTemplate
@@ -816,7 +816,7 @@ class TestSampleTemplate(TestCase):
         obs.sort_index(axis=1, inplace=True)
         exp.sort_index(axis=0, inplace=True)
         exp.sort_index(axis=1, inplace=True)
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_clean_validate_template_no_pgsql_reserved_words(self):
         ST = qdb.metadata_template.sample_template.SampleTemplate
@@ -2108,7 +2108,7 @@ class TestSampleTemplate(TestCase):
         obs.sort_index(axis=1, inplace=True)
         exp.sort_index(axis=0, inplace=True)
         exp.sort_index(axis=1, inplace=True)
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_validate_template_warning_missing_restrictions(self):
         del self.metadata['collection_timestamp']
@@ -2136,7 +2136,7 @@ class TestSampleTemplate(TestCase):
             # it should be QiitaDBWarning
             self.assertEqual(warn.category, qdb.exceptions.QiitaDBWarning)
             # it should contain this text
-            message = str(warn)
+            message = str(warn.message)
             exp_error = ('Sample "%s.Sample2", column "latitude", wrong value '
                          '"wrong latitude"' % self.new_study.id)
             self.assertIn(exp_error, message)
@@ -2186,7 +2186,7 @@ class TestSampleTemplate(TestCase):
             # warnings is a list of 1 element
             self.assertEqual(len(warn), 1)
             # the order might change so testing by elements
-            self.assertCountEqual(str(warn[0]).split('\n'),
+            self.assertCountEqual(str(warn[0].message).split('\n'),
                                   exp_message.split('\n'))
 
     def test_validate_errors_timestampB_year4digits(self):
@@ -2219,7 +2219,7 @@ class TestSampleTemplate(TestCase):
                 'of these fields.'.format(st.id))
             # warnings is a list of 1 element
             self.assertEqual(len(warn), 1)
-            self.assertEqual(str(warn[0]), exp_message)
+            self.assertEqual(str(warn[0].message), exp_message)
 
     def test_delete_column(self):
         st = qdb.metadata_template.sample_template.SampleTemplate.create(

--- a/qiita_db/metadata_template/test/test_util.py
+++ b/qiita_db/metadata_template/test/test_util.py
@@ -59,7 +59,7 @@ class TestUtil(TestCase):
             qdb.metadata_template.util.prefix_sample_names_with_id(
                 metadata_map, 1)
             self.assertEqual(len(warn), 1)
-            self.assertEqual(str(warn[0]), 'Some of the samples were '
+            self.assertEqual(str(warn[0].message), 'Some of the samples were '
                              'already prefixed with the study id.')
         metadata_map.sort_index(inplace=True)
         assert_frame_equal(metadata_map, exp_df)
@@ -69,7 +69,7 @@ class TestUtil(TestCase):
             StringIO(EXP_SAMPLE_TEMPLATE))
         exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_DICT_FORM, dtype=str)
         exp.index.name = 'sample_name'
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_load_template_to_dataframe_xlsx(self):
         mfp = join(dirname(abspath(getfile(currentframe()))), 'support_files')
@@ -79,7 +79,7 @@ class TestUtil(TestCase):
         obs = qdb.metadata_template.util.load_template_to_dataframe(fp)
         exp = pd.DataFrame.from_dict(EXP_QIIMP, dtype=str)
         exp.index.name = 'sample_name'
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
         # test loading an empty qiimp file
         fp = join(mfp, 'empty_qiimp_wb.xlsx')
@@ -92,7 +92,7 @@ class TestUtil(TestCase):
         obs = qdb.metadata_template.util.load_template_to_dataframe(fp)
         exp = pd.DataFrame.from_dict(EXP_NOT_QIIMP, dtype=str)
         exp.index.name = 'sample_name'
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_load_template_to_dataframe_qiime_map(self):
         obs = qdb.metadata_template.util.load_template_to_dataframe(
@@ -103,7 +103,7 @@ class TestUtil(TestCase):
         obs.sort_index(axis=1, inplace=True)
         exp.sort_index(axis=0, inplace=True)
         exp.sort_index(axis=1, inplace=True)
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_load_template_to_dataframe_duplicate_cols(self):
         LTTD = qdb.metadata_template.util.load_template_to_dataframe
@@ -132,7 +132,7 @@ class TestUtil(TestCase):
             StringIO(EXP_SAMPLE_TEMPLATE_SPACES))
         exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_DICT_FORM, dtype=str)
         exp.index.name = 'sample_name'
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_load_template_to_dataframe_empty_columns(self):
         obs = npt.assert_warns(
@@ -141,14 +141,14 @@ class TestUtil(TestCase):
             StringIO(EXP_ST_SPACES_EMPTY_COLUMN))
         exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_DICT_FORM, dtype=str)
         exp.index.name = 'sample_name'
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_load_template_to_dataframe_empty_rows(self):
         obs = qdb.metadata_template.util.load_template_to_dataframe(
             StringIO(EXP_SAMPLE_TEMPLATE_SPACES_EMPTY_ROW))
         exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_DICT_FORM, dtype=str)
         exp.index.name = 'sample_name'
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_load_template_to_dataframe_no_sample_name_cast(self):
         obs = qdb.metadata_template.util.load_template_to_dataframe(
@@ -158,20 +158,20 @@ class TestUtil(TestCase):
         exp.index.name = 'sample_name'
         obs.sort_index(inplace=True)
         exp.sort_index(inplace=True)
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_load_template_to_dataframe_empty_sample_names(self):
         obs = qdb.metadata_template.util.load_template_to_dataframe(
             StringIO(SAMPLE_TEMPLATE_NO_SAMPLE_NAMES))
         exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_DICT_FORM, dtype=str)
         exp.index.name = 'sample_name'
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
         obs = qdb.metadata_template.util.load_template_to_dataframe(
             StringIO(SAMPLE_TEMPLATE_NO_SAMPLE_NAMES_SOME_SPACES))
         exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_DICT_FORM, dtype=str)
         exp.index.name = 'sample_name'
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_load_template_to_dataframe_empty_column(self):
         obs = npt.assert_warns(
@@ -180,14 +180,14 @@ class TestUtil(TestCase):
             StringIO(SAMPLE_TEMPLATE_EMPTY_COLUMN))
         exp = pd.DataFrame.from_dict(ST_EMPTY_COLUMN_DICT_FORM, dtype=str)
         exp.index.name = 'sample_name'
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_load_template_to_dataframe_column_with_nas(self):
         obs = qdb.metadata_template.util.load_template_to_dataframe(
             StringIO(SAMPLE_TEMPLATE_COLUMN_WITH_NAS))
         exp = pd.DataFrame.from_dict(ST_COLUMN_WITH_NAS_DICT_FORM, dtype=str)
         exp.index.name = 'sample_name'
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_load_template_to_dataframe_exception(self):
         with self.assertRaises(qdb.exceptions.QiitaDBColumnError):
@@ -199,7 +199,7 @@ class TestUtil(TestCase):
             StringIO(EXP_SAMPLE_TEMPLATE_WHITESPACE))
         exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_DICT_FORM, dtype=str)
         exp.index.name = 'sample_name'
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_load_template_to_dataframe_lowercase(self):
         obs = qdb.metadata_template.util.load_template_to_dataframe(
@@ -207,13 +207,7 @@ class TestUtil(TestCase):
         exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_DICT_FORM, dtype=str)
         exp.index.name = 'sample_name'
         exp.rename(columns={"str_column": "str_CoLumn"}, inplace=True)
-        assert_frame_equal(obs, exp)
-
-    def test_load_template_to_dataframe_non_utf8_error(self):
-        bad = EXP_SAMPLE_TEMPLATE.replace('Test Sample 2', 'Test Sample\x962')
-        with self.assertRaises(ValueError):
-            qdb.metadata_template.util.load_template_to_dataframe(
-                StringIO(bad))
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_load_template_to_dataframe_non_utf8(self):
         replace = EXP_SAMPLE_TEMPLATE.replace(
@@ -233,7 +227,7 @@ class TestUtil(TestCase):
         exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_LAT_ALL_INT_DICT,
                                      dtype=str)
         exp.index.name = 'sample_name'
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
         obs = qdb.metadata_template.util.load_template_to_dataframe(
             StringIO(EXP_SAMPLE_TEMPLATE_LAT_MIXED_FLOAT_INT))
@@ -241,14 +235,14 @@ class TestUtil(TestCase):
         exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_MIXED_FLOAT_INT_DICT,
                                      dtype=str)
         exp.index.name = 'sample_name'
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_load_template_to_dataframe_with_nulls(self):
         obs = qdb.metadata_template.util.load_template_to_dataframe(
             StringIO(EXP_SAMPLE_TEMPLATE_NULLS))
         exp = pd.DataFrame.from_dict(SAMPLE_TEMPLATE_NULLS_DICT, dtype=str)
         exp.index.name = 'sample_name'
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_get_invalid_sample_names(self):
         all_valid = ['2.sample.1', 'foo.bar.baz', 'roses', 'are', 'red',

--- a/qiita_db/metadata_template/util.py
+++ b/qiita_db/metadata_template/util.py
@@ -7,9 +7,7 @@
 # -----------------------------------------------------------------------------
 
 from __future__ import division
-from future.utils import viewitems
 from six import StringIO
-from collections import defaultdict
 
 import pandas as pd
 import numpy as np
@@ -95,25 +93,7 @@ def load_template_to_dataframe(fn, index='sample_name'):
     # Load in file lines
     holdfile = None
     with qdb.util.open_file(fn, newline=None) as f:
-        errors = defaultdict(list)
         holdfile = f.readlines()
-        # here we are checking for non UTF-8 chars
-        for row, line in enumerate(holdfile):
-            for col, block in enumerate(line.split('\t')):
-                try:
-                    tblock = block.encode('utf-8')
-                except UnicodeDecodeError:
-                    tblock = str(block, errors='replace')
-                    tblock = tblock.replace(u'\ufffd', '&#128062;')
-                    errors[tblock].append('(%d, %d)' % (row, col))
-        if bool(errors):
-            raise ValueError(
-                "There are invalid (non UTF-8) characters in your information "
-                "file. The offending fields and their location (row, column) "
-                "are listed below, invalid characters are represented using "
-                "&#128062;: %s" % '; '.join(
-                    ['"%s" = %s' % (k, ', '.join(v))
-                     for k, v in viewitems(errors)]))
 
     if not holdfile:
         raise ValueError('Empty file passed!')
@@ -351,7 +331,7 @@ def _parse_mapping_file(lines, strip_quotes=True, suppress_stripping=False):
                 comments.append(line)
         else:
             # Will add empty string to empty fields
-            tmp_line = map(strip_f, line.split('\t'))
+            tmp_line = list(map(strip_f, line.split('\t')))
             if len(tmp_line) < len(header):
                 tmp_line.extend([''] * (len(header) - len(tmp_line)))
             mapping_data.append(tmp_line)

--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -784,7 +784,7 @@ class Software(qdb.base.QiitaObject):
         """
         config = ConfigParser()
         with open(fp, newline=None) as conf_file:
-            config.readfp(conf_file)
+            config.read_file(conf_file)
 
         name = config.get('main', 'NAME')
         version = config.get('main', 'VERSION')

--- a/qiita_db/test/test_analysis.py
+++ b/qiita_db/test/test_analysis.py
@@ -329,7 +329,7 @@ class TestAnalysis(TestCase):
                    '1.SKM4.640180', '1.SKB8.640193']}
         analysis.add_samples(exp)
         obs = analysis.samples
-        self.assertCountEqual(obs.keys(), exp.keys())
+        self.assertCountEqual(list(obs.keys()), exp.keys())
         for k in obs:
             self.assertCountEqual(obs[k], exp[k])
 
@@ -342,7 +342,7 @@ class TestAnalysis(TestCase):
                6: ['1.SKD8.640184', '1.SKB7.640196', '1.SKM9.640192',
                    '1.SKM4.640180', '1.SKB8.640193']}
         obs = analysis.samples
-        self.assertCountEqual(obs.keys(), exp.keys())
+        self.assertCountEqual(list(obs.keys()), exp.keys())
         for k in obs:
             self.assertCountEqual(obs[k], exp[k])
 
@@ -392,10 +392,10 @@ class TestAnalysis(TestCase):
         obs.sort_index(inplace=True)
         exp.sort_index(inplace=True)
         # then sorting columns
-        obs = obs.reindex_axis(sorted(obs.columns), axis=1)
-        exp = exp.reindex_axis(sorted(exp.columns), axis=1)
+        obs = obs.reindex(sorted(obs.columns), axis=1)
+        exp = exp.reindex(sorted(exp.columns), axis=1)
 
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_build_mapping_file_duplicated_samples_no_merge(self):
         analysis = self._create_analyses_with_samples()
@@ -416,10 +416,10 @@ class TestAnalysis(TestCase):
         obs.sort_index(inplace=True)
         exp.sort_index(inplace=True)
         # then sorting columns
-        obs = obs.reindex_axis(sorted(obs.columns), axis=1)
-        exp = exp.reindex_axis(sorted(exp.columns), axis=1)
+        obs = obs.reindex(sorted(obs.columns), axis=1)
+        exp = exp.reindex(sorted(exp.columns), axis=1)
 
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_build_mapping_file_duplicated_samples_merge(self):
         analysis = self._create_analyses_with_samples()
@@ -439,10 +439,10 @@ class TestAnalysis(TestCase):
         obs.sort_index(inplace=True)
         exp.sort_index(inplace=True)
         # then sorting columns
-        obs = obs.reindex_axis(sorted(obs.columns), axis=1)
-        exp = exp.reindex_axis(sorted(exp.columns), axis=1)
+        obs = obs.reindex(sorted(obs.columns), axis=1)
+        exp = exp.reindex(sorted(exp.columns), axis=1)
 
-        assert_frame_equal(obs, exp)
+        assert_frame_equal(obs, exp, check_like=True)
 
     def test_build_biom_tables(self):
         analysis = self._create_analyses_with_samples()
@@ -485,7 +485,7 @@ class TestAnalysis(TestCase):
              'SplitlibrariesFASTQ.biom' % analysis_id),
             ('18S', '%s_analysis_18S_PickclosedreferenceOTUsreference1'
              'Trimlenght150.biom' % analysis_id)]
-        self.assertEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
         exp = {'1.SKB8.640193', '1.SKD8.640184', '1.SKB7.640196'}
         for dt, fp, _ in obs_bioms:

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -244,8 +244,8 @@ class ArtifactTestsReadOnly(TestCase):
         tester = qdb.artifact.Artifact(1)
         obs = tester._create_lineage_graph_from_edge_list([])
         self.assertTrue(isinstance(obs, nx.DiGraph))
-        self.assertEqual(obs.nodes(), [tester])
-        self.assertEqual(list(obs.edges()), [])
+        self.assertCountEqual(obs.nodes(), [tester])
+        self.assertCountEqual(obs.edges(), [])
 
     def test_create_lineage_graph_from_edge_list(self):
         tester = qdb.artifact.Artifact(1)
@@ -265,9 +265,9 @@ class ArtifactTestsReadOnly(TestCase):
         obs = qdb.artifact.Artifact(1).ancestors
         self.assertTrue(isinstance(obs, nx.DiGraph))
         obs_nodes = obs.nodes()
-        self.assertEqual(obs_nodes, [qdb.artifact.Artifact(1)])
+        self.assertCountEqual(obs_nodes, [qdb.artifact.Artifact(1)])
         obs_edges = obs.edges()
-        self.assertEqual(obs_edges, [])
+        self.assertCountEqual(obs_edges, [])
 
         obs = qdb.artifact.Artifact(2).ancestors
         self.assertTrue(isinstance(obs, nx.DiGraph))
@@ -893,7 +893,7 @@ class ArtifactTests(TestCase):
         before = datetime.now()
         cmd = qdb.software.Command(3)
         exp_params = qdb.software.Parameters.from_default_params(
-            cmd.default_parameter_sets.next(), {'input_data': 1})
+            cmd.default_parameter_sets.__next__(), {'input_data': 1})
         obs = qdb.artifact.Artifact.create(
             self.filepaths_biom, "BIOM", parents=[qdb.artifact.Artifact(2)],
             processing_parameters=exp_params)
@@ -1270,7 +1270,7 @@ class ArtifactTests(TestCase):
 
         obs = self.prep_template.artifact.descendants_with_jobs.nodes()
         exp = [('artifact', artifact)]
-        self.assertEqual(obs, exp)
+        self.assertCountEqual(obs, exp)
 
 
 if __name__ == '__main__':

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -212,7 +212,7 @@ class CommandTests(TestCase):
         exp_params = {
             'input_data': ('artifact', ['FASTQ', 'per_sample_FASTQ'])}
         obs = qdb.software.Command(1).required_parameters
-        self.assertCountEqual(obs.keys(), exp_params.keys())
+        self.assertCountEqual(list(obs.keys()), exp_params.keys())
         self.assertEqual(obs['input_data'][0],  exp_params['input_data'][0])
         self.assertCountEqual(obs['input_data'][1],
                               exp_params['input_data'][1])
@@ -220,7 +220,7 @@ class CommandTests(TestCase):
         exp_params = {
             'input_data': ('artifact', ['SFF', 'FASTA', 'FASTA_Sanger'])}
         obs = qdb.software.Command(2).required_parameters
-        self.assertCountEqual(obs.keys(), exp_params.keys())
+        self.assertCountEqual(list(obs.keys()), exp_params.keys())
         self.assertEqual(obs['input_data'][0],  exp_params['input_data'][0])
         self.assertCountEqual(obs['input_data'][1],
                               exp_params['input_data'][1])

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -1709,7 +1709,7 @@ def get_artifacts_information(artifact_ids, only_biom=True):
 
                     if algorithm not in algorithm_az:
                         algorithm_az[algorithm] = hashlib.md5(
-                            algorithm).hexdigest()
+                            algorithm.encode('utf-8')).hexdigest()
 
                 if prep_template_id not in ts:
                     qdb.sql_connection.TRN.add(sql_ts, [prep_template_id])

--- a/qiita_pet/handlers/api_proxy/tests/test_artifact.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_artifact.py
@@ -257,7 +257,7 @@ class TestArtifactAPI(TestCase):
              'deprecated': None, 'platform': 'Illumina', 'algorithm_az': '',
              'prep_samples': 27}]
         exp = {'status': 'success', 'msg': '', 'data': data}
-        self.assertCountEqual(obs.keys(), exp.keys())
+        self.assertCountEqual(list(obs.keys()), exp.keys())
         self.assertEqual(obs['status'], exp['status'])
         self.assertEqual(obs['msg'], exp['msg'])
         self.assertCountEqual(obs['data'], exp['data'])

--- a/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
@@ -115,7 +115,8 @@ class TestPrepAPIReadOnly(TestCase):
 
     def test_prep_template_get_req(self):
         obs = prep_template_get_req(1, 'test@foo.bar')
-        self.assertCountEqual(obs.keys(), ['status', 'message', 'template'])
+        self.assertCountEqual(
+            list(obs.keys()), ['status', 'message', 'template'])
         self.assertEqual(obs['status'], 'success')
         self.assertEqual(obs['message'], '')
         self.assertEqual(obs['template'].keys(), [

--- a/qiita_pet/handlers/api_proxy/tests/test_sample_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_sample_template.py
@@ -76,7 +76,7 @@ class TestSampleAPI(TestCase):
 
     def test_sample_template_get_req(self):
         obs = sample_template_get_req(1, 'test@foo.bar')
-        self.assertEqual(obs.keys(), ['status', 'message', 'template'])
+        self.assertCountEqual(obs.keys(), ['status', 'message', 'template'])
         self.assertEqual(obs['status'], 'success')
         self.assertEqual(obs['message'], '')
         self.assertEqual(len(obs['template']), 27)

--- a/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
+++ b/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
@@ -284,7 +284,7 @@ class TestBaseHandlersUtils(TestCase):
             artifact_post_req(User('demo@microbio.me'), 1)
 
         obs = artifact_post_req(User('test@foo.bar'), 2)
-        self.assertEqual(list(obs.keys()), ['job'])
+        self.assertCountEqual(obs.keys(), ['job'])
         # Wait until the job is completed
         wait_for_prep_information_job(1)
         # Check that the delete function has been actually called

--- a/qiita_pet/handlers/base_handlers.py
+++ b/qiita_pet/handlers/base_handlers.py
@@ -16,7 +16,7 @@ from qiita_pet.util import convert_text_html
 class BaseHandler(RequestHandler):
     def get_current_user(self):
         '''Overrides default method of returning user curently connected'''
-        username = self.get_secure_cookie("user")
+        username = self.get_secure_cookie(b"user")
         if username is not None:
             # strip off quotes added by get_secure_cookie
             username = username.strip("\"' ")

--- a/qiita_pet/handlers/study_handlers/tests/test_artifact.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_artifact.py
@@ -182,7 +182,7 @@ class ArtifactGetInfoTest(TestHandlerBase):
              'parameters': {}, 'target_gene': '16S rRNA', 'name': 'BIOM'}]
         exp = {'status': 'success', 'msg': '', 'data': data}
         obs = loads(response.body)
-        self.assertCountEqual(obs.keys(), exp.keys())
+        self.assertCountEqual(list(obs.keys()), exp.keys())
         self.assertEqual(obs['status'], exp['status'])
         self.assertEqual(obs['msg'], exp['msg'])
         self.assertCountEqual(obs['data'], exp['data'])

--- a/qiita_pet/handlers/study_handlers/tests/test_sample_template.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_sample_template.py
@@ -128,7 +128,7 @@ class TestHelpers(TestHandlerBase):
         # Test success
         obs = sample_template_handler_post_request(
             1, user, 'uploaded_file.txt')
-        self.assertEqual(list(obs.keys()), ['job'])
+        self.assertCountEqual(obs.keys(), ['job'])
         job_info = r_client.get('sample_template_1')
         self.assertIsNotNone(job_info)
 
@@ -187,7 +187,7 @@ class TestHelpers(TestHandlerBase):
         obs = sample_template_handler_patch_request(
             user, "remove", "/%s/columns/col2/"
                             % new_study.id)
-        self.assertEqual(list(obs.keys()), ['job'])
+        self.assertCountEqual(obs.keys(), ['job'])
         job_info = r_client.get('sample_template_%s' % new_study.id)
         self.assertIsNotNone(job_info)
 
@@ -218,7 +218,7 @@ class TestHelpers(TestHandlerBase):
         # Test success
         obs = sample_template_handler_patch_request(
             user, "replace", "/1/data", req_value='uploaded_file.txt')
-        self.assertEqual(list(obs.keys()), ['job'])
+        self.assertCountEqual(obs.keys(), ['job'])
         job_info = r_client.get('sample_template_1')
         self.assertIsNotNone(job_info)
 
@@ -246,7 +246,7 @@ class TestHelpers(TestHandlerBase):
         # Test success
         user = User('test@foo.bar')
         obs = sample_template_handler_delete_request(1, user)
-        self.assertEqual(list(obs.keys()), ['job'])
+        self.assertCountEqual(obs.keys(), ['job'])
         job_info = r_client.get('sample_template_1')
         self.assertIsNotNone(job_info)
 
@@ -445,7 +445,7 @@ class TestSampleTemplateHandler(TestHandlerBase):
         self.assertEqual(response.code, 200)
         self.assertIsNotNone(response.body)
         obs = loads(response.body)
-        self.assertEqual(list(obs.keys()), ['job'])
+        self.assertCountEqual(obs.keys(), ['job'])
         # Wait until the job is done
         wait_for_processing_job(obs['job'])
 
@@ -457,7 +457,7 @@ class TestSampleTemplateHandler(TestHandlerBase):
         self.assertEqual(response.code, 200)
         self.assertIsNotNone(response.body)
         obs = loads(response.body)
-        self.assertEqual(list(obs.keys()), ['job'])
+        self.assertCountEqual(obs.keys(), ['job'])
         # Wait until the job is done
         wait_for_processing_job(obs['job'])
 
@@ -467,7 +467,7 @@ class TestSampleTemplateHandler(TestHandlerBase):
         self.assertEqual(response.code, 200)
         self.assertIsNotNone(response.body)
         obs = loads(response.body)
-        self.assertEqual(list(obs.keys()), ['job'])
+        self.assertCountEqual(obs.keys(), ['job'])
         # Wait until the job is done
         wait_for_processing_job(obs['job'])
 

--- a/qiita_pet/portal.py
+++ b/qiita_pet/portal.py
@@ -52,7 +52,7 @@ class PortalStyleManager(object):
         # Parse the configuration file
         config = ConfigParser()
         with open(self.conf_fp, newline=None) as conf_file:
-            config.readfp(conf_file)
+            config.read_file(conf_file)
 
         _required_sections = {'sitebase', 'index', 'study_list'}
         if not _required_sections.issubset(set(config.sections())):

--- a/qiita_pet/test/rest/test_study_preparation.py
+++ b/qiita_pet/test/rest/test_study_preparation.py
@@ -42,7 +42,7 @@ class StudyPrepCreatorTests(RESTHandlerTestCase):
                              headers=self.headers, asjson=True)
         self.assertEqual(response.code, 406)
         obs = json_decode(response.body)
-        self.assertEqual(list(obs.keys()), ['message'])
+        self.assertCountEqual(obs.keys(), ['message'])
         self.assertGreater(len(obs['message']), 0)
 
     def test_post_valid_study(self):
@@ -100,7 +100,7 @@ class StudyPrepArtifactCreatorTests(RESTHandlerTestCase):
         response = self.post(uri, data=body, headers=self.headers, asjson=True)
         self.assertEqual(response.code, 406)
         obs = json_decode(response.body)
-        self.assertEqual(list(obs.keys()), ['message'])
+        self.assertCountEqual(obs.keys(), ['message'])
         self.assertGreater(len(obs['message']), 0)
 
     def test_post_unknown_filepath_type_id(self):
@@ -112,7 +112,7 @@ class StudyPrepArtifactCreatorTests(RESTHandlerTestCase):
         response = self.post(uri, data=body, headers=self.headers, asjson=True)
         self.assertEqual(response.code, 406)
         obs = json_decode(response.body)
-        self.assertEqual(list(obs.keys()), ['message'])
+        self.assertCountEqual(obs.keys(), ['message'])
         self.assertGreater(len(obs['message']), 0)
 
     def test_post_files_notfound(self):
@@ -124,7 +124,7 @@ class StudyPrepArtifactCreatorTests(RESTHandlerTestCase):
         response = self.post(uri, data=body, headers=self.headers, asjson=True)
         self.assertEqual(response.code, 406)
         obs = json_decode(response.body)
-        self.assertEqual(list(obs.keys()), ['message'])
+        self.assertCountEqual(obs.keys(), ['message'])
         self.assertGreater(len(obs['message']), 0)
 
     def test_post_valid(self):

--- a/test_data_studies/commands.sh
+++ b/test_data_studies/commands.sh
@@ -32,7 +32,7 @@ for i in ${studies[@]}; do
 
     # Insert the study
     echo "\tloading study... "
-    output="`qiita db load_study --owner demo@microbio.me --title "$title" --info $conf_fp`"
+    output="`qiita db load-study --owner demo@microbio.me --title "$title" --info $conf_fp`"
     study_id=`echo -e "${output}" | cut -d " " -f 9`
     echo "Ok"
 
@@ -43,14 +43,14 @@ for i in ${studies[@]}; do
 
     # Loading prep template
     echo "\tloading prep template... "
-    output=`qiita db load_prep_template $prep_file --study $study_id --data_type "16S"`
+    output=`qiita db load-prep-template $prep_file --study $study_id --data_type "16S"`
     pt_id=`echo -e "${output}" | cut -d " " -f 10`
     echo "Ok"
 
     # Loading processed data
     echo "\tloading processed data... "
     cp $otu_table ${otu_table}_backup
-    output="`qiita db load_artifact --artifact_type BIOM --fp $otu_table --fp_type biom --prep_template $pt_id`"
+    output="`qiita db load-artifact --artifact_type BIOM --fp $otu_table --fp_type biom --prep_template $pt_id`"
     pd_id=`echo -e "${output}" | cut -d " " -f 2`
     mv ${otu_table}_backup $otu_table
     echo "Ok"


### PR DESCRIPTION
- These changes shows how PY3 has better string encoding than PY2 - allows to remove some checks and parsing that were necessary and now failing 
- For keys/values in dicts, we could use  self.assertCountEqual(dict.keys(), []) as it will check the elements vs. the datatype
- assert_frame_equal needs check_like=True so we don't test for order, which is not important for qiita/qiime2



  