### PR TITLE
adding processingjob shape/validator

### DIFF
--- a/qiita_db/support_files/patches/79.sql
+++ b/qiita_db/support_files/patches/79.sql
@@ -1,0 +1,11 @@
+-- Jun 23, 2020
+-- Adds a new job_type VALIDATOR to processing_job_resource_allocation
+
+INSERT INTO qiita.processing_job_resource_allocation (name, job_type, allocation) VALUES
+  ('default', 'VALIDATOR', '-q qiita -l nodes=1:ppn=1 -l mem=1gb -l walltime=4:00:00'),
+  ('per_sample_FASTQ', 'VALIDATOR', '-q qiita -l nodes=1:ppn=5 -l mem=2gb -l walltime=10:00:00'),
+  ('ordination_results', 'VALIDATOR', '-q qiita -l nodes=1:ppn=1 -l mem=10gb -l walltime=2:00:00'),
+  ('Demultiplexed', 'VALIDATOR', '-q qiita -l nodes=1:ppn=5 -l mem=25gb -l walltime=150:00:00'),
+  ('distance_matrix', 'VALIDATOR', '-q qiita -l nodes=1:ppn=1 -l mem=42gb -l walltime=150:00:00'),
+  ('BIOM', 'VALIDATOR', '-q qiita -l nodes=1:ppn=1 -l mem=90gb -l walltime=150:00:00'),
+  ('alpha_vector', 'VALIDATOR', '-q qiita -l nodes=1:ppn=1 -l mem=10gb -l walltime=70:00:00');


### PR DESCRIPTION
This PR adds two main changes to the ProcessingJob object:
- a shape property which returns the sample/metadata-columns related to the job, if possible
- adds a VALIDATOR job_type for qiita.processing_job_resource_allocation