### PR TITLE
BUG: Count samples by artifact visibility

### DIFF
--- a/qiita_db/meta_util.py
+++ b/qiita_db/meta_util.py
@@ -184,12 +184,16 @@ def update_redis_stats():
     number_of_samples = {}
     ebi_samples_prep = {}
     num_samples_ebi = 0
+
     for k, sts in viewitems(studies):
         number_of_samples[k] = 0
         for s in sts:
             st = s.sample_template
             if st is not None:
-                number_of_samples[k] += len(list(st.keys()))
+                for p in s.prep_templates():
+                    if p.artifact is not None and p.artifact.visibility == k:
+                        n = len(list(p.keys()))
+                        number_of_samples[k] += n
 
             ebi_samples_prep_count = 0
             for pt in s.prep_templates():


### PR DESCRIPTION
A study can have multiple visibilities, and samples are counted per visibility per study. As a result, samples in studies that have multiple visibilities were counted multiple times.

I did not create a regression test as I don't _believe_ the test data have a study where there is a prep that has multiple visibilities. If there is one, I'd be happy to use if for a regression test. If there isn't one, and if a regression test is important here, I may need some guidance on how best to create a mock study with artifacts spanning visibilities. 