### PR TITLE
improve purge filepaths

### DIFF
--- a/qiita_db/test/test_util.py
+++ b/qiita_db/test/test_util.py
@@ -8,7 +8,7 @@
 
 from unittest import TestCase, main
 from tempfile import mkstemp, mkdtemp, NamedTemporaryFile, TemporaryFile
-from os import close, remove, makedirs, mkdir
+from os import close, remove, mkdir
 from os.path import join, exists, basename
 from shutil import rmtree
 from datetime import datetime
@@ -1181,141 +1181,75 @@ class TestFilePathOpening(TestCase):
         remove(name)
 
 
-class PurgeFilepathsTestBase(DBUtilTestsBase):
+class PurgeFilepathsTests(DBUtilTestsBase):
 
-    def _common_purge_filepaths_test(self):
-        # Get all the filepaths so we can test if they've been removed or not
-        sql_fp = "SELECT filepath, data_directory_id FROM qiita.filepath"
+    def _get_current_filepaths(self):
+        sql_fp = "SELECT filepath_id FROM qiita.filepath"
         with qdb.sql_connection.TRN:
             qdb.sql_connection.TRN.add(sql_fp)
-            results = qdb.sql_connection.TRN.execute_fetchindex()
-        exp_count = len(results)
-        fps = [join(qdb.util.get_mountpoint_path_by_id(dd_id), fp)
-               for fp, dd_id in results]
+            results = qdb.sql_connection.TRN.execute_fetchflatten()
+        return [qdb.util.get_filepath_information(_id)['fullpath']
+                for _id in results]
 
+    def _create_files(self, files):
+        # format is: [mp_id, fp_type_id, file_name]
+        sql = """INSERT INTO qiita.filepath (
+                    data_directory_id, filepath_type_id, filepath, checksum,
+                    checksum_algorithm_id)
+                 VALUES (%s, %s, %s, '852952723', 1) RETURNING filepath_id"""
+        with qdb.sql_connection.TRN:
+            for f in files:
+                qdb.sql_connection.TRN.add(sql, tuple(f))
+                fid = qdb.sql_connection.TRN.execute_fetchflatten()[0]
+                qdb.util.get_filepath_information(fid)
+
+    def test_purge_filepaths_test(self):
+        # Get all the filepaths so we can test if they've been removed or not
+        fps_expected = self._get_current_filepaths()
         # Make sure that the files exist - specially for travis
-        for fp in fps:
+        for fp in fps_expected:
             if not exists(fp):
                 with open(fp, 'w') as f:
                     f.write('\n')
                 self.files_to_remove.append(fp)
 
-        # let's insert some new filepaths in the raw_data mount
-        _, raw_data_mp = qdb.util.get_mountpoint('raw_data')[0]
-        removed_fps = [
-            join(raw_data_mp, '2_sequences_barcodes.fastq.gz'),
-            join(raw_data_mp, '2_sequences.fastq.gz'),
-            join(raw_data_mp, 'directory_test')]
-        # creating the files
-        for fp in removed_fps[:-1]:
-            with open(fp, 'w') as f:
-                f.write('\n')
-        makedirs(removed_fps[-1])
-        # inserting them in the database
-        sql = """INSERT INTO qiita.filepath
-                    (filepath, filepath_type_id, checksum,
-                     checksum_algorithm_id, data_directory_id)
-                VALUES ('2_sequences_barcodes.fastq.gz', 3, '852952723', 1, 5),
-                       ('2_sequences.fastq.gz', 1, '852952723', 1, 5),
-                       ('directory_test', 8, '852952723', 1, 5)
-                RETURNING filepath_id"""
-        with qdb.sql_connection.TRN:
-            qdb.sql_connection.TRN.add(sql)
-            fp_ids = qdb.sql_connection.TRN.execute_fetchflatten()
-
-        fps = set(fps).difference(removed_fps)
-
-        # Before purging, let's check that the files exist
-        for fp in fps:
-            self.assertTrue(exists(fp))
-        for fp in removed_fps:
-            self.assertTrue(exists(fp))
-
+        # nothing shold be removed
         qdb.util.purge_filepaths()
