### PR TITLE
fix #2998

### DIFF
--- a/qiita_pet/support_files/doc/source/faq.rst
+++ b/qiita_pet/support_files/doc/source/faq.rst
@@ -44,7 +44,7 @@ collected 100 samples for your study, you will need 100 rows in your sample
 information file describing each of them, and additional rows for blanks and other
 control samples. If you prepared 95 of them for 16S and 50 of them for 18S,
 you will need 2 prep information files: one with 95 rows describing the preparation
-for 16S, and another one with 50 describing the 18S. For a more information
+for 16S, and another one with 50 describing the 18S. For more information
 visit :ref:`complex_example`.
 
 .. _example_study_processing_workflow:

--- a/qiita_pet/support_files/doc/source/faq.rst
+++ b/qiita_pet/support_files/doc/source/faq.rst
@@ -44,11 +44,8 @@ collected 100 samples for your study, you will need 100 rows in your sample
 information file describing each of them, and additional rows for blanks and other
 control samples. If you prepared 95 of them for 16S and 50 of them for 18S,
 you will need 2 prep information files: one with 95 rows describing the preparation
-for 16S, and another one with 50 describing the 18S. For a more complex
-example go
-`here <#h.eddzjlm5e6l6>`__ and for examples of these files you can go to
-the "Upload instructions"
-`here <https://www.google.com/url?q=https%3A%2F%2Fvamps.mbl.edu%2Fmobe_workshop%2Fwiki%2Findex.php%2FMain_Page&sa=D&sntz=1&usg=AFQjCNE4PTOKIvFNlWtHmJyLLy11mfzF8A>`__.
+for 16S, and another one with 50 describing the 18S. For a more information
+visit :ref:`complex_example`.
 
 .. _example_study_processing_workflow:
 

--- a/qiita_pet/support_files/doc/source/qiita-philosophy/index.rst
+++ b/qiita_pet/support_files/doc/source/qiita-philosophy/index.rst
@@ -70,6 +70,8 @@ public, both in Qiita and the permanent repository, Figure 2.
    study listing page.
 
 
+.. _complex_example:
+
 Qiita allows for complex study designs
 --------------------------------------
 

--- a/qiita_pet/templates/upload.html
+++ b/qiita_pet/templates/upload.html
@@ -5,7 +5,7 @@
 <script type="text/javascript">
   function validate_file() {
     var ssh_key = $("#ssh-key")[0].files[0];
-    if (ssh_key.size > 2000) {
+    if (ssh_key.size > 4000) {
       alert("Your input file is too large to be a valid key, please try again.");
       $("#ssh-key").val("");
     }


### PR DESCRIPTION
This fixes #2998 and also a minor thing with the documentation, now it looks like this (and points t to the right information):
<img width="741" alt="Screen Shot 2020-05-14 at 10 41 58 AM" src="https://user-images.githubusercontent.com/2014559/81961789-1b2ea780-95d0-11ea-9561-a4f59813cf11.png">
