### PR TITLE
add a zip error message to the documentation

### DIFF
--- a/qiita_pet/support_files/doc/source/faq.rst
+++ b/qiita_pet/support_files/doc/source/faq.rst
@@ -118,6 +118,18 @@ To update your unzip for most operating systems you can simply use your regular 
 admin program. However, for Mac we suggest using
 `this version of unzip <ftp://ftp.microbio.me/pub/qiita/unzip>`__.
 
+Additionally, there is a chance that you will see an error/warning message like this:
+``extracting: BIOM/57457/all.biom bad CRC f6b2a86b (should be 38903659)``. These
+messages are consequence of the zip library we are using internally and are fine to
+ignore. If you want to check them, we suggest taking any of the files and generating their
+CRC32 checksum; in MAC's you can run ``crc32 [filename]`` and should get the first number
+in that message; for example:
+
+.. code-block:: bash
+
+   $ crc32 57457_all.biom
+   f6b2a86b
+
 Do you have general analytical questions?
 -----------------------------------------
 


### PR DESCRIPTION
Added some text, looks like this now:

![Screen Shot 2019-07-12 at 6 52 24 AM](https://user-images.githubusercontent.com/2014559/61129505-c8490880-a471-11e9-883f-e02723ef18be.png)