-        obs_count = qdb.util.get_count("qiita.filepath")
-        # the patching system moves some files around so 'job/1_job_result.txt'
-        # and 'job/2_test_folder' are also going to be removed; thus, we need
-        # to rest them
-        extra_rm_files = ['job/2_test_folder', 'job/1_job_result.txt']
-        self.assertEqual(obs_count, exp_count - len(extra_rm_files))
+        fps_viewed = self._get_current_filepaths()
+        self.assertCountEqual(fps_expected, fps_viewed)
 
-        # Check that the 2 rows that have been removed are the correct ones
-        sql = """SELECT EXISTS(
-                    SELECT * FROM qiita.filepath WHERE filepath_id IN %s)"""
-        with qdb.sql_connection.TRN:
-            qdb.sql_connection.TRN.add(sql, [tuple(fp_ids)])
-            obs = qdb.sql_connection.TRN.execute_fetchflatten()[0]
-        self.assertFalse(obs)
-        with qdb.sql_connection.TRN:
-            qdb.sql_connection.TRN.add(sql, [tuple(fp_ids)])
-            obs = qdb.sql_connection.TRN.execute_fetchflatten()[0]
-        self.assertFalse(obs)
+        # testing study filepath delete by inserting a new study sample info
+        # and make sure it gets deleted
+        mp_id, mp = qdb.util.get_mountpoint('templates')[0]
+        txt_id = qdb.util.convert_to_id('plain_text', "filepath_type")
+        self._create_files([[mp_id, txt_id, '100_filepath.txt']])
+        qdb.util.purge_filepaths()
+        fps_viewed = self._get_current_filepaths()
+        self.assertCountEqual(fps_expected, fps_viewed)
 
-        # Check that the files have been successfully removed
-        for fp in removed_fps:
-            self.assertFalse(exists(fp))
+        # testing artifact filepath delete by filepaths for 2 different files
+        # and making sure they get deleted
+        mp_id, mp = qdb.util.get_mountpoint('BIOM')[0]
+        biom_id = qdb.util.convert_to_id('biom', "filepath_type")
+        self._create_files([
+            [mp_id, txt_id, 'artifact_filepath.txt'],
+            [mp_id, biom_id, 'my_biom.biom']
+        ])
+        qdb.util.purge_filepaths()
+        fps_viewed = self._get_current_filepaths()
+        self.assertCountEqual(fps_expected, fps_viewed)
 
