### PR TITLE
Non public artifact download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Qiita changelog
 
+Version 112019
+--------------
+
+* Added PacBio_SMRT to the list of platform and PacBio RS, PacBio RS II, Sequel, Sequel II as valid instrument models
+* Improved downloads for public data (BIOM, raw data, etc.; see https://qiita.ucsd.edu/static/doc/html/downloading.html)
+* Added the possibility of just downloading sample or preparation information files
+* During a meta-analysis if `sample_name` and `sample_id`/`sample-id` are present, Qiita will drop the columns `sample_id`/`sample-id` to avoid issues with QIIME2
+* The redbiom webpage only accepts ' or " for escaping strings
+* Added qiime2.2019.10 to the system; which updated these plugins: qp-qiime2, qtp-biom, qtp-diversity, qtp-visualization
+
 Version 092019
 --------------
 

--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -228,7 +228,7 @@ class ConfigurationManager(object):
         self.jwt_secret = config.get('main', 'JWT_SECRET')
         if not self.jwt_secret:
             self.jwt_secret = b64encode(uuid4().bytes + uuid4().bytes)
-            warnings.warn("Random JWT secret generated.  Non Public Artifact"
+            warnings.warn("Random JWT secret generated.  Non Public Artifact "
                           "Download Links will expire upon system restart.")
 
         self.key_file = config.get('main', 'KEY_FILE')

--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -228,7 +228,8 @@ class ConfigurationManager(object):
         self.jwt_secret = config.get('main', 'JWT_SECRET')
         if not self.jwt_secret:
             self.jwt_secret = b64encode(uuid4().bytes + uuid4().bytes)
-            warnings.warn("Random JWT secret generated.")
+            warnings.warn("Random JWT secret generated.  Non Public Artifact"
+                          "Download Links will expire upon system restart.")
 
         self.key_file = config.get('main', 'KEY_FILE')
         if not self.key_file:

--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -225,6 +225,11 @@ class ConfigurationManager(object):
             self.cookie_secret = b64encode(uuid4().bytes + uuid4().bytes)
             warnings.warn("Random cookie secret generated.")
 
+        self.jwt_secret = config.get('main', 'JWT_SECRET')
+        if not self.jwt_secret:
+            self.jwt_secret = b64encode(uuid4().bytes + uuid4().bytes)
+            warnings.warn("Random JWT secret generated.")
+
         self.key_file = config.get('main', 'KEY_FILE')
         if not self.key_file:
             self.key_file = join(install_dir, 'qiita_core', 'support_files',

--- a/qiita_core/support_files/config_test.cfg
+++ b/qiita_core/support_files/config_test.cfg
@@ -65,6 +65,9 @@ KEY_FILE =
 #   print b64encode(uuid4().bytes + uuid4().bytes)"
 COOKIE_SECRET = SECRET
 
+# The value used to secure JWTs for delegated permission artifact download.
+JWT_SECRET = SUPER_SECRET
+
 # ----------------------------- SMTP settings -----------------------------
 [smtp]
 # The hostname to connect to

--- a/qiita_core/tests/test_configuration_manager.py
+++ b/qiita_core/tests/test_configuration_manager.py
@@ -270,6 +270,9 @@ KEY_FILE = /tmp/server.key
 #   print b64encode(uuid4().bytes + uuid4().bytes)"
 COOKIE_SECRET = SECRET
 
+# The value used to secure JWTs for delegated permission artifact download.
+JWT_SECRET = SUPER_SECRET
+
 # ----------------------------- SMTP settings -----------------------------
 [smtp]
 # The hostname to connect to

--- a/qiita_core/tests/test_configuration_manager.py
+++ b/qiita_core/tests/test_configuration_manager.py
@@ -125,6 +125,7 @@ class ConfigurationManagerTests(TestCase):
 
         conf_setter = partial(self.conf.set, 'main')
         conf_setter('COOKIE_SECRET', '')
+        conf_setter('JWT_SECRET', '')
         conf_setter('BASE_DATA_DIR', '')
         conf_setter('PLUGIN_DIR', '')
         conf_setter('CERTIFICATE_FILE', '')
@@ -137,7 +138,9 @@ class ConfigurationManagerTests(TestCase):
             obs._get_main(self.conf)
 
             obs_warns = [str(w.message) for w in warns]
-            exp_warns = ['Random cookie secret generated.']
+            exp_warns = ['Random cookie secret generated.',
+                         'Random JWT secret generated.  Non Public Artifact '
+                         'Download Links will expire upon system restart.']
             self.assertCountEqual(obs_warns, exp_warns)
 
         self.assertNotEqual(obs.cookie_secret, "SECRET")

--- a/qiita_db/download_link.py
+++ b/qiita_db/download_link.py
@@ -117,7 +117,8 @@ class DownloadLink(qdb.base.QiitaObject):
 
         Returns
         -------
-        A jwt
+        str
+            A JSON web token
 
         """
 

--- a/qiita_db/download_link.py
+++ b/qiita_db/download_link.py
@@ -6,8 +6,6 @@
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
 
-from __future__ import division
-
 import qiita_db as qdb
 
 from jose import jwt as jose_jwt

--- a/qiita_db/download_link.py
+++ b/qiita_db/download_link.py
@@ -61,7 +61,7 @@ class DownloadLink(qdb.base.QiitaObject):
             sql = """INSERT INTO qiita.{0} (jti, jwt, exp)
             VALUES (%s, %s, %s) RETURNING jti""".format(cls._table)
             qdb.sql_connection.TRN.add(sql, [jti, jwt, exp])
-            return qdb.sql_connection.TRN.execute_fetchlast()
+            qdb.sql_connection.TRN.execute()
 
     @classmethod
     def delete(cls, jti):
@@ -75,7 +75,7 @@ class DownloadLink(qdb.base.QiitaObject):
         with qdb.sql_connection.TRN:
             sql = """DELETE FROM qiita.{0} WHERE jti=%s""".format(cls._table)
             qdb.sql_connection.TRN.add(sql, [jti])
-            return qdb.sql_connection.TRN.execute_fetchlast()
+            qdb.sql_connection.TRN.execute()
 
     @classmethod
     def exists(cls, jti):
@@ -91,7 +91,7 @@ class DownloadLink(qdb.base.QiitaObject):
             sql = """SELECT COUNT(jti) FROM qiita.{0}
                      WHERE jti=%s""".format(cls._table)
             qdb.sql_connection.TRN.add(sql, [jti])
-            return qdb.sql_connection.TRN.execute_fetchlast()
+            return qdb.sql_connection.TRN.execute_fetchlast() == 1
 
     @classmethod
     def delete_expired(cls):

--- a/qiita_db/download_link.py
+++ b/qiita_db/download_link.py
@@ -111,7 +111,7 @@ class DownloadLink(qdb.base.QiitaObject):
         with qdb.sql_connection.TRN:
             sql = """DELETE FROM qiita.{0} WHERE exp<%s""".format(cls._table)
             qdb.sql_connection.TRN.add(sql, [now])
-            return qdb.sql_connection.TRN.execute_fetchlast()
+            qdb.sql_connection.TRN.execute()
 
     @classmethod
     def get(cls, jti):

--- a/qiita_db/download_link.py
+++ b/qiita_db/download_link.py
@@ -86,7 +86,6 @@ class DownloadLink(qdb.base.QiitaObject):
         -------
         bool
             True if link exists else false
-
         """
 
         with qdb.sql_connection.TRN:

--- a/qiita_db/download_link.py
+++ b/qiita_db/download_link.py
@@ -97,13 +97,7 @@ class DownloadLink(qdb.base.QiitaObject):
 
     @classmethod
     def delete_expired(cls):
-        r"""Deletes all expired download links
-
-        Returns
-        -------
-        None
-
-        """
+        r"""Deletes all expired download links"""
         now = datetime.now(timezone.utc)
 
         with qdb.sql_connection.TRN:

--- a/qiita_db/download_link.py
+++ b/qiita_db/download_link.py
@@ -1,0 +1,130 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014--, The Qiita Development Team.
+#
+# Distributed under the terms of the BSD 3-clause License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# -----------------------------------------------------------------------------
+
+from __future__ import division
+
+import qiita_db as qdb
+
+from jose import jwt as jose_jwt
+from datetime import datetime, timezone
+from qiita_core.qiita_settings import qiita_config
+
+
+class DownloadLink(qdb.base.QiitaObject):
+    r"""
+    A shortened url for downloading artifacts
+    alongside a signed jwt and expiration
+
+    Methods
+    -------
+    delete_expired
+
+    See Also
+    --------
+    qiita_db.QiitaObject
+    """
+
+    _table = "download_link"
+
+    @classmethod
+    def create(cls, jwt):
+        r"""Creates a new object with a new id on the storage system
+
+        Parameters
+        ----------
+        jwt : Json Web Token signing the access link.
+        This jwt will have, at a minimum, jti and exp fields
+
+        Raises
+        ------
+        IncompetentQiitaDeveloperError
+            If the jwt is improperly signed or doesn't contain a jti or exp
+        QiitaDBDuplicateError
+            If the jti already exists in the database
+        """
+
+        jwt_data = jose_jwt.decode(jwt,
+                                   qiita_config.jwt_secret,
+                                   algorithms='HS256')
+        jti = jwt_data["jti"]
+        exp = datetime.utcfromtimestamp(jwt_data["exp"] / 1000)
+
+        with qdb.sql_connection.TRN:
+            if cls.exists(jti):
+                raise qdb.exceptions.QiitaDBDuplicateError(
+                    "JTI Already Exists")
+
+            # Insert study into database
+            sql = """INSERT INTO qiita.{0} (jti, jwt, exp)
+            VALUES (%s, %s, %s) RETURNING jti""".format(cls._table)
+            qdb.sql_connection.TRN.add(sql, [jti, jwt, exp])
+            return qdb.sql_connection.TRN.execute_fetchlast()
+
+    @classmethod
+    def delete(cls, jti):
+        r"""Deletes the link with specified jti from the storage system
+
+        Parameters
+        ----------
+        jti : object
+            The jwt token identifier
+
+        """
+        with qdb.sql_connection.TRN:
+            sql = """DELETE FROM qiita.{0} WHERE jti=%s""".format(cls._table)
+            qdb.sql_connection.TRN.add(sql, [jti])
+            return qdb.sql_connection.TRN.execute_fetchlast()
+
+    @classmethod
+    def exists(cls, jti):
+        r"""Checks if a link with specified jti exists
+
+        Returns
+        -------
+        bool
+            True if link exists else false
+
+        """
+
+        with qdb.sql_connection.TRN:
+            sql = """SELECT COUNT(jti) FROM qiita.{0}
+                     WHERE jti=%s""".format(cls._table)
+            qdb.sql_connection.TRN.add(sql, [jti])
+            return qdb.sql_connection.TRN.execute_fetchlast()
+
+    @classmethod
+    def delete_expired(cls):
+        r"""Deletes all expired download links
+
+        Returns
+        -------
+        None
+
+        """
+        now = datetime.now(timezone.utc)
+
+        with qdb.sql_connection.TRN:
+            sql = """DELETE FROM qiita.{0} WHERE exp<%s""".format(cls._table)
+            qdb.sql_connection.TRN.add(sql, [now])
+            return qdb.sql_connection.TRN.execute_fetchlast()
+
+    @classmethod
+    def get(cls, jti):
+        r"""Retrieves a jwt by its jti
+
+        Returns
+        -------
+        A jwt
+
+        """
+
+        with qdb.sql_connection.TRN:
+            sql = """SELECT jwt FROM qiita.{0}
+                     WHERE jti=%s""".format(cls._table)
+            qdb.sql_connection.TRN.add(sql, [jti])
+            return qdb.sql_connection.TRN.execute_fetchlast()

--- a/qiita_db/download_link.py
+++ b/qiita_db/download_link.py
@@ -57,7 +57,7 @@ class DownloadLink(qdb.base.QiitaObject):
                 raise qdb.exceptions.QiitaDBDuplicateError(
                     "JTI Already Exists")
 
-            # Insert study into database
+            # insert token into database
             sql = """INSERT INTO qiita.{0} (jti, jwt, exp)
             VALUES (%s, %s, %s) RETURNING jti""".format(cls._table)
             qdb.sql_connection.TRN.add(sql, [jti, jwt, exp])
@@ -71,7 +71,6 @@ class DownloadLink(qdb.base.QiitaObject):
         ----------
         jti : object
             The jwt token identifier
-
         """
         with qdb.sql_connection.TRN:
             sql = """DELETE FROM qiita.{0} WHERE jti=%s""".format(cls._table)

--- a/qiita_db/support_files/patches/77.sql
+++ b/qiita_db/support_files/patches/77.sql
@@ -1,0 +1,9 @@
+-- Nov 27, 2019
+-- Adds download_link table for allowing jwt secured downloads of artifacts from shortened links
+CREATE TABLE qiita.download_link (
+  jti VARCHAR(32) PRIMARY KEY NOT NULL,
+  jwt TEXT NOT NULL,
+  exp TIMESTAMP NOT NULL
+);
+
+CREATE INDEX idx_download_link_exp ON qiita.download_link ( exp ) ;

--- a/qiita_pet/handlers/artifact_handlers/base_handlers.py
+++ b/qiita_pet/handlers/artifact_handlers/base_handlers.py
@@ -161,6 +161,46 @@ def artifact_summary_get_request(user, artifact_id):
             buttons.append(btn_base % ('revert to sandbox', 'sandbox',
                                        'Revert to sandbox'))
 
+        download_gen_link = """%s/private_download/generate/artifact/%s""" % \
+                            (qiita_config.base_url, str(artifact_id))
+
+        # Have no fear, this is just python to generate html with an onclick in
+        # javascript that makes an ajax call to a separate url, takes the
+        # response and writes it to the newly uncollapsed div.  Do note that
+        # you have to be REALLY CAREFUL with properly escaping quotation marks.
+        private_download = """<p>
+  <button class="btn btn-primary" type="button" aria-expanded="false"
+  aria-controls="privateDownloadLink"
+    onclick="$.ajax({
+        url:'%s',
+        method:'POST',
+        success: function(resp){
+          var newLink = $('<a>',{
+            text: resp.url,
+            title: resp.url,
+            href: resp.url
+          });
+          $('#downloadLinkText').text('Link will expire in 7 days');
+          $('#downloadLinkText').append('<br/>')
+          $('#downloadLinkText').append(newLink)
+          $('#privateDownloadLink').collapse('show')
+        },
+        error: function(resp){
+          $('#downloadLinkText').text('Failed to Generate Download Link');
+          $('#privateDownloadLink').collapse('show')
+        }});
+        ">
+    Generate Download Link
+  </button>
+</p>
+<div class="collapse" id="privateDownloadLink">
+  <div class="card card-body" id="downloadLinkText">
+    Generating Download Link...
+  </div>
+</div>""" % download_gen_link
+
+        buttons.append(private_download)
+
         if user.level == 'admin':
             if artifact.can_be_submitted_to_ebi:
                 buttons.append(

--- a/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
+++ b/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
@@ -231,13 +231,13 @@ class TestBaseHandlersUtils(TestCase):
                            'sure you want to revert to sandbox artifact id: '
                            '2?\')) { set_artifact_visibility(\'sandbox\', 2) '
                            '}" class="btn btn-primary btn-sm">Revert to '
-                           'sandbox</button> ' + private_download_button % 2 +
-                           ' <a class="btn btn-primary '
+                           'sandbox</button> <a class="btn btn-primary '
                            'btn-sm" href="/ebi_submission/2"><span '
                            'class="glyphicon glyphicon-export"></span> '
                            'Submit to EBI</a> <a class="btn btn-primary '
                            'btn-sm" href="/vamps/2"><span class="glyphicon '
-                           'glyphicon-export"></span> Submit to VAMPS</a>'),
+                           'glyphicon-export"></span> Submit to VAMPS</a> ' +
+                           private_download_button % 2),
                'processing_info': {
                  'command_active': True, 'software_deprecated': False,
                  'command': 'Split libraries FASTQ',

--- a/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
+++ b/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
@@ -79,6 +79,20 @@ class TestBaseHandlersUtils(TestCase):
 
     def test_artifact_summary_get_request(self):
         user = User('test@foo.bar')
+        main_buttons = (
+            '<button onclick="if (confirm(' "\'Are you sure you want to make "
+            "public artifact id: 1?')) { set_artifact_visibility('public', 1) "
+            '}" class="btn btn-primary btn-sm">Make public</button> <button '
+            'onclick="if (confirm(' "'Are you sure you want to revert to "
+            "sandbox artifact id: 1?')) { set_artifact_visibility('sandbox', 1"
+            ') }" class="btn btn-primary btn-sm">Revert to sandbox</button> ')
+        private_download_button = (
+            '<button class="btn btn-primary btn-sm" type="button" '
+            'aria-expanded="false" aria-controls="privateDownloadLink" '
+            'onclick="generate_private_download_link(%s)">Generate Download '
+            'Link</button><div class="collapse" id="privateDownloadLink"><div '
+            'class="card card-body" id="privateDownloadText">Generating '
+            'Download Link...</div></div>')
         # Artifact w/o summary
         obs = artifact_summary_get_request(user, 1)
         exp_files = [
@@ -92,15 +106,7 @@ class TestBaseHandlersUtils(TestCase):
                'artifact_timestamp': '2012-10-01 09:10',
                'visibility': 'private',
                'editable': True,
-               'buttons': ('<button onclick="if (confirm(\'Are you sure you '
-                           'want to make public artifact id: 1?\')) { '
-                           'set_artifact_visibility(\'public\', 1) }" '
-                           'class="btn btn-primary btn-sm">Make public'
-                           '</button> <button onclick="if (confirm(\'Are you '
-                           'sure you want to revert to sandbox artifact id: '
-                           '1?\')) { set_artifact_visibility(\'sandbox\', 1) '
-                           '}" class="btn btn-primary btn-sm">Revert to '
-                           'sandbox</button>'),
+               'buttons': main_buttons + private_download_button % 1,
                'processing_info': {},
                'files': exp_files,
                'is_from_analysis': False,
@@ -122,15 +128,7 @@ class TestBaseHandlersUtils(TestCase):
                'artifact_timestamp': '2012-10-01 09:10',
                'visibility': 'private',
                'editable': True,
-               'buttons': ('<button onclick="if (confirm(\'Are you sure you '
-                           'want to make public artifact id: 1?\')) { '
-                           'set_artifact_visibility(\'public\', 1) }" '
-                           'class="btn btn-primary btn-sm">Make public'
-                           '</button> <button onclick="if (confirm(\'Are you '
-                           'sure you want to revert to sandbox artifact id: '
-                           '1?\')) { set_artifact_visibility(\'sandbox\', 1) '
-                           '}" class="btn btn-primary btn-sm">Revert to '
-                           'sandbox</button>'),
+               'buttons': main_buttons + private_download_button % 1,
                'processing_info': {},
                'files': exp_files,
                'is_from_analysis': False,
@@ -160,15 +158,7 @@ class TestBaseHandlersUtils(TestCase):
                'artifact_timestamp': '2012-10-01 09:10',
                'visibility': 'private',
                'editable': True,
-               'buttons': ('<button onclick="if (confirm(\'Are you sure you '
-                           'want to make public artifact id: 1?\')) { '
-                           'set_artifact_visibility(\'public\', 1) }" '
-                           'class="btn btn-primary btn-sm">Make public'
-                           '</button> <button onclick="if (confirm(\'Are you '
-                           'sure you want to revert to sandbox artifact id: '
-                           '1?\')) { set_artifact_visibility(\'sandbox\', 1) '
-                           '}" class="btn btn-primary btn-sm">Revert to '
-                           'sandbox</button>'),
+               'buttons': main_buttons + private_download_button % 1,
                'processing_info': {},
                'files': exp_files,
                'is_from_analysis': False,
@@ -209,7 +199,7 @@ class TestBaseHandlersUtils(TestCase):
                'artifact_timestamp': '2012-10-01 09:10',
                'visibility': 'sandbox',
                'editable': True,
-               'buttons': '',
+               'buttons': private_download_button % 1,
                'processing_info': {},
                'files': exp_files,
                'is_from_analysis': False,
@@ -241,7 +231,8 @@ class TestBaseHandlersUtils(TestCase):
                            'sure you want to revert to sandbox artifact id: '
                            '2?\')) { set_artifact_visibility(\'sandbox\', 2) '
                            '}" class="btn btn-primary btn-sm">Revert to '
-                           'sandbox</button> <a class="btn btn-primary '
+                           'sandbox</button> ' + private_download_button % 2 +
+                           ' <a class="btn btn-primary '
                            'btn-sm" href="/ebi_submission/2"><span '
                            'class="glyphicon glyphicon-export"></span> '
                            'Submit to EBI</a> <a class="btn btn-primary '
@@ -275,7 +266,7 @@ class TestBaseHandlersUtils(TestCase):
                'artifact_timestamp': obs['artifact_timestamp'],
                'visibility': 'sandbox',
                'editable': True,
-               'buttons': '',
+               'buttons': private_download_button % 8,
                'processing_info': {},
                'files': [(22, 'biom_table.biom (biom)', '1756512010',
                           '1.1 MB')],

--- a/qiita_pet/handlers/qiita_redbiom.py
+++ b/qiita_pet/handlers/qiita_redbiom.py
@@ -49,13 +49,12 @@ class RedbiomPublicSearch(BaseHandler):
             study_artifacts = defaultdict(lambda: defaultdict(list))
             for ctx in contexts:
                 # redbiom.fetch.data_from_samples returns a biom, which we
-                # will ignore, and a dict
+                # will ignore, and a dict: {sample_id_in_table: original_id}
                 _, data = redbiom.fetch.data_from_samples(ctx, redbiom_samples)
-                for vals in data.values():
-                    for idx in vals:
-                        aid, sample_id = idx.split('_', 1)
-                        sid = sample_id.split('.', 1)[0]
-                        study_artifacts[sid][aid].append(sample_id)
+                for idx in data.keys():
+                    sample_id, aid = idx.rsplit('.', 1)
+                    sid = sample_id.split('.', 1)[0]
+                    study_artifacts[sid][aid].append(sample_id)
 
         return message, study_artifacts
 

--- a/qiita_pet/static/js/qiita.js
+++ b/qiita_pet/static/js/qiita.js
@@ -398,3 +398,24 @@ function format_biom_rows(data, row, for_study_list = true, samples = null) {
   proc_data_table += '</table>';
   return proc_data_table;
 }
+
+function generate_private_download_link(artifact_id){
+  $.ajax({
+    url: "/private_download/" + artifact_id,
+    method: 'POST',
+    success: function(response){
+      var newLink = $('<a>',{
+        text: response.url,
+        title: response.url,
+        href: response.url
+      });
+      $('#privateDownloadText').text('Link will expire in 7 days');
+      $('#privateDownloadText').append('<br/>')
+      $('#privateDownloadText').append(newLink)
+      $('#privateDownloadLink').collapse('show')
+  },
+  error: function(resp){
+    $('#downloadLinkText').text('Failed to Generate Download Link');
+    $('#privateDownloadLink').collapse('show')
+  }});
+}

--- a/qiita_pet/test/test_download.py
+++ b/qiita_pet/test/test_download.py
@@ -572,7 +572,7 @@ class TestDownloadPrivateArtifactHandler(TestHandlerBase):
         super(TestDownloadPrivateArtifactHandler, self).tearDown()
 
     def test_download(self):
-        # Stupidly, you can't post None, you must post an empty byte array
+        # you can't post None, you must post an empty byte array
         response = self.post('/private_download/1', b'')
         self.assertEqual(response.code, 200)
 

--- a/qiita_pet/test/test_download.py
+++ b/qiita_pet/test/test_download.py
@@ -198,12 +198,6 @@ class TestDownloadStudyBIOMSHandler(TestHandlerBase):
 
 class TestDownloadRelease(TestHandlerBase):
 
-    def setUp(self):
-        super(TestDownloadRelease, self).setUp()
-
-    def tearDown(self):
-        super(TestDownloadRelease, self).tearDown()
-
     def test_download(self):
         # check success
         response = self.get('/release/download/1')
@@ -287,12 +281,6 @@ class TestDownloadRawData(TestHandlerBase):
 
 class TestDownloadEBISampleAccessions(TestHandlerBase):
 
-    def setUp(self):
-        super(TestDownloadEBISampleAccessions, self).setUp()
-
-    def tearDown(self):
-        super(TestDownloadEBISampleAccessions, self).tearDown()
-
     def test_download(self):
         # check success
         response = self.get('/download_ebi_accessions/samples/1')
@@ -324,12 +312,6 @@ class TestDownloadEBISampleAccessions(TestHandlerBase):
 
 
 class TestDownloadEBIPrepAccessions(TestHandlerBase):
-
-    def setUp(self):
-        super(TestDownloadEBIPrepAccessions, self).setUp()
-
-    def tearDown(self):
-        super(TestDownloadEBIPrepAccessions, self).tearDown()
 
     def test_download(self):
         # check success
@@ -363,12 +345,6 @@ class TestDownloadEBIPrepAccessions(TestHandlerBase):
 
 class TestDownloadUpload(TestHandlerBase):
 
-    def setUp(self):
-        super(TestDownloadUpload, self).setUp()
-
-    def tearDown(self):
-        super(TestDownloadUpload, self).tearDown()
-
     def test_download(self):
         # check failure
         response = self.get('/download_upload/1/uploaded_file.txt')
@@ -381,12 +357,6 @@ class TestDownloadUpload(TestHandlerBase):
 
 
 class TestDownloadPublicHandler(TestHandlerBase):
-
-    def setUp(self):
-        super(TestDownloadPublicHandler, self).setUp()
-
-    def tearDown(self):
-        super(TestDownloadPublicHandler, self).tearDown()
 
     def test_download(self):
         # check failures
@@ -525,12 +495,6 @@ class TestDownloadPublicHandler(TestHandlerBase):
 
 class TestDownloadPublicArtifactHandler(TestHandlerBase):
 
-    def setUp(self):
-        super(TestDownloadPublicArtifactHandler, self).setUp()
-
-    def tearDown(self):
-        super(TestDownloadPublicArtifactHandler, self).tearDown()
-
     def test_download(self):
         # check failures
         response = self.get('/public_artifact_download/')
@@ -565,11 +529,6 @@ class TestDownloadPublicArtifactHandler(TestHandlerBase):
 
 
 class TestDownloadPrivateArtifactHandler(TestHandlerBase):
-    def setUp(self):
-        super(TestDownloadPrivateArtifactHandler, self).setUp()
-
-    def tearDown(self):
-        super(TestDownloadPrivateArtifactHandler, self).tearDown()
 
     def test_download(self):
         # you can't post None, you must post an empty byte array

--- a/qiita_pet/test/test_download.py
+++ b/qiita_pet/test/test_download.py
@@ -573,7 +573,7 @@ class TestDownloadPrivateArtifactHandler(TestHandlerBase):
 
     def test_download(self):
         # Stupidly, you can't post None, you must post an empty byte array
-        response = self.post('/private_download/generate/artifact/1', b'')
+        response = self.post('/private_download/1', b'')
         self.assertEqual(response.code, 200)
 
         resp_dict = json.loads(response.body)

--- a/qiita_pet/webserver.py
+++ b/qiita_pet/webserver.py
@@ -188,8 +188,6 @@ class Application(tornado.web.Application):
             (r"/release/download/(.*)", DownloadRelease),
             (r"/public_download/", DownloadPublicHandler),
             (r"/public_artifact_download/", DownloadPublicArtifactHandler),
-            (r"/private_download/generate/artifact/(.*)",
-                DownloadPrivateArtifactHandler),
             (r"/private_download/(.*)", DownloadPrivateArtifactHandler),
             (r"/public/", PublicHandler),
             (r"/vamps/(.*)", VAMPSHandler),

--- a/qiita_pet/webserver.py
+++ b/qiita_pet/webserver.py
@@ -50,7 +50,8 @@ from qiita_pet.handlers.stats import StatsHandler
 from qiita_pet.handlers.download import (
     DownloadHandler, DownloadStudyBIOMSHandler, DownloadRelease,
     DownloadRawData, DownloadEBISampleAccessions, DownloadEBIPrepAccessions,
-    DownloadUpload, DownloadPublicHandler, DownloadPublicArtifactHandler)
+    DownloadUpload, DownloadPublicHandler, DownloadPublicArtifactHandler,
+    DownloadPrivateArtifactHandler)
 from qiita_pet.handlers.prep_template import (
     PrepTemplateHandler, PrepTemplateGraphHandler, PrepTemplateJobHandler)
 from qiita_pet.handlers.ontology import OntologyHandler
@@ -187,6 +188,9 @@ class Application(tornado.web.Application):
             (r"/release/download/(.*)", DownloadRelease),
             (r"/public_download/", DownloadPublicHandler),
             (r"/public_artifact_download/", DownloadPublicArtifactHandler),
+            (r"/private_download/generate/artifact/(.*)",
+                DownloadPrivateArtifactHandler),
+            (r"/private_download/(.*)", DownloadPrivateArtifactHandler),
             (r"/public/", PublicHandler),
             (r"/vamps/(.*)", VAMPSHandler),
             (r"/redbiom/(.*)", RedbiomPublicSearch),

--- a/scripts/all-qiita-cron-job
+++ b/scripts/all-qiita-cron-job
@@ -5,3 +5,4 @@ qiita-cron-job generate-biom-and-metadata-release
 qiita-cron-job purge-filepaths
 qiita-cron-job update-redis-stats
 qiita-cron-job generate-plugin-releases
+qiita-cron-job purge_json_web_tokens

--- a/scripts/all-qiita-cron-job
+++ b/scripts/all-qiita-cron-job
@@ -5,4 +5,4 @@ qiita-cron-job generate-biom-and-metadata-release
 qiita-cron-job purge-filepaths
 qiita-cron-job update-redis-stats
 qiita-cron-job generate-plugin-releases
-qiita-cron-job purge_json_web_tokens
+qiita-cron-job purge-json-web-tokens

--- a/scripts/qiita-cron-job
+++ b/scripts/qiita-cron-job
@@ -18,6 +18,7 @@ from qiita_db.meta_util import (
     generate_biom_and_metadata_release as
     qiita_generate_biom_and_metadata_release,
     generate_plugin_releases as qiita_generate_plugin_releases)
+from qiita_db.download_link import DownloadLink
 
 
 @click.group()
@@ -49,6 +50,11 @@ def update_redis_stats():
 @commands.command()
 def generate_biom_and_metadata_release():
     qiita_generate_biom_and_metadata_release('public')
+
+
+@commands.command()
+def purge_json_web_tokens():
+    DownloadLink.delete_expired()
 
 
 @commands.command()

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ setup(name='qiita-spots',
                         'paramiko', 'seaborn',  'matplotlib', 'scipy', 'nose',
                         'flake8', 'six', 'qiita-files @ https://github.com/'
                         'qiita-spots/qiita-files/archive/master.zip', 'mock',
+                        'python-jose',
                         'supervisor @ https://github.com/Supervisor/'
                         'supervisor/archive/master.zip', 'joblib'],
       classifiers=classifiers


### PR DESCRIPTION
This branch allows creation of shareable download links for private artifacts:

A logged in user with permission to download a private artifact posts to /private_download/generate/artifact/
This saves a jwt to the database and responds with a url

That user, or anyone with the generated url can then download the artifact.  Revocation is handled through expiration of the token or removal of access permissions of the user signed in the jwt.  