### PR TITLE
fix #2773

### DIFF
--- a/qiita_pet/handlers/qiita_redbiom.py
+++ b/qiita_pet/handlers/qiita_redbiom.py
@@ -13,8 +13,10 @@ import redbiom.search
 import redbiom._requests
 import redbiom.util
 import redbiom.fetch
+import redbiom.admin
 from tornado.gen import coroutine, Task
 from tornado.web import HTTPError
+from requests.exceptions import HTTPError as rHTTPError
 
 from qiita_core.util import execute_as_transaction
 from qiita_db.util import generate_study_list_without_artifacts
@@ -27,9 +29,18 @@ class RedbiomPublicSearch(BaseHandler):
     def get(self, search):
         # making sure that if someone from a portal forces entry to this URI
         # we go to the main portal
+        try:
+            timestamps = redbiom.admin.get_timestamps()
+        except (rHTTPError):
+            timestamps = []
+
+        if timestamps:
+            latests_release = timestamps[0]
+        else:
+            latests_release = 'Not reported'
         if self.request.uri != '/redbiom/':
             self.redirect('/redbiom/')
-        self.render('redbiom.html')
+        self.render('redbiom.html', latests_release=latests_release)
 
     def _redbiom_metadata_search(self, query, contexts):
         study_artifacts = defaultdict(lambda: defaultdict(list))

--- a/qiita_pet/handlers/qiita_redbiom.py
+++ b/qiita_pet/handlers/qiita_redbiom.py
@@ -35,12 +35,12 @@ class RedbiomPublicSearch(BaseHandler):
             timestamps = []
 
         if timestamps:
-            latests_release = timestamps[0]
+            latest_release = timestamps[0]
         else:
-            latests_release = 'Not reported'
+            latest_release = 'Not reported'
         if self.request.uri != '/redbiom/':
             self.redirect('/redbiom/')
-        self.render('redbiom.html', latests_release=latests_release)
+        self.render('redbiom.html', latest_release=latest_release)
 
     def _redbiom_metadata_search(self, query, contexts):
         study_artifacts = defaultdict(lambda: defaultdict(list))

--- a/qiita_pet/templates/redbiom.html
+++ b/qiita_pet/templates/redbiom.html
@@ -180,7 +180,7 @@
 {%block content%}
   <small>
     <!-- Date to be fixed once we fix: https://github.com/biocore/qiita/issues/2773 -->
-    Redbiom only searches on public data. Last update: <i>{{latests_release}}</i>. Note that you will only be able to expand and add artifacts to analyses if you are signed into Qiita.
+    Redbiom only searches on public data. Last update: <i>{{latest_release}}</i>. Note that you will only be able to expand and add artifacts to analyses if you are signed into Qiita.
     <br/><br/>
     <a href="{% raw qiita_config.portal_dir %}/static/doc/html/redbiom.html" class="btn btn-info btn-sm" target="_blank">Help and examples?</a>
     <br/>

--- a/qiita_pet/templates/redbiom.html
+++ b/qiita_pet/templates/redbiom.html
@@ -180,7 +180,7 @@
 {%block content%}
   <small>
     <!-- Date to be fixed once we fix: https://github.com/biocore/qiita/issues/2773 -->
-    Redbiom only searches on public data. Last update: December 18th, 2018. Note that you will only be able to expand and add artifacts to analyses if you are signed into Qiita.
+    Redbiom only searches on public data. Last update: <i>{{latests_release}}</i>. Note that you will only be able to expand and add artifacts to analyses if you are signed into Qiita.
     <br/><br/>
     <a href="{% raw qiita_config.portal_dir %}/static/doc/html/redbiom.html" class="btn btn-info btn-sm" target="_blank">Help and examples?</a>
     <br/>


### PR DESCRIPTION
Originally #2773 was created as the qiita redbiom page displayed the incorrect information of when redbiom was deployed. This PR adds that information to the page; thus it should close that issue. 