### PR TITLE
improve delete analysis

### DIFF
--- a/qiita_ware/test/test_private_plugin.py
+++ b/qiita_ware/test/test_private_plugin.py
@@ -422,10 +422,15 @@ class TestPrivatePluginDeleteAnalysis(BaseTestPrivatePlugin):
         # basically want 8 -> 9 -> 10 -> 12 -> 14
         #                       -> 11 -> 13
         fd, fp10 = mkstemp(suffix='_table.biom')
+        close(fd)
         fd, fp11 = mkstemp(suffix='_table.biom')
+        close(fd)
         fd, fp12 = mkstemp(suffix='_table.biom')
+        close(fd)
         fd, fp13 = mkstemp(suffix='_table.biom')
+        close(fd)
         fd, fp14 = mkstemp(suffix='_table.biom')
+        close(fd)
         with biom_open(fp10, 'w') as f:
             et.to_hdf5(f, "test")
         with biom_open(fp11, 'w') as f:

--- a/qiita_ware/test/test_private_plugin.py
+++ b/qiita_ware/test/test_private_plugin.py
@@ -52,6 +52,19 @@ class BaseTestPrivatePlugin(TestCase):
         job._set_status('queued')
         return job
 
+    def setUp(self):
+        self._clean_up_files = []
+
+    def tearDown(self):
+        for f in self._clean_up_files:
+            if exists(f):
+                if isdir(f):
+                    rmtree(f)
+                else:
+                    remove(f)
+
+        r_client.flushdb()
+
 
 @qiita_test_checker()
 class TestPrivatePlugin(BaseTestPrivatePlugin):
@@ -64,16 +77,6 @@ class TestPrivatePlugin(BaseTestPrivatePlugin):
 
         self.temp_dir = mkdtemp()
         self._clean_up_files = [self.fp, self.temp_dir]
-
-    def tearDown(self):
-        for f in self._clean_up_files:
-            if exists(f):
-                if isdir(f):
-                    rmtree(f)
-                else:
-                    remove(f)
-
-        r_client.flushdb()
 
     def test_copy_artifact(self):
         # Failure test
@@ -433,6 +436,7 @@ class TestPrivatePluginDeleteAnalysis(BaseTestPrivatePlugin):
             et.to_hdf5(f, "test")
         with biom_open(fp14, 'w') as f:
             et.to_hdf5(f, "test")
+        self._clean_up_files.extend([fp10, fp11, fp12, fp13, fp14])
 
         # copying some processing parameters
         a9 = Artifact(9)

--- a/qiita_ware/test/test_private_plugin.py
+++ b/qiita_ware/test/test_private_plugin.py
@@ -445,10 +445,10 @@ class TestPrivatePluginDeleteAnalysis(BaseTestPrivatePlugin):
                               processing_parameters=pp)
         a12 = Artifact.create([(fp12, 7)], "BIOM", parents=[a10],
                               processing_parameters=pp)
-        a13 = Artifact.create([(fp13, 7)], "BIOM", parents=[a11],
-                              processing_parameters=pp)
-        a14 = Artifact.create([(fp14, 7)], "BIOM", parents=[a12],
-                              processing_parameters=pp)
+        Artifact.create([(fp13, 7)], "BIOM", parents=[a11],
+                        processing_parameters=pp)
+        Artifact.create([(fp14, 7)], "BIOM", parents=[a12],
+                        processing_parameters=pp)
 
         job = self._create_job('delete_analysis', {'analysis_id': 1})
         private_task(job.id)


### PR DESCRIPTION
When deleting an analysis a user could find this error `Error (log id: 3): The object with ID '12' does not exists in table 'artifact'`, when the analysis had this _valid_ shape:
```
        #           8 -> 9 -> 10 -> 12 -> 14
        #                  -> 11 -> 13
```

