### PR TITLE
download_public -> public_download

### DIFF
--- a/qiita_pet/handlers/base_handlers.py
+++ b/qiita_pet/handlers/base_handlers.py
@@ -45,9 +45,6 @@ class BaseHandler(RequestHandler):
                 # Any issue with this check leaves default as not admin
                 pass
 
-        # render error page
-        self.render('error.html', status_code=status_code, is_admin=is_admin)
-
         # log the error
         from traceback import format_exception
         exc_info = kwargs["exc_info"]
@@ -59,7 +56,12 @@ class BaseHandler(RequestHandler):
         request_info = ''.join(["<strong>%s</strong>: %s\n" %
                                (k, req_dict[k]) for k in
                                 req_dict.keys() if k != 'files'])
-        error = exc_info[1]
+        error = str(exc_info[1]).split(':', 1)[1]
+
+        # render error page
+        self.render('error.html', status_code=status_code, is_admin=is_admin,
+                    error=error)
+
         LogEntry.create(
             'Runtime',
             'ERROR:\n%s\nTRACE:\n%s\nHTTP INFO:\n%s\n' %

--- a/qiita_pet/handlers/download.py
+++ b/qiita_pet/handlers/download.py
@@ -346,53 +346,46 @@ class DownloadPublicHandler(BaseHandlerDownload):
         data = self.get_argument("data", None)
         study_id = self.get_argument("study_id",  None)
         data_type = self.get_argument("data_type",  None)
+        dtypes = get_data_types().keys()
 
         if data is None or study_id is None or data not in ('raw', 'biom'):
-            raise HTTPError(405, reason='You need to specify both data (the '
-                            'data type you want to download - raw/biom) and '
-                            'study_id')
-        if data_type is not None:
-            dtypes = get_data_types().keys()
-            if data_type not in dtypes:
-                raise HTTPError(405, reason='Not a valid data_type. Valid '
-                                'types are: %s' % ', '.join(dtypes))
-
-        # checking that study exists and that it is public
-        study_id = int(study_id)
-        try:
-            study = Study(int(study_id))
-        except QiitaDBUnknownIDError:
-            raise HTTPError(405, reason='Study does not exist')
-        if study.status != 'public':
-            raise HTTPError(405, reason='Study is not public. If this is a '
-                            'mistake contact: qiita.help@gmail.com')
-
-        to_download = []
-        if data == 'raw':
-            public_raw_download = study.public_raw_download
-            if not public_raw_download:
-                raise HTTPError(405, reason='No raw data access. If this is a '
-                                'mistake contact: qiita.help@gmail.com')
-
-            # loop over artifacts and retrieve raw data (no parents)
-            for a in study.artifacts(dtype=data_type):
-                if not a.parents:
-                    if a.visibility != 'public':
-                        continue
-                    to_download.extend(self._list_artifact_files_nginx(a))
+            self.write('You need to specify both data (the data type you want '
+                       'to download - raw/biom) and study_id')
+        elif data_type is not None and data_type not in dtypes:
+            self.write('Not a valid data_type. Valid types are: '
+                       '%s' % ', '.join(dtypes))
         else:
-            for a in study.artifacts(artifact_type='BIOM', dtype=data_type):
-                if a.visibility == 'public':
-                    to_download.extend(self._list_artifact_files_nginx(a))
+            study_id = int(study_id)
+            try:
+                study = Study(int(study_id))
+            except QiitaDBUnknownIDError:
+                self.write('Study does not exist')
+            else:
+                public_raw_download = study.public_raw_download
+                if study.status != 'public':
+                    self.write('Study is not public. If this is a mistake '
+                               'contact: qiita.help@gmail.com')
+                elif data == 'raw' and not public_raw_download:
+                    self.write('No raw data access. If this is a mistake '
+                               'contact: qiita.help@gmail.com')
+                else:
+                    to_download = []
+                    for a in study.artifacts(dtype=data_type,
+                                             artifact_type='BIOM'
+                                             if data == 'biom' else None):
+                        if a.visibility != 'public':
+                            continue
+                        to_download.extend(self._list_artifact_files_nginx(a))
 
-        if not to_download:
-            raise HTTPError(405, reason='Nothing to download. If this is a '
-                            'mistake contact: qiita.help@gmail.com')
+                    if not to_download:
+                        self.write('Nothing to download. If this is a mistake '
+                                   'contact: qiita.help@gmail.com')
+                    else:
+                        self._write_nginx_file_list(to_download)
 
-        self._write_nginx_file_list(to_download)
+                        zip_fn = 'study_%d_%s_%s.zip' % (
+                            study_id, data, datetime.now().strftime(
+                                '%m%d%y-%H%M%S'))
 
-        zip_fn = 'study_%d_%s_%s.zip' % (
-            study_id, data, datetime.now().strftime('%m%d%y-%H%M%S'))
-
-        self._set_nginx_headers(zip_fn)
+                        self._set_nginx_headers(zip_fn)
         self.finish()

--- a/qiita_pet/support_files/doc/source/faq.rst
+++ b/qiita_pet/support_files/doc/source/faq.rst
@@ -178,13 +178,13 @@ How to download raw or all BIOM files from a given study?
 We provide direct access to public data via a single end point. This end point can be used to download BIOMs or raw data,
 in specific (do not forget to replace `study-id` and/or `data_type` for your study or data type of interest ):
 
-- All raw data: https://qiita.ucsd.edu/download_public/?data=raw&study_id=study-id
+- All raw data: https://qiita.ucsd.edu/public_download/?data=raw&study_id=study-id
 
-- All BIOMs + mapping files: https://qiita.ucsd.edu/download_public/?data=biom&study_id=study-id
+- All BIOMs + mapping files: https://qiita.ucsd.edu/public_download/?data=biom&study_id=study-id
 
-- Only 16S raw data: https://qiita.ucsd.edu/download_public/?data=raw&study_id=study-id&data_type=16S
+- Only 16S raw data: https://qiita.ucsd.edu/public_download/?data=raw&study_id=study-id&data_type=16S
 
-- Only Metagenomic BIOMs + mapping files: https://qiita.ucsd.edu/download_public/?data=biom&study_id=study-id&data_type=Metagenomic
+- Only Metagenomic BIOMs + mapping files: https://qiita.ucsd.edu/public_download/?data=biom&study_id=study-id&data_type=Metagenomic
 
 
 How to cite Qiita?

--- a/qiita_pet/templates/error.html
+++ b/qiita_pet/templates/error.html
@@ -2,6 +2,7 @@
 {% autoescape None %}
 {% block content%}
     <h1 style="text-align:center">ERROR: CODE {{status_code}}!</h1>
+    <h2 style="text-align:center">{{error}}!</h2>
     <p style="text-align:center">The error has been logged and will be looked at.</p>
     <p style="text-align:center">Need help? Send us an <a href="mailto:qiita.help@gmail.com">email</a>.</p>
     {% if is_admin %}

--- a/qiita_pet/test/test_download.py
+++ b/qiita_pet/test/test_download.py
@@ -387,31 +387,31 @@ class TestDownloadPublicHandler(TestHandlerBase):
 
     def test_download(self):
         # check failures
-        response = self.get('/download_public/')
-        self.assertEqual(response.code, 405)
-        self.assertEqual(response.reason, 'You need to specify both data (the '
-                         'data type you want to download - raw/biom) and '
-                         'study_id')
+        response = self.get('/public_download/')
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.body.decode('ascii'), 'You need to specify '
+                         'both data (the data type you want to download - '
+                         'raw/biom) and study_id')
 
