### PR TITLE
fix #2798, fix #2121

### DIFF
--- a/qiita_pet/handlers/public.py
+++ b/qiita_pet/handlers/public.py
@@ -1,0 +1,100 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014--, The Qiita Development Team.
+#
+# Distributed under the terms of the BSD 3-clause License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# -----------------------------------------------------------------------------
+
+from tornado.web import HTTPError
+from tornado.gen import coroutine
+
+from .base_handlers import BaseHandler
+from qiita_db.study import Study
+from qiita_db.artifact import Artifact
+from qiita_db.util import get_artifacts_information
+from qiita_db.exceptions import QiitaDBUnknownIDError
+from qiita_core.util import execute_as_transaction
+from qiita_pet.util import EBI_LINKIFIER
+from qiita_pet.handlers.util import doi_linkifier, pubmed_linkifier
+
+
+class PublicHandler(BaseHandler):
+    @coroutine
+    @execute_as_transaction
+    def get(self):
+        study_id = self.get_argument("study_id",  None)
+        artifact_id = self.get_argument("artifact_id",  None)
+
+        if study_id is None and artifact_id is None:
+            raise HTTPError(
+                422, reason='You need to specify study_id or artifact_id')
+            self.finish()
+        elif study_id is not None:
+            try:
+                study = Study(int(study_id))
+            except QiitaDBUnknownIDError:
+                raise HTTPError(
+                    422, reason="Study %s doesn't exist" % study_id)
+                self.finish()
+            artifact_ids = [a.id for a in study.artifacts()
+                            if a.visibility == 'public']
+        else:
+            try:
+                artifact = Artifact(int(artifact_id))
+            except QiitaDBUnknownIDError:
+                raise HTTPError(
+                    422, reason="Artifact %s doesn't exist" % artifact_id)
+                self.finish()
+            if artifact.visibility != 'public':
+                raise HTTPError(
+                    422, reason="Artifact %s is not public" % artifact_id)
+                self.finish()
+
+            study = artifact.study
+            if study is None:
+                raise HTTPError(422, reason="Artifact %s doesn't belong to "
+                                "a study" % artifact_id)
+                self.finish()
+            artifact_ids = [artifact.id]
+
+        if study.status != 'public':
+            raise HTTPError(
+                422, reason='Not a public study')
+            self.finish()
+
+        study_info = study.info
+        study_info['study_id'] = study.id
+        study_info['study_title'] = study.title
+        study_info['shared_with'] = [s.id for s in study.shared_with]
+        study_info['status'] = study.status
+        study_info['ebi_study_accession'] = study.ebi_study_accession
+        study_info['ebi_submission_status'] = study.ebi_submission_status
+
+        # Clean up StudyPerson objects to string for display
+        email = '<a href="mailto:{email}">{name} ({affiliation})</a>'
+        pi = study.info['principal_investigator']
+        study_info['principal_investigator'] = email.format(**{
+            'name': pi.name,
+            'email': pi.email,
+            'affiliation': pi.affiliation})
+
+        study_info['owner'] = study.owner.id
+        # Add needed info that is not part of the initial info pull
+        study_info['publications'] = []
+        for pub, is_doi in study.publications:
+            if is_doi:
+                study_info['publications'].append(pubmed_linkifier([pub]))
+            else:
+                study_info['publications'].append(doi_linkifier([pub]))
+        study_info['publications'] = ', '.join(study_info['publications'])
+
+        if study_info['ebi_study_accession']:
+            links = ''.join([EBI_LINKIFIER.format(a) for a in study_info[
+                'ebi_study_accession'].split(',')])
+            study_info['ebi_study_accession'] = '%s (%s)' % (
+                links, study_info['ebi_submission_status'])
+
+        self.render("public.html", study_info=study_info,
+                    artifacts_info=get_artifacts_information(
+                        artifact_ids, False))

