### PR TITLE
fix #2902

### DIFF
--- a/qiita_db/artifact.py
+++ b/qiita_db/artifact.py
@@ -1415,6 +1415,15 @@ class Artifact(qdb.base.QiitaObject):
 
     @property
     def being_deleted_by(self):
+        """The running job that is deleting this artifact
+
+        Returns
+        -------
+        qiita_db.processing_job.ProcessingJob
+            The running job that is deleting this artifact, None if it
+            doesn't exist
+        """
+
         with qdb.sql_connection.TRN:
             sql = """
                 SELECT processing_job_id FROM qiita.artifact_processing_job

--- a/qiita_db/artifact.py
+++ b/qiita_db/artifact.py
@@ -50,6 +50,7 @@ class Artifact(qdb.base.QiitaObject):
     -------
     create
     delete
+    being_deleted_by
 
     See Also
     --------
@@ -1411,6 +1412,21 @@ class Artifact(qdb.base.QiitaObject):
             parent_softwares.append(parent_software)
 
         return ', '.join(merging_schemes), ', '.join(parent_softwares)
+
+    @property
+    def being_deleted_by(self):
+        with qdb.sql_connection.TRN:
+            sql = """
+                SELECT processing_job_id FROM qiita.artifact_processing_job
+                  LEFT JOIN qiita.processing_job using (processing_job_id)
+                  LEFT JOIN qiita.processing_job_status using (
+                    processing_job_status_id)
+                  LEFT JOIN qiita.software_command using (command_id)
+                  WHERE artifact_id = %s AND name = 'delete_artifact' AND
+                    processing_job_status = 'running'"""
+            qdb.sql_connection.TRN.add(sql, [self.id])
+            res = qdb.sql_connection.TRN.execute_fetchindex()
+        return qdb.processing_job.ProcessingJob(res[0][0]) if res else None
 
     def jobs(self, cmd=None, status=None, show_hidden=False):
         """Jobs that used this artifact as input

--- a/qiita_db/processing_job.py
+++ b/qiita_db/processing_job.py
@@ -591,6 +591,9 @@ class ProcessingJob(qdb.base.QiitaObject):
                         TTRN.add(sql, [artifact_info, job_id])
                     else:
                         pending[artifact_info[0]][pname] = artifact_info[1]
+                elif pname == 'artifact':
+                    TTRN.add(sql, [parameters.values[pname], job_id])
+
             if pending:
                 sql = """UPDATE qiita.processing_job
                          SET pending = %s

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -14,7 +14,6 @@ from os.path import exists, join, basename
 from shutil import copyfile
 from functools import partial
 from json import dumps
-from time import sleep
 
 import pandas as pd
 import networkx as nx
@@ -22,6 +21,7 @@ from biom import example_table as et
 from biom.util import biom_open
 
 from qiita_core.util import qiita_test_checker
+from qiita_core.testing import wait_for_processing_job
 import qiita_db as qdb
 
 
@@ -1148,8 +1148,7 @@ class ArtifactTests(TestCase):
             qdb.user.User('test@foo.bar'), params, True)
         job.submit()
         # let's wait for job
-        while job.status in ('queued', 'running'):
-            sleep(1)
+        wait_for_processing_job(job.id)
 
         with self.assertRaises(qdb.exceptions.QiitaDBUnknownIDError):
             qdb.artifact.Artifact(test.id)

--- a/qiita_pet/handlers/api_proxy/prep_template.py
+++ b/qiita_pet/handlers/api_proxy/prep_template.py
@@ -661,6 +661,9 @@ def prep_template_graph_get_req(prep_id, user_id):
     G = artifact.descendants_with_jobs
 
     nodes, edges, wf_id = get_network_nodes_edges(G, full_access)
+    # nodes returns [node_type, node_name, element_id]; here we are looking
+    # for the node_type == artifact, and check by the element/artifact_id if
+    # it's being deleted
     artifacts_being_deleted = [a[2] for a in nodes if a[0] == 'artifact' and
                                Artifact(a[2]).being_deleted_by is not None]
 

--- a/qiita_pet/handlers/api_proxy/prep_template.py
+++ b/qiita_pet/handlers/api_proxy/prep_template.py
@@ -18,6 +18,7 @@ from qiita_core.util import execute_as_transaction
 from qiita_core.qiita_settings import r_client
 from qiita_pet.handlers.api_proxy.util import check_access, check_fp
 from qiita_pet.util import get_network_nodes_edges
+from qiita_db.artifact import Artifact
 from qiita_db.metadata_template.util import load_template_to_dataframe
 from qiita_db.util import convert_to_id, get_files_from_uploads_folders
 from qiita_db.study import Study
@@ -660,11 +661,14 @@ def prep_template_graph_get_req(prep_id, user_id):
     G = artifact.descendants_with_jobs
 
     nodes, edges, wf_id = get_network_nodes_edges(G, full_access)
+    artifacts_being_deleted = [a[2] for a in nodes if a[0] == 'artifact' and
+                               Artifact(a[2]).being_deleted_by is not None]
 
     return {'edges': edges,
             'nodes': nodes,
             'workflow': wf_id,
             'status': 'success',
+            'artifacts_being_deleted': artifacts_being_deleted,
             'message': ''}
 
 

--- a/qiita_pet/handlers/artifact_handlers/base_handlers.py
+++ b/qiita_pet/handlers/artifact_handlers/base_handlers.py
@@ -396,8 +396,6 @@ def artifact_post_req(user, artifact_id):
     being_deleted_by = artifact.being_deleted_by
 
     if being_deleted_by is None:
-        check_artifact_access(user, artifact)
-
         analysis = artifact.analysis
 
         if analysis:

--- a/qiita_pet/handlers/artifact_handlers/base_handlers.py
+++ b/qiita_pet/handlers/artifact_handlers/base_handlers.py
@@ -391,6 +391,7 @@ def artifact_post_req(user, artifact_id):
     """
     artifact_id = int(artifact_id)
     artifact = Artifact(artifact_id)
