### PR TITLE
fix #1570

### DIFF
--- a/qiita_pet/handlers/api_proxy/artifact.py
+++ b/qiita_pet/handlers/api_proxy/artifact.py
@@ -22,6 +22,7 @@ from qiita_db.util import (
     get_mountpoint, get_visibilities, get_artifacts_information)
 from qiita_db.software import Command, Parameters, Software
 from qiita_db.processing_job import ProcessingJob
+from qiita_db.exceptions import QiitaDBError
 
 PREP_TEMPLATE_KEY_FORMAT = 'prep_template_%s'
 
@@ -215,7 +216,7 @@ def artifact_post_req(user_id, filepaths, artifact_type, name,
         # activated so there is no Validate for the given artifact_type
         try:
             command = Command.get_validator(artifact_type)
-        except Exception as e:
+        except QiitaDBError as e:
             return {'status': 'error', 'message': str(e)}
         job = ProcessingJob.create(
             user,

--- a/qiita_pet/handlers/api_proxy/artifact.py
+++ b/qiita_pet/handlers/api_proxy/artifact.py
@@ -211,9 +211,12 @@ def artifact_post_req(user_id, filepaths, artifact_type, name,
             return {'status': 'error',
                     'message': "Can't create artifact, no files provided."}
 
-        # TODO: It might be good to have an API call that wraps to a lower
-        # level method that creates this job.
-        command = Command.get_validator(artifact_type)
+        # This try/except will catch the case when the plugins are not
+        # activated so there is no Validate for the given artifact_type
+        try:
+            command = Command.get_validator(artifact_type)
+        except Exception as e:
+            return {'status': 'error', 'message': str(e)}
         job = ProcessingJob.create(
             user,
             Parameters.load(command, values_dict={

--- a/qiita_pet/templates/study_ajax/add_artifact.html
+++ b/qiita_pet/templates/study_ajax/add_artifact.html
@@ -76,6 +76,10 @@
             populate_data_type_menu_div();
             populate_main_div('{% raw qiita_config.portal_dir %}/study/description/prep_template/', { prep_id: {{prep_id}}, study_id: {{study_id}} });
           }
+        },
+        error: function(object, status, error_msg) {
+          // Something went wrong, show the message
+          bootstrapAlert("Error: " + error_msg + "  " + status, "danger");
         }
       });
     });

--- a/qiita_pet/templates/study_ajax/artifact_file_selector.html
+++ b/qiita_pet/templates/study_ajax/artifact_file_selector.html
@@ -129,7 +129,7 @@
     $(".fileListParam").each( function(i, cont) {
       var files = [];
       $("#"+cont.id+"-list").children().each( function(j, c_cont) {
-          files.push(c_cont.id);
+        files.push(c_cont.id);
       });
       $(cont).val(files);
     });
@@ -245,7 +245,7 @@
   </div>
   {% for ft, req, files in file_types %}
     <div class="col-md-3" id="{{ft}}-div">
-      <input type="hidden" name="{{ft}}" id="{{ft}}" value="" class="fileListParam">
+      <input type="hidden" name="{{ft}}[]" id="{{ft}}" value="" class="fileListParam">
       <p style="text-align: center;"><i>{{ ft.replace('_', ' ') }}</i></p>
       <ul id="{{ft}}-list" data-file-required="{{req}}" data-file-count="{{num_prefixes}}" data-correct="true" class="connectedSortable checkable">
         {% for fp in files %}


### PR DESCRIPTION
Note that #1570 is a pretty old issue but it still had some validity, here are the 2 cases described there: 
- adding sample/prep info files with spaces: it works fine without any changes
- adding raw files with spaces: we already supported this in python but not in JS cause it was missing `[]`

Additionally, while debugging, found that we needed a couple of changes to better handle errors and properly show them to users so they can report the issue back to us 