--- a/qiita_pet/support_files/doc/source/faq.rst
+++ b/qiita_pet/support_files/doc/source/faq.rst
@@ -88,6 +88,17 @@ A few more instructions: for the example above the workflow should be:
    be quite time consuming depending on the number of samples and the depth
    of sequencing.
 
+
+Access to a public study or artifact
+------------------------------------
+
+Access to Qiita resources is limited for non registered users; however, if you want
+to point to a given study or artifact you can use (do not forget to replace `study-id` or `artifact-id`):
+
+- Study: https://qiita.ucsd.edu/public/?study_id=study-id
+
+- Artifact: https://qiita.ucsd.edu/public/?artifact_id=artifact-id
+
 .. _issues_unzip:
 
 How to solve download or unzip errors?

--- a/qiita_pet/templates/public.html
+++ b/qiita_pet/templates/public.html
@@ -1,0 +1,65 @@
+{% extends sitebase.html %}
+
+{% block head %}
+<script type="text/javascript">
+  $(document).ready(function() {
+      $('#artifacts-table').dataTable({"caption": "Artifacts", "order": [[ 1, "asc" ]]});
+  });
+</script>
+{% end %}
+
+{% block content %}
+
+<div class="col-md-12">
+  {% if user is not None %}
+    <h2><a href="{% raw qiita_config.portal_dir %}/study/description/{{study_info['study_id']}}">{{study_info['study_title']}} - ID {{study_info['study_id']}}</a></h2>
+  {% else %}
+    <h2>{{study_info['study_title']}} - ID {{study_info['study_id']}}</h2>
+  {% end %}
+
+  <table border="0">
+    <tr>
+      <td valign="top">
+        <b>Alias:</b> {{study_info['study_alias']}}<br />
+        <b>Abstract:</b> {{study_info['study_abstract']}}<br />
+        <b>Description:</b> {{study_info['study_description']}}<br />
+        <b>Owner:</b> {{study_info['owner']}}<br />
+        <b>Publications:</b> {% raw study_info['publications'] %}<br />
+        <b>PI:</b> {% raw study_info['principal_investigator'] %}<br />
+        <b>EBI:</b> {% raw study_info['ebi_study_accession'] %}<br />
+      </td>
+    </tr>
+  </table>
+</div>
+
+
+<div class="col-md-12">
+  <hr/>
+  <table id='artifacts-table' class="display table-bordered table-hover">
+    <caption>Artifacts</caption>
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Data Type</th>
+        <th>Platform</th>
+        <th>Target Gene</th>
+        <th>Target Subfragment</th>
+        <th>Algorithm</th>
+      </tr>
+    </thead>
+    {% for ainfo in artifacts_info %}
+      {% if not ainfo['deprecated'] and ainfo['active'] %}
+        <tr>
+          <td>{{ainfo['artifact_id']}}</td>
+          <td>{{ainfo['data_type']}}</td>
+          <td>{{ainfo['platform']}}</td>
+          <td>{{ainfo['target_gene']}}</td>
+          <td>{{','.join(ainfo['target_subfragment'])}}</td>
+          <td>{{ainfo['algorithm']}}</td>
+        </tr>
+      {% end %}
+    {% end %}
+  </table>
+</div>
+
+{% end %}