+    check_artifact_access(user, artifact)
 
     being_deleted_by = artifact.being_deleted_by
 

--- a/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
+++ b/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
@@ -102,7 +102,7 @@ class TestBaseHandlersUtils(TestCase):
              '2125826711', '58B')]
         exp = {'name': 'Raw data 1',
                'artifact_id': 1,
-               'artifact_type': 'FASTQ',
+               'artifact_type': 'FASTQ', 'being_deleted': False,
                'artifact_timestamp': '2012-10-01 09:10',
                'visibility': 'private',
                'editable': True,
@@ -124,7 +124,7 @@ class TestBaseHandlersUtils(TestCase):
         obs = artifact_summary_get_request(user, 1)
         exp = {'name': 'Raw data 1',
                'artifact_id': 1,
-               'artifact_type': 'FASTQ',
+               'artifact_type': 'FASTQ', 'being_deleted': False,
                'artifact_timestamp': '2012-10-01 09:10',
                'visibility': 'private',
                'editable': True,
@@ -154,7 +154,7 @@ class TestBaseHandlersUtils(TestCase):
         obs = artifact_summary_get_request(user, 1)
         exp = {'name': 'Raw data 1',
                'artifact_id': 1,
-               'artifact_type': 'FASTQ',
+               'artifact_type': 'FASTQ', 'being_deleted': False,
                'artifact_timestamp': '2012-10-01 09:10',
                'visibility': 'private',
                'editable': True,
@@ -177,7 +177,7 @@ class TestBaseHandlersUtils(TestCase):
         obs = artifact_summary_get_request(demo_u, 1)
         exp = {'name': 'Raw data 1',
                'artifact_id': 1,
-               'artifact_type': 'FASTQ',
+               'artifact_type': 'FASTQ', 'being_deleted': False,
                'artifact_timestamp': '2012-10-01 09:10',
                'visibility': 'public',
                'editable': False,
@@ -195,7 +195,7 @@ class TestBaseHandlersUtils(TestCase):
         obs = artifact_summary_get_request(user, 1)
         exp = {'name': 'Raw data 1',
                'artifact_id': 1,
-               'artifact_type': 'FASTQ',
+               'artifact_type': 'FASTQ', 'being_deleted': False,
                'artifact_timestamp': '2012-10-01 09:10',
                'visibility': 'sandbox',
                'editable': True,
@@ -219,7 +219,7 @@ class TestBaseHandlersUtils(TestCase):
             (5, '1_seqs.demux (preprocessed demux)', '', '0B')]
         exp = {'name': 'Demultiplexed 1',
                'artifact_id': 2,
-               'artifact_type': 'Demultiplexed',
+               'artifact_type': 'Demultiplexed', 'being_deleted': False,
                'artifact_timestamp': '2012-10-01 10:10',
                'visibility': 'private',
                'editable': True,
@@ -261,7 +261,7 @@ class TestBaseHandlersUtils(TestCase):
         obs = artifact_summary_get_request(user, 8)
         exp = {'name': 'noname',
                'artifact_id': 8,
-               'artifact_type': 'BIOM',
+               'artifact_type': 'BIOM', 'being_deleted': False,
                # this value changes on build so copy from obs
                'artifact_timestamp': obs['artifact_timestamp'],
                'visibility': 'sandbox',

--- a/qiita_pet/static/js/networkVue.js
+++ b/qiita_pet/static/js/networkVue.js
@@ -216,7 +216,7 @@ Vue.component('processing-graph', {
         // Clean up the div
         $("#processing-results").empty();
         // Update the artifact node to mark that it is being deleted
-        var node = vm.nodes_ds.get(artifactId);
+        var node = vm.nodes_ds.get(artifactId.toString());
         var node_info = vm.colorScheme['deleting'];
         node.group = 'deleting';
         node.color = node_info;
@@ -985,6 +985,10 @@ Vue.component('processing-graph', {
           // Format node list data
           for(var i = 0; i < data.nodes.length; i++) {
             var node_info = vm.colorScheme[data.nodes[i][4]];
+            if (data.artifacts_being_deleted.includes(data.nodes[i][2])) {
+              data.nodes[i][0] = 'deleting'
+              node_info = vm.colorScheme['deleting']
+            }
             // forcing a string
             data.nodes[i][2] = data.nodes[i][2].toString()
             vm.nodes.push({id: data.nodes[i][2], shape: node_info['shape'], label: formatNodeLabel(data.nodes[i][3]), type: data.nodes[i][1], group: data.nodes[i][0], color: node_info, status: data.nodes[i][4]});

--- a/qiita_pet/templates/artifact_ajax/artifact_summary.html
+++ b/qiita_pet/templates/artifact_ajax/artifact_summary.html
@@ -133,23 +133,28 @@
         {% end %}
       {% end %}
       <i id='summary-title'>{{name}}</i><i> (ID: {{artifact_id}}) Visibility: {{visibility}}</i>
-      {% if editable %}
-        <a class="btn btn-default btn-sm" data-toggle="modal" data-target="#update-artifact-name"><span class="glyphicon glyphicon-pencil"></span> Edit name</a>
-      {% end %}
 
-      {% if artifact_type == 'BIOM' and not is_from_analysis %}
-        <input type="button" class="btn btn-default btn-sm" value="Add to Analysis" onclick="send_samples_to_analysis(this, [{{artifact_id}}]);">
+      {% if being_deleted %}
+        <h4 style="color: #FF2222;">This artifact is being deleted</h4>
       {% else %}
-        <a class="btn btn-default btn-sm" id="process-btn"><span class="glyphicon glyphicon-play"></span> Process</a>
-      {% end %}
+        {% if editable %}
+          <a class="btn btn-default btn-sm" data-toggle="modal" data-target="#update-artifact-name"><span class="glyphicon glyphicon-pencil"></span> Edit name</a>
+        {% end %}
 
-      {% if editable %}
-        <a class="btn btn-danger btn-sm" onclick="if (confirm('Are you sure you want to delete artifact {{artifact_id}}?')){ processingNetwork.$refs.procGraph.deleteArtifact({{artifact_id}}) };"><span class="glyphicon glyphicon-trash"></span> Delete</a>
-        {% raw buttons %}
-      {% end %}
+        {% if artifact_type == 'BIOM' and not is_from_analysis %}
+          <input type="button" class="btn btn-default btn-sm" value="Add to Analysis" onclick="send_samples_to_analysis(this, [{{artifact_id}}]);">
+        {% else %}
+          <a class="btn btn-default btn-sm" id="process-btn"><span class="glyphicon glyphicon-play"></span> Process</a>
+        {% end %}
 
-      {% if processing_info %}
-        <button class="btn btn-default btn-sm" data-toggle="collapse" data-target="#processing-info"><span class="glyphicon glyphicon-eye-open"></span> Show processing information</a>
+        {% if editable %}
+          <a class="btn btn-danger btn-sm" onclick="if (confirm('Are you sure you want to delete artifact {{artifact_id}}?')){ processingNetwork.$refs.procGraph.deleteArtifact({{artifact_id}}) };"><span class="glyphicon glyphicon-trash"></span> Delete</a>
+          {% raw buttons %}
+        {% end %}
+
+        {% if processing_info %}
+          <button class="btn btn-default btn-sm" data-toggle="collapse" data-target="#processing-info"><span class="glyphicon glyphicon-eye-open"></span> Show processing information</a>
+        {% end %}
       {% end %}
     </h4>
     {% if processing_info %}

--- a/qiita_pet/util.py
+++ b/qiita_pet/util.py
@@ -188,6 +188,9 @@ def get_network_nodes_edges(graph, full_access, nodes=None, edges=None):
     # n[1] is the object
     for n in graph.nodes():
         if n[0] == 'job':
+            # ignoring internal Jobs
+            if n[1].command.software.name == 'Qiita':
+                continue
             atype = 'job'
             name = n[1].command.name
             status = n[1].status


### PR DESCRIPTION
Before this patch we didn't keep track of deleting jobs and this was the behavior:
![2902_before](https://user-images.githubusercontent.com/2014559/80325759-b1eb1e00-87f3-11ea-98b1-8115a6de8c69.gif)

The main issues were:
- The artifact id was not being parse as string so JS couldn't be updated
- The internal jobs were not accounted as part of the artifacts, which mean that they weren't able to be track
- We didn't have a method to query if an artifact was being deleted; because it was not easy to track
- Once we have those things we can use in the GUI to reflect the delete status

![2902](https://user-images.githubusercontent.com/2014559/80325753-adbf0080-87f3-11ea-8b38-bfe0bf9545cd.gif)
