### PR TITLE
Fix 3057

### DIFF
--- a/qiita_db/metadata_template/sample_template.py
+++ b/qiita_db/metadata_template/sample_template.py
@@ -333,15 +333,17 @@ class SampleTemplate(MetadataTemplate):
         """
         self._update_accession_numbers('biosample_accession', value)
 
-    def to_dataframe(self, add_ebi_accessions=False):
+    def to_dataframe(self, add_ebi_accessions=False, samples=None):
         """Returns the metadata template as a dataframe
 
         Parameters
         ----------
         add_ebi_accessions : bool, optional
             If this should add the ebi accessions
+        samples list of string, optional
+            A list of the sample names we actually want to retrieve
         """
-        df = self._common_to_dataframe_steps()
+        df = self._common_to_dataframe_steps(samples=samples)
 
         if add_ebi_accessions:
             accessions = self.ebi_sample_accessions

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -1963,8 +1963,7 @@ class TestSampleTemplate(TestCase):
                '1.SKM4.640180', '1.SKM5.640177', '1.SKM6.640187',
                '1.SKM7.640188', '1.SKM8.640201', '1.SKM9.640192'}
         self.assertEqual(set(obs.index), exp)
-
-        self.assertEqual(set(obs.columns), {
+        exp_columns = {
             'physical_specimen_location', 'physical_specimen_remaining',
             'dna_extracted', 'sample_type', 'collection_timestamp',
             'host_subject_id', 'description', 'latitude', 'longitude',
@@ -1973,7 +1972,15 @@ class TestSampleTemplate(TestCase):
             'water_content_soil', 'elevation', 'temp', 'tot_nitro',
             'samp_salinity', 'altitude', 'env_biome', 'country', 'ph',
             'anonymized_name', 'tot_org_carb', 'description_duplicate',
-            'env_feature', 'scientific_name', 'qiita_study_id'})
+            'env_feature', 'scientific_name', 'qiita_study_id'}
+        self.assertEqual(set(obs.columns), exp_columns)
+
+        # test limiting samples produced
+        exp_samples = set(['1.SKD4.640185', '1.SKD5.640186'])
+        obs = self.tester.to_dataframe(samples=exp_samples)
+        self.assertEqual(len(obs), 2)
+        self.assertEqual(set(obs.index), exp_samples)
+        self.assertEqual(set(obs.columns), exp_columns)
 
         # test with add_ebi_accessions as True
         obs = self.tester.to_dataframe(True)

--- a/qiita_db/support_files/patches/81.sql
+++ b/qiita_db/support_files/patches/81.sql
@@ -1,0 +1,5 @@
+-- Jan 8, 2021
+-- Update 
+Add a flag to the studies to see if the study was submitted by Qiita or downloaded by EBI
+
+ALTER TABLE qiita.study ADD autoloaded BOOL NOT NULL DEFAULT false;

--- a/qiita_db/support_files/patches/81.sql
+++ b/qiita_db/support_files/patches/81.sql
@@ -1,5 +1,0 @@
--- Jan 8, 2021
--- Update 
-Add a flag to the studies to see if the study was submitted by Qiita or downloaded by EBI
-
-ALTER TABLE qiita.study ADD autoloaded BOOL NOT NULL DEFAULT false;

--- a/qiita_pet/templates/study_ajax/prep_summary.html
+++ b/qiita_pet/templates/study_ajax/prep_summary.html
@@ -429,7 +429,7 @@
       <span id="prep-name-span">{{name}}</span> - ID {{prep_id}} ({{data_type}})
       <a class="btn btn-default" data-toggle="modal" data-target="#update-prep-name"><span class="glyphicon glyphicon-pencil"></span> Edit name</a>
       <a class="btn btn-default" href="{% raw qiita_config.portal_dir %}/download/{{download_prep_id}}"><span class="glyphicon glyphicon-download-alt"></span> Prep info</a>
-      <a class="btn btn-default" href="{% raw qiita_config.portal_dir %}/download_sample_info_per_prep/{{prep_id}}"><span class="glyphicon glyphicon-download-alt"></span> Sample info</a>
+      <a class="btn btn-default" href="{% raw qiita_config.portal_dir %}/download_sample_info_per_prep/{{prep_id}}"><span class="glyphicon glyphicon-download-alt"></span> Sample info (only this prep)</a>
       {% if is_submitted_to_ebi %}
         <a class="btn btn-default" href="{% raw qiita_config.portal_dir %}/download_ebi_accessions/experiments/{{prep_id}}"><span class="glyphicon glyphicon-download-alt"></span> EBI experiment accessions</a>
       {% end %}

--- a/qiita_pet/templates/study_ajax/prep_summary.html
+++ b/qiita_pet/templates/study_ajax/prep_summary.html
@@ -429,6 +429,7 @@
       <span id="prep-name-span">{{name}}</span> - ID {{prep_id}} ({{data_type}})
       <a class="btn btn-default" data-toggle="modal" data-target="#update-prep-name"><span class="glyphicon glyphicon-pencil"></span> Edit name</a>
       <a class="btn btn-default" href="{% raw qiita_config.portal_dir %}/download/{{download_prep_id}}"><span class="glyphicon glyphicon-download-alt"></span> Prep info</a>
+      <a class="btn btn-default" href="{% raw qiita_config.portal_dir %}/download_sample_info_per_prep/{{prep_id}}"><span class="glyphicon glyphicon-download-alt"></span> Sample info</a>
       {% if is_submitted_to_ebi %}
         <a class="btn btn-default" href="{% raw qiita_config.portal_dir %}/download_ebi_accessions/experiments/{{prep_id}}"><span class="glyphicon glyphicon-download-alt"></span> EBI experiment accessions</a>
       {% end %}

--- a/qiita_pet/templates/study_ajax/sample_prep_summary.html
+++ b/qiita_pet/templates/study_ajax/sample_prep_summary.html
@@ -52,6 +52,44 @@
       sampleTemplatePage.$refs.stElem.deleteSamples(to_delete);
     }
   }
+
+  /**
+   *
+   * Function to download the data displayed in the page
+   *
+   */
+  function download_summary(){
+    var information = [];
+    var prep_names = {% raw columns %};
+
+    // adding header
+    var header = ['sample_id']
+    $.each(prep_colums, function(i, prep){
+      header.push(prep_names[prep]);
+    });
+    information.push(header.join('\t'))
+
+    // adding data
+    $.each(rows, function (i, row){
+      var line = [row['sample']]
+      $.each(prep_colums, function(i, prep){
+        line.push(row[prep]);
+      });
+      information.push(line.join('\t'));
+    });
+
+    information = information.join('\n');
+
+    // downloading file
+    var element = document.createElement('a');
+    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(information));
+    element.setAttribute('download', 'study_{{study_id}}_sample_preparations_summary.tsv');
+    element.style.display = 'none';
+    document.body.appendChild(element);
+    element.click();
+    document.body.removeChild(element);
+  }
+
   var columns = [
       { 'name': '<input type="checkbox" onchange="toggleCheckboxes(this)">',
         'field': 'sample-delete', 'id': 'sample-delete', width: 69, sortable: false, formatter: linkFormatter },
@@ -271,6 +309,9 @@
     <tr>
       <td>
         <h3>Sample Summary</h3><br/>
+        <button class="btn btn-default st-interactive" onclick="download_summary();">
+            <span class="glyphicon glyphicon-download-alt"></span> Summary
+        </button>
         <button class="btn btn-danger st-interactive" onclick="deleteIndividualSamples()">
             <span class="glyphicon glyphicon-trash"></span> Delete Selected
         </button>
@@ -280,6 +321,7 @@
       </td>
       <td style="text-align: right">
         Add sample column information to table
+        <br/>
         <select id="metadata_category" name="metadata_category">
           <option value=""></option>
           {% for col in categories %}

--- a/qiita_pet/test/test_download.py
+++ b/qiita_pet/test/test_download.py
@@ -6,12 +6,14 @@
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
 
+import pandas as pd
 from unittest import main
 from mock import Mock
 from os.path import exists, isdir, join, basename
 from os import remove, makedirs, close
 from shutil import rmtree
 from tempfile import mkdtemp, mkstemp
+from io import StringIO
 
 from biom.util import biom_open
 from biom import example_table as et
@@ -337,6 +339,25 @@ class TestDownloadEBIPrepAccessions(TestHandlerBase):
         BaseHandler.get_current_user = Mock(
             return_value=User("demo@microbio.me"))
         response = self.get('/download_ebi_accessions/experiments/1')
+        self.assertEqual(response.code, 405)
+
+
+class TestDownloadSampleInfoPerPrep(TestHandlerBase):
+
+    def test_download(self):
+        # check success
+        response = self.get('/download_sample_info_per_prep/1')
+        self.assertEqual(response.code, 200)
+
+        df = pd.read_csv(StringIO(response.body.decode('ascii')), sep='\t')
+        # just testing shape as the actual content is tested in the dataframe
+        # generation
+        self.assertEqual(df.shape, (27, 33))
+
+        # changing user so we can test the failures
+        BaseHandler.get_current_user = Mock(
+            return_value=User("demo@microbio.me"))
+        response = self.get('/download_sample_info_per_prep/1')
         self.assertEqual(response.code, 405)
 
 

--- a/qiita_pet/webserver.py
+++ b/qiita_pet/webserver.py
@@ -51,7 +51,7 @@ from qiita_pet.handlers.download import (
     DownloadHandler, DownloadStudyBIOMSHandler, DownloadRelease,
     DownloadRawData, DownloadEBISampleAccessions, DownloadEBIPrepAccessions,
     DownloadUpload, DownloadPublicHandler, DownloadPublicArtifactHandler,
-    DownloadPrivateArtifactHandler)
+    DownloadSampleInfoPerPrep, DownloadPrivateArtifactHandler)
 from qiita_pet.handlers.prep_template import (
     PrepTemplateHandler, PrepTemplateGraphHandler, PrepTemplateJobHandler)
 from qiita_pet.handlers.ontology import OntologyHandler
@@ -183,6 +183,8 @@ class Application(tornado.web.Application):
             (r"/download_raw_data/(.*)", DownloadRawData),
             (r"/download_ebi_accessions/samples/(.*)",
                 DownloadEBISampleAccessions),
+            (r"/download_sample_info_per_prep/(.*)",
+                DownloadSampleInfoPerPrep),
             (r"/download_ebi_accessions/experiments/(.*)",
                 DownloadEBIPrepAccessions),
             (r"/download_upload/(.*)", DownloadUpload),


### PR DESCRIPTION
1. Fixes #3057 by simply generating a tsv file from the already loaded data; the new button looks like this:
<img width="1068" alt="sample_prep_summary" src="https://user-images.githubusercontent.com/2014559/103557350-496b3b00-4e70-11eb-89f1-e44655d3ba76.png">

2. It also adds the possibility of downloading the sample information file for a given prep (AKA download the sample information for only those samples in the prep); the new button looks like this:
<img width="1344" alt="samples_from_prep" src="https://user-images.githubusercontent.com/2014559/103557446-73246200-4e70-11eb-8d19-dcd06126e2c1.png">
