### PR TITLE
fix parent cp visibility error

### DIFF
--- a/qiita_db/artifact.py
+++ b/qiita_db/artifact.py
@@ -458,9 +458,9 @@ class Artifact(qdb.base.QiitaObject):
                 visibilities = {a.visibility for a in instance.parents}
                 # set based on the "lowest" visibility
                 if 'sandbox' in visibilities:
-                    instance._set_visibility('sandbox')
+                    instance.visibility = 'sandbox'
                 elif 'private' in visibilities:
-                    instance._set_visibility('private')
+                    instance.visibility = 'private'
                 else:
                     instance._set_visibility('public')
 


### PR DESCRIPTION
The issue comes from studies/artifacts that became public before we had more stringent metadata requirements and when a new artifact (new reprocessing) is added the new artifact will not comply with them and the artifact will not be created. The easiest solution is to simply skip the validation step for when a new artifact is created.

All tests passed. So ready for review.