--- a/qiita_pet/test/test_public.py
+++ b/qiita_pet/test/test_public.py
@@ -1,0 +1,66 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014--, The Qiita Development Team.
+#
+# Distributed under the terms of the BSD 3-clause License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# -----------------------------------------------------------------------------
+
+from unittest import main
+
+from qiita_pet.test.tornado_test_base import TestHandlerBase
+from qiita_db.artifact import Artifact
+
+
+class TestPublicHandler(TestHandlerBase):
+    def test_public(self):
+        response = self.get('/public/')
+        self.assertEqual(response.code, 422)
+        self.assertIn("You need to specify study_id or artifact_id",
+                      response.body.decode('ascii'))
+
+        response = self.get('/public/?study_id=100')
+        self.assertEqual(response.code, 422)
+        self.assertIn("Study 100 doesn't exist",
+                      response.body.decode('ascii'))
+
+        response = self.get('/public/?artifact_id=100')
+        self.assertEqual(response.code, 422)
+        self.assertIn("Artifact 100 doesn't exist",
+                      response.body.decode('ascii'))
+
+        response = self.get('/public/?artifact_id=1')
+        self.assertEqual(response.code, 422)
+        self.assertIn("Artifact 1 is not public",
+                      response.body.decode('ascii'))
+
+        response = self.get('/public/?study_id=1')
+        self.assertEqual(response.code, 422)
+        self.assertIn("Not a public study",
+                      response.body.decode('ascii'))
+
+        # artifact 1 is the first artifact within Study 1
+        Artifact(1).visibility = 'public'
+
+        response = self.get('/public/?study_id=1')
+        self.assertEqual(response.code, 200)
+
+        response = self.get('/public/?artifact_id=1')
+        self.assertEqual(response.code, 200)
+
+        response = self.get('/public/?artifact_id=7')
+        self.assertEqual(response.code, 422)
+        self.assertIn("Artifact 7 is not public",
+                      response.body.decode('ascii'))
+
+        # artifact 8 is part of an analysis
+        Artifact(8).visibility = 'public'
+
+        response = self.get('/public/?artifact_id=8')
+        self.assertEqual(response.code, 422)
+        self.assertIn("Artifact 8 doesn't belong to a study",
+                      response.body.decode('ascii'))
+
+
+if __name__ == '__main__':
+    main()

--- a/qiita_pet/webserver.py
+++ b/qiita_pet/webserver.py
@@ -76,6 +76,7 @@ from qiita_db.handlers.archive import APIArchiveObservations
 from qiita_db.util import get_mountpoint
 from qiita_pet.handlers.rest import ENDPOINTS as REST_ENDPOINTS
 from qiita_pet.handlers.qiita_redbiom import RedbiomPublicSearch
+from qiita_pet.handlers.public import PublicHandler
 
 if qiita_config.portal == "QIITA":
     from qiita_pet.handlers.portal import (
@@ -185,6 +186,7 @@ class Application(tornado.web.Application):
             (r"/download_upload/(.*)", DownloadUpload),
             (r"/release/download/(.*)", DownloadRelease),
             (r"/public_download/", DownloadPublicHandler),
+            (r"/public/", PublicHandler),
             (r"/vamps/(.*)", VAMPSHandler),
             (r"/redbiom/(.*)", RedbiomPublicSearch),
             (r"/iframe/", IFrame),


### PR DESCRIPTION
This PR adds a new public page that shows a study and/or artifact summary - this means that any user can see a summary of a public study/artifact.

Some screenshots:
- The new text in the FAQs explaining this new functionality: ![Screen Shot 2019-08-28 at 10 57 57 AM](https://user-images.githubusercontent.com/2014559/63876630-275fcf80-c983-11e9-8624-b0c96e8061a9.png)
- The error page shown when the study/artifact don't exist or isn't public: ![Screen Shot 2019-08-28 at 10 49 44 AM](https://user-images.githubusercontent.com/2014559/63876677-3fcfea00-c983-11e9-9067-da6e421d661d.png)
- The page when a user is not log in: ![Screen Shot 2019-08-28 at 10 52 17 AM](https://user-images.githubusercontent.com/2014559/63876705-4bbbac00-c983-11e9-8a55-2559bfa9df82.png)
- When is logged: ![Screen Shot 2019-08-28 at 10 52 29 AM](https://user-images.githubusercontent.com/2014559/63876722-57a76e00-c983-11e9-9a0a-aee945c95e1c.png)
- For a study showing all the artifacts: ![Screen Shot 2019-08-28 at 10 52 46 AM](https://user-images.githubusercontent.com/2014559/63876798-83c2ef00-c983-11e9-92b6-f38d265a76d8.png)

