### PR TITLE
fix #2221

### DIFF
--- a/qiita_pet/templates/study_ajax/add_prep_template.html
+++ b/qiita_pet/templates/study_ajax/add_prep_template.html
@@ -111,7 +111,6 @@ $(document).ready(function () {
     <label class="col-sm-2 col-form-label">User defined investigation type:</label>
     <div class="col-sm-3">
       <select id="user-ontology" name="user-ontology" value="user-ontology" class="form-control">
-        <option value=""></option>
         {% for o in ontology['User'] %}
           <option value="{{o}}">{{o}}</option>
         {% end %}


### PR DESCRIPTION
After discussing #2221 with @adswafford we realized the only outstanding issue was that Other (only on prep creation) had 2 empty entries; the reason is cause we were forcing adding an empty one, while there was one already in the DB (we were duplicating).