-        # Check that all the other files still exist
-        for fp in fps:
-            if '/'.join(fp.split('/')[-2:]) not in extra_rm_files:
-                self.assertTrue(exists(fp))
-
-
-class PurgeFilepathsTestA(PurgeFilepathsTestBase):
-    def test_purge_files_from_filesystem(self):
-        info = {"timeseries_type_id": 1, "metadata_complete": True,
-                "mixs_compliant": True, "study_alias": "TST",
-                "study_description": "Some description of the study goes here",
-                "study_abstract": "Some abstract goes here",
-                "principal_investigator_id": qdb.study.StudyPerson(1),
-                "lab_person_id": qdb.study.StudyPerson(1)}
-
-        new_study = qdb.study.Study.create(
-            qdb.user.User('shared@foo.bar'),
-            'test_purge_files_from_filesystem', info=info)
-
-        metadata_dict = {
-            'SKB8.640193': {'center_name': 'ANL',
-                            'amzn_primer': 'GTGCCAGCMGCCGCGGTAA',
-                            'bartab': 'GTCCGCAAGTTA',
-                            'frd_prefix': "s_G1_L001_sequences",
-                            'platform': 'Illumina',
-                            'instrument_model': 'Illumina MiSeq',
-                            'library_construction_protocol': 'AAAA',
-                            'experiment_design_description': 'BBBB'}}
-        metadata = pd.DataFrame.from_dict(metadata_dict, orient='index',
-                                          dtype=str)
-        st = qdb.metadata_template.sample_template.SampleTemplate.create(
-            metadata, new_study)
-        fps = [fp for _, fp in st.get_filepaths()]
-        qdb.metadata_template.sample_template.SampleTemplate.delete(st.id)
-        qdb.study.Study.delete(new_study.id)
-
-        for fp in fps:
-            self.assertTrue(exists(fp))
-
-        qdb.util.purge_files_from_filesystem(True)
-
-        for fp in fps:
-            self.assertFalse(exists(fp))
-
-    def test_purge_filepaths(self):
-        self._common_purge_filepaths_test()
-
-
-class PurgeFilepathsTestB(PurgeFilepathsTestBase):
-    def test_purge_filepaths_null_cols(self):
-        # For more details about the source of the issue that motivates this
-        # test: http://www.depesz.com/2008/08/13/nulls-vs-not-in/
-        # In the current set up, the only place where we can actually have a
-        # null value in a filepath id is in the reference table. Add a new
-        # reference without tree and taxonomy:
-        fd, seqs_fp = mkstemp(suffix="_seqs.fna")
-        close(fd)
-        ref = qdb.reference.Reference.create("null_db", "13_2", seqs_fp)
-        self.files_to_remove.append(ref.sequence_fp)
-
-        self._common_purge_filepaths_test()
+        # testing analysis filepath delete by filepaths for 2 different files
+        # and making sure they get deleted
+        mp_id, mp = qdb.util.get_mountpoint('analysis')[0]
+        biom_id = qdb.util.convert_to_id('biom', "filepath_type")
+        self._create_files([
+            [mp_id, txt_id, 'my_analysis_map.txt'],
+            [mp_id, biom_id, 'my_analysis_biom.biom']
+        ])
+        qdb.util.purge_filepaths()
+        fps_viewed = self._get_current_filepaths()
+        self.assertCountEqual(fps_expected, fps_viewed)
 
 
 STUDY_INFO = {

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -754,45 +754,97 @@ def purge_filepaths(delete_files=True):
         if True it will actually delete the files, if False print
     """
     with qdb.sql_connection.TRN:
-        # Get all the (table, column) pairs that reference to the filepath
-        # table. Adapted from http://stackoverflow.com/q/5347050/3746629
-        sql = """SELECT R.TABLE_NAME, R.column_name
-            FROM INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE u
-            INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS FK
-                ON U.CONSTRAINT_CATALOG = FK.UNIQUE_CONSTRAINT_CATALOG
-                AND U.CONSTRAINT_SCHEMA = FK.UNIQUE_CONSTRAINT_SCHEMA
-                AND U.CONSTRAINT_NAME = FK.UNIQUE_CONSTRAINT_NAME
-            INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE R
-                ON R.CONSTRAINT_CATALOG = FK.CONSTRAINT_CATALOG
-                AND R.CONSTRAINT_SCHEMA = FK.CONSTRAINT_SCHEMA
-                AND R.CONSTRAINT_NAME = FK.CONSTRAINT_NAME
-            WHERE U.COLUMN_NAME = 'filepath_id'
-                AND U.TABLE_SCHEMA = 'qiita'
-                AND U.TABLE_NAME = 'filepath'"""
+        files_to_remove = []
+        # qiita can basically download 5 things: references, info files,
+        # artifacts, analyses & working_dir.
+        # 1. references are not longer used so we can skip
+
+        # 2. info files: here we could remove all old info files (the backup we
+        #    keep when a user uploads a new file) and all info files from
+        #    studies that no longer exist. We want to keep the old templates
+        #    so we can recover them (this has happened before) but let's remove
+        #    those from deleted studies
+        pt_id = qdb.util.convert_to_id('plain_text', "filepath_type")
+        sql = """SELECT filepath_id, filepath FROM qiita.filepath
+                 WHERE filepath_type_id = %s AND filepath ~ '^[0-9]' AND
+                    data_directory_id = %s AND filepath_id NOT IN (
+                        SELECT filepath_id FROM qiita.prep_template_filepath
+                        UNION
+                        SELECT filepath_id FROM qiita.sample_template_filepath)
+              """
+        for mp_id, mp in get_mountpoint('templates'):
+            qdb.sql_connection.TRN.add(sql, [pt_id, mp_id])
+            studies_exits = []
+            studies_erased = []
+            for fid, fp in qdb.sql_connection.TRN.execute_fetchindex():
+                # making sure the studies do _not_ exist, remember info files
+                # are prepended by the study id
+                study_id = int(fp.split('_')[0])
+                if study_id in studies_exits:
+                    continue
+                elif study_id in studies_erased:
+                    fpath = qdb.util.get_filepath_information(
+                        fid)['fullpath']
+                    files_to_remove.append([fid, fpath])
+                else:
+                    try:
+                        qdb.study.Study(study_id)
+                    except qdb.exceptions.QiitaDBUnknownIDError:
+                        fpath = qdb.util.get_filepath_information(
+                            fid)['fullpath']
+                        files_to_remove.append([fid, fpath])
+                        studies_erased.append(study_id)
+                    else:
+                        studies_exits.append(study_id)
+
+        # 3. artifacts: we need to select all the filepaths that are not in
+        #    the artifact_filepath, this will return both all filepaths not
+        #    from artifacts and those that are not being used, thus, we need
+        #    to also not select those files that are not part of the artifacts
+        #    by ignoring those files paths not stored in a data_directory from
+        #    an artifact
+        sql = """SELECT filepath_id FROM qiita.filepath
+                 WHERE filepath_id not in (
+                    SELECT filepath_id FROM qiita.artifact_filepath) AND
+                data_directory_id in (
+                    SELECT data_directory_id FROM qiita.artifact_type at
+                        LEFT JOIN qiita.data_directory dd ON (
+                            dd.data_type = at.artifact_type)
+                    WHERE subdirectory = true)
+              """
         qdb.sql_connection.TRN.add(sql)
+        for fid in qdb.sql_connection.TRN.execute_fetchflatten():
+            fpath = qdb.util.get_filepath_information(fid)['fullpath']
+            files_to_remove.append([fid, fpath])
 
-        union_str = " UNION ".join(
-            ["SELECT %s FROM qiita.%s WHERE %s IS NOT NULL" % (col, table, col)
-             for table, col in qdb.sql_connection.TRN.execute_fetchindex()])
-        if union_str:
-            # Get all the filepaths from the filepath table that are not
-            # referenced from any place in the database
-            sql = """SELECT filepath_id, filepath, filepath_type, data_directory_id
-                FROM qiita.filepath FP JOIN qiita.filepath_type FPT
-                    ON FP.filepath_type_id = FPT.filepath_type_id
-                WHERE filepath_id NOT IN (%s)""" % union_str
-            qdb.sql_connection.TRN.add(sql)
+        # 4. analysis: we need to select all the filepaths that are not in
+        #    the analysis_filepath, this will return both all filepaths not
+        #    from analyses and those that are not being used, thus, we need
+        #    to also not select those files that are not part of the artifacts
+        #    by ignoring those files paths not stored in a data_directory from
+        #    an artifact:
+        sql = """SELECT filepath_id FROM qiita.filepath
+                 WHERE filepath_id not in (
+                    SELECT filepath_id FROM qiita.analysis_filepath) AND
+                data_directory_id in (
+                    SELECT data_directory_id FROM qiita.data_directory
+                    WHERE data_type = 'analysis')
+              """
+        qdb.sql_connection.TRN.add(sql)
+        for fid in qdb.sql_connection.TRN.execute_fetchflatten():
+            fpath = qdb.util.get_filepath_information(fid)['fullpath']
+            files_to_remove.append([fid, fpath])
 
-        # We can now go over and remove all the filepaths
-        sql = "DELETE FROM qiita.filepath WHERE filepath_id=%s"
-        db_results = qdb.sql_connection.TRN.execute_fetchindex()
-        for fp_id, fp, fp_type, dd_id in db_results:
+        # 5. working directory:
+
+        # Deleting the files!
+        sql = "DELETE FROM qiita.filepath WHERE filepath_id = %s"
+        for fid, fpath in files_to_remove:
             if delete_files:
-                qdb.sql_connection.TRN.add(sql, [fp_id])
-                fp = join(get_mountpoint_path_by_id(dd_id), fp)
-                _rm_files(qdb.sql_connection.TRN, fp)
+                qdb.sql_connection.TRN.add(sql, [fid])
+                _rm_files(qdb.sql_connection.TRN, fpath)
             else:
-                print(fp, fp_type)
+                print(fpath)
 
         if delete_files:
             qdb.sql_connection.TRN.execute()
@@ -810,70 +862,6 @@ def _rm_exists(fp, obj, _id, delete_files):
                 qdb.sql_connection.TRN.execute()
         else:
             print("Remove %s" % fp)
-
-
-def purge_files_from_filesystem(delete_files=True):
-    r"""Goes over the filesystem and removes all the filepaths that are not
-    used in any place
-
-    Parameters
-    ----------
-    delete_files : bool
-        if True it will actually delete the files, if False print
-    """
-    # Step 1, check which mounts actually exists, we'll just report the
-    #         discrepancies
-    with qdb.sql_connection.TRN:
-        qdb.sql_connection.TRN.add(
-            "SELECT DISTINCT data_type FROM qiita.data_directory")
-        mount_types = qdb.sql_connection.TRN.execute_fetchflatten()
-
-    fbd = qdb.util.get_db_files_base_dir()
-    actual_paths = {join(fbd, x) for x in listdir(fbd)}
-    db_paths = {fp for mt in mount_types
-                for x, fp in qdb.util.get_mountpoint(mt, retrieve_all=True)}
-
-    missing_db = actual_paths - db_paths
-    if missing_db:
-        print('\n\npaths without db entries: %s\n\n' % ', '.join(missing_db))
-    missing_paths = [x for x in db_paths - actual_paths if not isdir(x)]
-    if missing_paths:
-        print('\n\npaths without actual mounts: %s\n\n' % ', '.join(
-            missing_paths))
-
-    # Step 2, clean based on the 2 main group: True/False subdirectory
-    # subdirectory True, the artifacts are stored within their own folders
-    paths = {fp for mt in mount_types
-             for x, fp, sp in get_mountpoint(mt, True, True) if sp}
-    for pt in paths:
-        if isdir(pt):
-            for aid in listdir(pt):
-                _rm_exists(
-                    join(pt, aid), qdb.artifact.Artifact, aid, delete_files)
-    # subdirectory False - this are the legacy folders, the files are stored
-    # in the base folder prepended with the element id, which are:
-    #  *** ignored or not in use anymore ***
-    # - job
-    # - preprocessed_data
-    # - processed_data
-    # - raw_data
-    # - reference
-    # - working_dir
-    #  *** dealing ***
-    # - analysis
-    # - templates
-    # - uploads
-    data_types = {
-        'analysis': qdb.analysis.Analysis,
-        'templates': qdb.study.Study,
-        'uploads': qdb.study.Study
-    }
-    for dt, obj in data_types.items():
-        for _, pt in get_mountpoint(dt, True):
-            if isdir(pt):
-                for ppt in listdir(pt):
-                    obj_id = ppt.split('_')[0]
-                    _rm_exists(join(pt, ppt), obj, obj_id, delete_files)
 
 
 def empty_trash_upload_folder(delete_files=True):

--- a/scripts/all-qiita-cron-job
+++ b/scripts/all-qiita-cron-job
@@ -3,6 +3,5 @@
 qiita-cron-job empty-trash-upload-folder
 qiita-cron-job generate-biom-and-metadata-release
 qiita-cron-job purge-filepaths
-qiita-cron-job purge-files-from-filesystem
 qiita-cron-job update-redis-stats
 qiita-cron-job generate-plugin-releases

--- a/scripts/qiita-cron-job
+++ b/scripts/qiita-cron-job
@@ -12,8 +12,7 @@ import click
 
 from qiita_db.util import (
     purge_filepaths as qiita_purge_filepaths,
-    empty_trash_upload_folder as qiita_empty_trash_upload_folder,
-    purge_files_from_filesystem as qiita_purge_files_from_filesystem)
+    empty_trash_upload_folder as qiita_empty_trash_upload_folder)
 from qiita_db.meta_util import (
     update_redis_stats as qiita_update_redis_stats,
     generate_biom_and_metadata_release as
@@ -32,14 +31,6 @@ def commands():
               'are not linked to any other table')
 def purge_filepaths(remove):
     qiita_purge_filepaths(remove)
-
-
-@commands.command()
-@click.option('--remove/--no-remove', default=False,
-              help='check the filesystem mounts and remove files not used in '
-              'the database')
-def purge_files_from_filesystem(remove):
-    qiita_purge_files_from_filesystem(remove)
 
 
 @commands.command()


### PR DESCRIPTION
We now purge filepaths based on their origin: study, artifact, analysis; and we also remove the code for purge_files_from_filesystem as we decided it will not be used _ever_ in production.  