### PR TITLE
fix #2979

### DIFF
--- a/qiita_pet/templates/study_ajax/sample_prep_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_prep_summary.html
@@ -30,10 +30,12 @@
       return ""
     {% end %}
   }
-  function deleteIndividualSamples(samples){
+  function deleteIndividualSamples(){
     var sample_names = [];
-    samples.each(function(){
-      sample_names.push($(this).prop('name'));
+    $.each(rows, function (i, d) {
+      if (d['sample-delete'] == 'checked') {
+        sample_names.push(d['sample'])
+      }
     });
     sampleTemplatePage.$refs.stElem.deleteSamples(sample_names);
   }
@@ -269,7 +271,7 @@
     <tr>
       <td>
         <h3>Sample Summary</h3><br/>
-        <button class="btn btn-danger st-interactive" onclick="deleteIndividualSamples($('.sample-delete:checkbox:checked'))">
+        <button class="btn btn-danger st-interactive" onclick="deleteIndividualSamples()">
             <span class="glyphicon glyphicon-trash"></span> Delete Selected
         </button>
         <button class="btn btn-danger st-interactive" onclick="deleteNonOverlappingSamplePrepSamples()">


### PR DESCRIPTION
Before this change, note the sample numbers:
![fix-2979](https://user-images.githubusercontent.com/2014559/76785406-01f9ae00-677b-11ea-993f-1d2bc56e81fe.gif)

Now:
![now](https://user-images.githubusercontent.com/2014559/76785430-0e7e0680-677b-11ea-8d62-d3d629521381.png)