-        response = self.get('/download_public/?data=raw&study_id=10000')
-        self.assertEqual(response.code, 405)
-        self.assertEqual(response.reason, 'Study does not exist')
+        response = self.get('/public_download/?data=raw&study_id=10000')
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.body.decode('ascii'), 'Study does not exist')
 
-        response = self.get('/download_public/?data=raw&study_id=1')
-        self.assertEqual(response.code, 405)
-        self.assertEqual(response.reason, 'Study is not public. If this is a '
-                         'mistake contact: qiita.help@gmail.com')
+        response = self.get('/public_download/?data=raw&study_id=1')
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.body.decode('ascii'), 'Study is not public. '
+                         'If this is a mistake contact: qiita.help@gmail.com')
 
         # 7 is an uploaded biom, which should now be available but as it's a
         # biom, only the prep info file will be retrieved
         Artifact(7).visibility = 'public'
-        response = self.get('/download_public/?data=raw&study_id=1')
-        self.assertEqual(response.code, 405)
-        self.assertEqual(response.reason, 'No raw data access. If this is a '
-                         'mistake contact: qiita.help@gmail.com')
+        response = self.get('/public_download/?data=raw&study_id=1')
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.body.decode('ascii'), 'No raw data access. '
+                         'If this is a mistake contact: qiita.help@gmail.com')
 
         # check success
