### PR TITLE
fix #2433

### DIFF
--- a/qiita_pet/handlers/study_handlers/sample_template.py
+++ b/qiita_pet/handlers/study_handlers/sample_template.py
@@ -283,9 +283,9 @@ class SampleTemplateHandler(BaseHandler):
         study_id = int(self.get_argument('study_id'))
         filepath = self.get_argument('filepath')
         data_type = self.get_argument('data_type')
-        direct_upload = self.get_argument('data_type', False)
+        direct_upload = self.get_argument('direct_upload', False)
 
-        if direct_upload:
+        if direct_upload and direct_upload == 'true':
             direct_upload = True
             fd, filepath = mkstemp(suffix='.txt')
             close(fd)

--- a/qiita_pet/handlers/study_handlers/sample_template.py
+++ b/qiita_pet/handlers/study_handlers/sample_template.py
@@ -6,8 +6,10 @@
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
 
+from os import close
 from os.path import basename
 from json import loads, dumps
+from tempfile import mkstemp
 
 from tornado.web import authenticated, HTTPError
 
@@ -65,7 +67,7 @@ def sample_template_checks(study_id, user, check_exists=False):
 
 
 def sample_template_handler_post_request(study_id, user, filepath,
-                                         data_type=None):
+                                         data_type=None, direct_upload=False):
     """Creates a new sample template
 
     Parameters
@@ -79,6 +81,9 @@ def sample_template_handler_post_request(study_id, user, filepath,
     data_type: str, optional
         If filepath is a QIIME mapping file, the data type of the prep
         information file
+    direct_upload: boolean, optional
+        If filepath is a direct upload; if False we need to process the
+        filepath as part of the study upload folder
 
     Returns
     -------
@@ -94,10 +99,11 @@ def sample_template_handler_post_request(study_id, user, filepath,
     sample_template_checks(study_id, user)
 
     # Check if the file exists
-    fp_rsp = check_fp(study_id, filepath)
-    if fp_rsp['status'] != 'success':
-        raise HTTPError(404, reason='Filepath not found')
-    filepath = fp_rsp['file']
+    if not direct_upload:
+        fp_rsp = check_fp(study_id, filepath)
+        if fp_rsp['status'] != 'success':
+            raise HTTPError(404, reason='Filepath not found')
+        filepath = fp_rsp['file']
 
     is_mapping_file = looks_like_qiime_mapping_file(filepath)
     if is_mapping_file and not data_type:
@@ -277,9 +283,19 @@ class SampleTemplateHandler(BaseHandler):
         study_id = int(self.get_argument('study_id'))
         filepath = self.get_argument('filepath')
         data_type = self.get_argument('data_type')
+        direct_upload = self.get_argument('data_type', False)
+
+        if direct_upload:
+            direct_upload = True
+            fd, filepath = mkstemp(suffix='.txt')
+            close(fd)
+            with open(filepath, 'w') as f:
+                f.write(
+                    self.request.files['theFile'][0]['body'].decode('ascii'))
 
         self.write(sample_template_handler_post_request(
-            study_id, self.current_user, filepath, data_type=data_type))
+            study_id, self.current_user, filepath, data_type=data_type,
+            direct_upload=direct_upload))
 
     @authenticated
     def patch(self):

--- a/qiita_pet/handlers/study_handlers/tests/test_sample_template.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_sample_template.py
@@ -133,6 +133,16 @@ class TestHelpers(TestHandlerBase):
         # Wait until the job is done
         wait_for_processing_job(loads(job_info)['job_id'])
 
+        # Test direct upload
+        obs = sample_template_handler_post_request(
+            1, user, fp, data_type='16S', direct_upload=True)
+        self.assertCountEqual(obs.keys(), ['job'])
+        job_info = r_client.get('sample_template_1')
+        self.assertIsNotNone(job_info)
+
+        # Wait until the job is done
+        wait_for_processing_job(loads(job_info)['job_id'])
+
     def test_sample_template_handler_patch_request(self):
         user = User('test@foo.bar')
 

--- a/qiita_pet/static/js/sampleTemplateVue.js
+++ b/qiita_pet/static/js/sampleTemplateVue.js
@@ -163,7 +163,7 @@ Vue.component('sample-template-page', {
       var file = $('#st-direct-upload')[0].files[0];
 
       // We can have 2 scenarios: direct file upload or path from upload
-      // folder. The former is sent via PATCH using defauls, the latter
+      // folder. The former is sent via PATCH using defaults, the latter
       // via POST using "processData: false, contentType: false"; taken from:
       // https://stackoverflow.com/a/5976031
       if (file !== undefined) {
@@ -477,7 +477,7 @@ Vue.component('sample-template-page', {
             return false;
           }
           if (this.files[0].size > 2097152) {
-            alert('You can only upload files smaller than 2MB; please use "Upload Files" button on the left.');
+            alert('You can only upload files smaller than 2MB. For larger files please use the "Upload Files" button on the left.'');
             return false;
           }
           vm.updateSampleTemplate()

--- a/qiita_pet/static/js/sampleTemplateVue.js
+++ b/qiita_pet/static/js/sampleTemplateVue.js
@@ -80,7 +80,7 @@ Vue.component('sample-template-page', {
           // Hide the processing div
           $('#st-processsing-div').hide();
           // Enable interaction bits
-          $('#update-btn-div').show();
+          $('#update-st-div').show();
           $('.st-interactive').prop('disabled', false);
           if (jobStatus === 'error') {
             // The job errored - show the error
@@ -116,7 +116,7 @@ Vue.component('sample-template-page', {
       $('#st-processsing-div').show();
       // Disable interaction bits
       $('.st-interactive').prop('disabled', true);
-      $('#update-btn-div').hide();
+      $('#update-st-div').hide();
       // Force the first check to happen now
       vm.checkJob();
       // Set the interval for further checking - this jobs tend to be way faster
@@ -164,7 +164,8 @@ Vue.component('sample-template-page', {
 
       // We can have 2 scenarios: direct file upload or path from upload
       // folder. The former is sent via PATCH using defauls, the latter
-      // via POST using "processData: false, contentType: false"
+      // via POST using "processData: false, contentType: false"; taken from:
+      // https://stackoverflow.com/a/5976031
       if (file !== undefined) {
         var fd = new FormData();
         fd.append('theFile', file);
@@ -467,7 +468,7 @@ Vue.component('sample-template-page', {
         // Add the direct upload field
         $('<label>')
           .addClass('btn btn-default')
-            .append('Direct upload file <small>(< 2M)</small>')
+            .append('Direct upload file <small>(< 2MB)</small>')
             .appendTo($row)
             .append('<input type="file" style="display: none;" id="st-direct-upload">');
         $('#st-direct-upload').on('change', function() {
@@ -476,7 +477,7 @@ Vue.component('sample-template-page', {
             return false;
           }
           if (this.files[0].size > 2097152) {
-            alert('You can only upload files smaller than 2M; please use the regular uploader.');
+            alert('You can only upload files smaller than 2MB; please use "Upload Files" button on the left.');
             return false;
           }
           vm.updateSampleTemplate()


### PR DESCRIPTION
Example: Update sample info file via the upload folder, then use the direct upload. Note that we are testing that the jobs are created and the errors retrieved correctly; thus, the error messages on the top. 
![2433](https://user-images.githubusercontent.com/2014559/56905738-02ebf900-6a5e-11e9-9b3c-d616289f2608.gif)