-        response = self.get('/download_public/?data=biom&study_id=1')
+        response = self.get('/public_download/?data=biom&study_id=1')
         self.assertEqual(response.code, 200)
         exp = (
             '- [0-9]* /protected/templates/1_prep_2_qiime_[0-9]*-[0-9]*.txt '
@@ -420,7 +420,7 @@ class TestDownloadPublicHandler(TestHandlerBase):
 
         Study(1).public_raw_download = True
         # check success
-        response = self.get('/download_public/?data=raw&study_id=1')
+        response = self.get('/public_download/?data=raw&study_id=1')
         self.assertEqual(response.code, 200)
         exp = (
             '- [0-9]* /protected/templates/1_prep_2_qiime_[0-9]*-[0-9]*.txt '
@@ -429,28 +429,31 @@ class TestDownloadPublicHandler(TestHandlerBase):
 
         # testing data_type
         response = self.get(
-            '/download_public/?data=raw&study_id=1&data_type=X')
-        self.assertEqual(response.code, 405)
-        self.assertEqual(response.reason, 'Not a valid data_type. Valid types '
+            '/public_download/?data=raw&study_id=1&data_type=X')
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.body.decode('ascii'),
+                         'Not a valid data_type. Valid types '
                          'are: 16S, 18S, ITS, Proteomic, Metabolomic, '
                          'Metagenomic, Multiomic, Metatranscriptomics, '
                          'Viromics, Genomics, Transcriptomics')
 
         response = self.get(
-            '/download_public/?data=raw&study_id=1&data_type=Genomics')
-        self.assertEqual(response.code, 405)
-        self.assertEqual(response.reason, 'Nothing to download. If this is a '
+            '/public_download/?data=raw&study_id=1&data_type=Genomics')
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.body.decode('ascii'),
+                         'Nothing to download. If this is a '
                          'mistake contact: qiita.help@gmail.com')
         response = self.get(
-            '/download_public/?data=biom&study_id=1&data_type=Genomics')
-        self.assertEqual(response.code, 405)
-        self.assertEqual(response.reason, 'Nothing to download. If this is a '
+            '/public_download/?data=biom&study_id=1&data_type=Genomics')
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.body.decode('ascii'),
+                         'Nothing to download. If this is a '
                          'mistake contact: qiita.help@gmail.com')
 
         # check succcess
         Artifact(5).visibility = 'public'
         response = self.get(
-            '/download_public/?data=raw&study_id=1&data_type=18S')
+            '/public_download/?data=raw&study_id=1&data_type=18S')
         self.assertEqual(response.code, 200)
         exp = (
             '[0-9]* [0-9]* /protected/raw_data/1_s_G1_L001_sequences_barcodes'
@@ -460,7 +463,7 @@ class TestDownloadPublicHandler(TestHandlerBase):
         self.assertRegex(response.body.decode('ascii'), exp)
 
         response = self.get(
-            '/download_public/?data=biom&study_id=1&data_type=18S')
+            '/public_download/?data=biom&study_id=1&data_type=18S')
         self.assertEqual(response.code, 200)
         exp = (
             '[0-9]* [0-9]* /protected/processed_data/1_study_1001_closed_'

--- a/qiita_pet/test/test_download.py
+++ b/qiita_pet/test/test_download.py
@@ -388,26 +388,26 @@ class TestDownloadPublicHandler(TestHandlerBase):
     def test_download(self):
         # check failures
         response = self.get('/public_download/')
-        self.assertEqual(response.code, 200)
-        self.assertEqual(response.body.decode('ascii'), 'You need to specify '
+        self.assertEqual(response.code, 422)
+        self.assertEqual(response.reason, 'You need to specify '
                          'both data (the data type you want to download - '
                          'raw/biom) and study_id')
 
         response = self.get('/public_download/?data=raw&study_id=10000')
-        self.assertEqual(response.code, 200)
-        self.assertEqual(response.body.decode('ascii'), 'Study does not exist')
+        self.assertEqual(response.code, 422)
+        self.assertEqual(response.reason, 'Study does not exist')
 
         response = self.get('/public_download/?data=raw&study_id=1')
-        self.assertEqual(response.code, 200)
-        self.assertEqual(response.body.decode('ascii'), 'Study is not public. '
+        self.assertEqual(response.code, 422)
+        self.assertEqual(response.reason, 'Study is not public. '
                          'If this is a mistake contact: qiita.help@gmail.com')
 
         # 7 is an uploaded biom, which should now be available but as it's a
         # biom, only the prep info file will be retrieved
         Artifact(7).visibility = 'public'
         response = self.get('/public_download/?data=raw&study_id=1')
-        self.assertEqual(response.code, 200)
-        self.assertEqual(response.body.decode('ascii'), 'No raw data access. '
+        self.assertEqual(response.code, 422)
+        self.assertEqual(response.reason, 'No raw data access. '
                          'If this is a mistake contact: qiita.help@gmail.com')
 
         # check success
@@ -430,24 +430,21 @@ class TestDownloadPublicHandler(TestHandlerBase):
         # testing data_type
         response = self.get(
             '/public_download/?data=raw&study_id=1&data_type=X')
-        self.assertEqual(response.code, 200)
-        self.assertEqual(response.body.decode('ascii'),
-                         'Not a valid data_type. Valid types '
+        self.assertEqual(response.code, 422)
+        self.assertEqual(response.reason, 'Not a valid data_type. Valid types '
                          'are: 16S, 18S, ITS, Proteomic, Metabolomic, '
                          'Metagenomic, Multiomic, Metatranscriptomics, '
                          'Viromics, Genomics, Transcriptomics')
 
         response = self.get(
             '/public_download/?data=raw&study_id=1&data_type=Genomics')
-        self.assertEqual(response.code, 200)
-        self.assertEqual(response.body.decode('ascii'),
-                         'Nothing to download. If this is a '
+        self.assertEqual(response.code, 422)
+        self.assertEqual(response.reason, 'Nothing to download. If this is a '
                          'mistake contact: qiita.help@gmail.com')
         response = self.get(
             '/public_download/?data=biom&study_id=1&data_type=Genomics')
-        self.assertEqual(response.code, 200)
-        self.assertEqual(response.body.decode('ascii'),
-                         'Nothing to download. If this is a '
+        self.assertEqual(response.code, 422)
+        self.assertEqual(response.reason, 'Nothing to download. If this is a '
                          'mistake contact: qiita.help@gmail.com')
 
         # check succcess

--- a/qiita_pet/webserver.py
+++ b/qiita_pet/webserver.py
@@ -184,7 +184,7 @@ class Application(tornado.web.Application):
                 DownloadEBIPrepAccessions),
             (r"/download_upload/(.*)", DownloadUpload),
             (r"/release/download/(.*)", DownloadRelease),
-            (r"/download_public/", DownloadPublicHandler),
+            (r"/public_download/", DownloadPublicHandler),
             (r"/vamps/(.*)", VAMPSHandler),
             (r"/redbiom/(.*)", RedbiomPublicSearch),
             (r"/iframe/", IFrame),


### PR DESCRIPTION
After testing this new functionality; realized that:
1. public_download is a better name than download_public
2. 405 will not show the reason in the browser which will be misleading; thus changing to 200