### PR TITLE
fix #2751

### DIFF
--- a/qiita_db/meta_util.py
+++ b/qiita_db/meta_util.py
@@ -412,7 +412,7 @@ def generate_biom_and_metadata_release(study_status='public'):
                     continue
                 fp = relpath(x['fp'], bdir)
                 for pt in a.prep_templates:
-                    categories = pt.categories()
+                    categories = pt.categories
                     platform = ''
                     target_gene = ''
                     if 'platform' in categories:

--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -55,6 +55,19 @@ from string import ascii_letters, digits
 QIITA_COLUMN_NAME = 'qiita_sample_column_names'
 
 
+def _helper_get_categories(table):
+    """This is a helper function to avoid duplication of code"""
+    with qdb.sql_connection.TRN:
+        sql = """SELECT sample_values->>'columns'
+                 FROM qiita.{0}
+                 WHERE sample_id = '{1}'""".format(table, QIITA_COLUMN_NAME)
+        qdb.sql_connection.TRN.add(sql)
+        results = qdb.sql_connection.TRN.execute_fetchflatten()
+        if results:
+            results = sorted(loads(results[0]))
+        return results
+
+
 class BaseSample(qdb.base.QiitaObject):
     r"""Sample object that accesses the db to get the information of a sample
     belonging to a PrepTemplate or a SampleTemplate.
@@ -184,17 +197,7 @@ class BaseSample(qdb.base.QiitaObject):
         set of str
             The set of all available metadata categories
         """
-        with qdb.sql_connection.TRN:
-            sql = """SELECT sample_values->>'columns'
-                     FROM qiita.{0}
-                     WHERE sample_id = '{1}'""".format(
-                        self._dynamic_table, QIITA_COLUMN_NAME)
-            qdb.sql_connection.TRN.add(sql)
-            results = qdb.sql_connection.TRN.execute_fetchflatten()
-            if results:
-                results = loads(results[0])
-
-            return set(results)
+        return set(_helper_get_categories(self._dynamic_table))
 
     def _to_dict(self):
         r"""Returns the categories and their values in a dictionary
@@ -729,7 +732,7 @@ class MetadataTemplate(qdb.base.QiitaObject):
             If the column_name is selected as a specimen_id_column in the
             study.
         """
-        if column_name not in self.categories():
+        if column_name not in self.categories:
             raise qdb.exceptions.QiitaDBColumnError(
                 "'%s' not in info file %d" % (column_name, self._id))
         if not self.can_be_updated(columns={column_name}):
@@ -754,7 +757,7 @@ class MetadataTemplate(qdb.base.QiitaObject):
             qdb.sql_connection.TRN.add(sql, [column_name, QIITA_COLUMN_NAME])
 
             # deleting from QIITA_COLUMN_NAME
-            columns = self.categories()
+            columns = self.categories
             columns.remove(column_name)
             values = '{"columns": %s}' % dumps(columns)
             sql = """UPDATE {0}
@@ -834,7 +837,7 @@ class MetadataTemplate(qdb.base.QiitaObject):
 
             # Check if we are adding new columns
             headers = md_template.keys().tolist()
-            new_cols = set(headers).difference(self.categories())
+            new_cols = set(headers).difference(self.categories)
 
             if not new_cols and not new_samples:
                 return None, None
@@ -855,7 +858,7 @@ class MetadataTemplate(qdb.base.QiitaObject):
                 # code). Sorting the new columns to enforce an order
                 new_cols = sorted(new_cols)
 
-                cols = self.categories()
+                cols = self.categories
                 cols.extend(new_cols)
 
                 values = dumps({"columns": cols})
@@ -1167,7 +1170,7 @@ class MetadataTemplate(qdb.base.QiitaObject):
         """
         with qdb.sql_connection.TRN:
             # Retrieve all the information from the database
-            cols = self.categories()
+            cols = self.categories
             sql = """SELECT sample_id, sample_values
                      FROM qiita.{0}
                      WHERE sample_id != '{1}'""".format(
@@ -1237,6 +1240,7 @@ class MetadataTemplate(qdb.base.QiitaObject):
                         self._filepath_table, self._id_column, self.id,
                         sort='descending')]
 
+    @property
     def categories(self):
         """Identifies the metadata columns present in an info file
 
@@ -1245,19 +1249,7 @@ class MetadataTemplate(qdb.base.QiitaObject):
         cols : list
             The category fields
         """
-        with qdb.sql_connection.TRN:
-            sql = """SELECT sample_values->>'columns'
-                     FROM qiita.{0}
-                     WHERE sample_id = '{1}'""".format(
-                        self._table_name(self._id), QIITA_COLUMN_NAME)
-
-            qdb.sql_connection.TRN.add(sql)
-
-            results = qdb.sql_connection.TRN.execute_fetchflatten()
-            if results:
-                results = sorted(loads(results[0]))
-
-            return results
+        return _helper_get_categories(self._table_name(self._id))
 
     def extend(self, md_template):
         """Adds the given template to the current one
@@ -1269,7 +1261,7 @@ class MetadataTemplate(qdb.base.QiitaObject):
         """
         with qdb.sql_connection.TRN:
             md_template = self._clean_validate_template(
-                md_template, self.study_id, current_columns=self.categories())
+                md_template, self.study_id, current_columns=self.categories)
             new_samples, new_columns = self._common_extend_steps(md_template)
             if new_samples or new_columns:
                 self.validate(self.columns_restrictions)
@@ -1396,7 +1388,7 @@ class MetadataTemplate(qdb.base.QiitaObject):
                             self._table_name(self._id))
                 qdb.sql_connection.TRN.add(sql, [dumps(values), sid])
 
-            nc = list(set(new_columns).union(set(self.categories())))
+            nc = list(set(new_columns).union(set(self.categories)))
             table_name = self._table_name(self.id)
             values = dumps({"columns": nc})
             sql = """UPDATE qiita.{0}
@@ -1430,7 +1422,7 @@ class MetadataTemplate(qdb.base.QiitaObject):
         with qdb.sql_connection.TRN:
             # Clean and validate the metadata template given
             new_map = self._clean_validate_template(
-                md_template, self.study_id, current_columns=self.categories())
+                md_template, self.study_id, current_columns=self.categories)
             samples, columns = self._update(new_map)
             self.validate(self.columns_restrictions)
             self.generate_files(samples, columns)
@@ -1450,7 +1442,7 @@ class MetadataTemplate(qdb.base.QiitaObject):
         """
         with qdb.sql_connection.TRN:
             md_template = self._clean_validate_template(
-                md_template, self.study_id, current_columns=self.categories())
+                md_template, self.study_id, current_columns=self.categories)
             new_samples, new_columns = self._common_extend_steps(md_template)
             samples, columns = self._update(md_template)
             if samples is None:
@@ -1516,7 +1508,7 @@ class MetadataTemplate(qdb.base.QiitaObject):
             If category is not part of the template
         """
         with qdb.sql_connection.TRN:
-            if category not in self.categories():
+            if category not in self.categories:
                 raise qdb.exceptions.QiitaDBColumnError(category)
             sql = """SELECT sample_id,
                         COALESCE(sample_values->>'{0}', 'None') AS {0}
@@ -1542,7 +1534,7 @@ class MetadataTemplate(qdb.base.QiitaObject):
         cols = {col for restriction in restrictions
                 for col in restriction.columns}
 
-        return cols.difference(self.categories())
+        return cols.difference(self.categories)
 
     def _get_accession_numbers(self, column):
         """Return the accession numbers stored in `column`
@@ -1639,7 +1631,7 @@ class MetadataTemplate(qdb.base.QiitaObject):
             If the values aren't castable
         """
         warning_msg = []
-        columns = self.categories()
+        columns = self.categories
         wrong_msg = 'Sample "%s", column "%s", wrong value "%s"'
         for label, restriction in restriction_dict.items():
             missing = set(restriction.columns).difference(columns)
@@ -1796,7 +1788,7 @@ class MetadataTemplate(qdb.base.QiitaObject):
             success = True
             message = []
             restrictions = self.restrictions
-            categories = self.categories()
+            categories = self.categories
 
             difference = sorted(set(restrictions.keys()) - set(categories))
             if difference:

--- a/qiita_db/metadata_template/prep_template.py
+++ b/qiita_db/metadata_template/prep_template.py
@@ -142,7 +142,7 @@ class PrepTemplate(MetadataTemplate):
 
             md_template = cls._clean_validate_template(md_template, study.id)
             _check_duplicated_columns(list(md_template.columns),
-                                      study.sample_template.categories())
+                                      study.sample_template.categories)
 
             # Insert the metadata template
             sql = """INSERT INTO qiita.prep_template
@@ -394,7 +394,7 @@ class PrepTemplate(MetadataTemplate):
                                        "prep template")
 
         _check_duplicated_columns(list(new_columns), qdb.study.Study(
-            self.study_id).sample_template.categories())
+            self.study_id).sample_template.categories)
 
         return True, ""
 

--- a/qiita_db/metadata_template/test/test_prep_template.py
+++ b/qiita_db/metadata_template/test/test_prep_template.py
@@ -909,7 +909,7 @@ class TestPrepTemplate(TestCase):
                           'instrument_model', 'experiment_design_description',
                           'library_construction_protocol', 'center_name',
                           'center_project_name', 'emp_status'}
-        self.assertCountEqual(pt.categories(), exp_categories)
+        self.assertCountEqual(pt.categories, exp_categories)
         exp_dict = {
             '%s.SKB7.640196' % self.test_study.id: {
                 'barcode': 'CCTCTGAGAGCT',
@@ -1058,7 +1058,7 @@ class TestPrepTemplate(TestCase):
                           'instrument_model', 'experiment_design_description',
                           'library_construction_protocol', 'center_name',
                           'center_project_name', 'emp_status'}
-        self.assertCountEqual(pt.categories(), exp_categories)
+        self.assertCountEqual(pt.categories, exp_categories)
         exp_dict = {
             '%s.SKB7.640196' % self.test_study.id: {
                 'ebi_submission_accession': None,
@@ -1628,7 +1628,7 @@ class TestPrepTemplate(TestCase):
         pt = qdb.metadata_template.prep_template.PrepTemplate.create(
             self.metadata, self.test_study, self.data_type)
         pt.delete_column('str_column')
-        self.assertNotIn('str_column', pt.categories())
+        self.assertNotIn('str_column', pt.categories)
 
         # testing errors
         pt = qdb.metadata_template.prep_template.PrepTemplate(1)

--- a/qiita_db/metadata_template/test/test_sample_template.py
+++ b/qiita_db/metadata_template/test/test_sample_template.py
@@ -542,7 +542,7 @@ class TestSampleTemplate(TestCase):
                'physical_specimen_remaining', 'dna_extracted',
                'sample_type', 'collection_timestamp', 'host_subject_id',
                'description', 'latitude', 'longitude', 'scientific_name'}
-        obs = set(self.tester.categories())
+        obs = set(self.tester.categories)
         self.assertCountEqual(obs, exp)
 
     def test_iter(self):
@@ -974,7 +974,7 @@ class TestSampleTemplate(TestCase):
                           'longitude', 'physical_specimen_location',
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id'}
-        self.assertCountEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories, exp_categories)
         exp_dict = {
             "%s.Sample1" % new_id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -1040,7 +1040,7 @@ class TestSampleTemplate(TestCase):
                           'longitude', 'physical_specimen_location',
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id'}
-        self.assertCountEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories, exp_categories)
         exp_dict = {
             "%s.12.Sample1" % new_id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -1106,7 +1106,7 @@ class TestSampleTemplate(TestCase):
                           'longitude', 'physical_specimen_location',
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id'}
-        self.assertCountEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories, exp_categories)
         exp_dict = {
             "%s.foo.Sample1" % new_id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -1172,7 +1172,7 @@ class TestSampleTemplate(TestCase):
                           'longitude', 'physical_specimen_location',
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id'}
-        self.assertCountEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories, exp_categories)
         exp_dict = {
             "%s.Sample1" % new_id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -1463,7 +1463,7 @@ class TestSampleTemplate(TestCase):
                           'longitude', 'physical_specimen_location',
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id'}
-        self.assertCountEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories, exp_categories)
         exp_dict = {
             "%s.Sample1" % st.id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -1568,7 +1568,7 @@ class TestSampleTemplate(TestCase):
                           'longitude', 'physical_specimen_location',
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id'}
-        self.assertCountEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories, exp_categories)
         exp_dict = {
             "%s.Sample1" % st.id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -1650,7 +1650,7 @@ class TestSampleTemplate(TestCase):
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id',
                           'texture', 'tot_nitro'}
-        self.assertCountEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories, exp_categories)
         exp_dict = {
             "%s.Sample1" % st.id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -1736,7 +1736,7 @@ class TestSampleTemplate(TestCase):
                           'longitude', 'physical_specimen_location',
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id', 'tot_nitro'}
-        self.assertCountEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories, exp_categories)
         exp_dict = {
             "%s.Sample1" % st.id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -1835,7 +1835,7 @@ class TestSampleTemplate(TestCase):
                           'longitude', 'physical_specimen_location',
                           'physical_specimen_remaining', 'sample_type',
                           'scientific_name', 'taxon_id', 'tot_nitro'}
-        self.assertCountEqual(st.categories(), exp_categories)
+        self.assertCountEqual(st.categories, exp_categories)
         exp_dict = {
             "%s.Sample1" % st.id: {
                 'collection_timestamp': '2014-05-29 12:24:15',
@@ -2247,7 +2247,7 @@ class TestSampleTemplate(TestCase):
         st = qdb.metadata_template.sample_template.SampleTemplate.create(
             self.metadata, self.new_study)
         st.delete_column('dna_extracted')
-        self.assertNotIn('dna_extracted', st.categories())
+        self.assertNotIn('dna_extracted', st.categories)
 
     def test_delete_column_specimen_id(self):
         st = qdb.metadata_template.sample_template.SampleTemplate.create(

--- a/qiita_db/processing_job.py
+++ b/qiita_db/processing_job.py
@@ -1815,7 +1815,7 @@ class ProcessingJob(qdb.base.QiitaObject):
                 pass
             else:
                 samples = len(st)
-                columns = len(st.categories())
+                columns = len(st.categories)
         elif analysis_id is not None:
             try:
                 analysis = qdb.analysis.Analysis(analysis_id)

--- a/qiita_db/study.py
+++ b/qiita_db/study.py
@@ -784,7 +784,7 @@ class Study(qdb.base.QiitaObject):
                                                     "sample information.")
 
         if value is not None:
-            if value not in st.categories():
+            if value not in st.categories:
                 raise qdb.exceptions.QiitaDBLookupError("Category '%s' is not "
                                                         "present in the sample"
                                                         " information."

--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -1790,7 +1790,7 @@ def get_artifacts_information(artifact_ids, only_biom=True):
             if prep_template_id is not None:
                 if prep_template_id not in ps:
                     pt = PT(prep_template_id)
-                    categories = pt.categories()
+                    categories = pt.categories
                     if 'platform' in categories:
                         platform = ', '.join(
                             set(pt.get_category('platform').values()))

--- a/qiita_pet/handlers/api_proxy/prep_template.py
+++ b/qiita_pet/handlers/api_proxy/prep_template.py
@@ -137,7 +137,7 @@ def prep_template_ajax_get_req(user_id, prep_id):
 
     # The call to list is needed because keys is an iterator
     num_samples = len(list(pt.keys()))
-    num_columns = len(pt.categories())
+    num_columns = len(pt.categories)
     investigation_type = pt.investigation_type
 
     download_prep_id = None

--- a/qiita_pet/handlers/api_proxy/sample_template.py
+++ b/qiita_pet/handlers/api_proxy/sample_template.py
@@ -139,7 +139,7 @@ def sample_template_meta_cats_get_req(samp_id, user_id):
 
     return {'status': 'success',
             'message': '',
-            'categories': sorted(SampleTemplate(int(samp_id)).categories())
+            'categories': sorted(SampleTemplate(int(samp_id)).categories)
             }
 
 

--- a/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_prep_template.py
@@ -535,7 +535,7 @@ class TestPrepAPI(TestCase):
         exp = {'status': 'success', 'message': '', 'row_id': '10'}
         self.assertEqual(obs, exp)
         self._wait_for_parallel_job('prep_template_%s' % pt.id)
-        self.assertNotIn('target_subfragment', pt.categories())
+        self.assertNotIn('target_subfragment', pt.categories)
 
         # Change the name of the prep template
         obs = prep_template_patch_req(

--- a/qiita_pet/handlers/rest/study_samples.py
+++ b/qiita_pet/handlers/rest/study_samples.py
@@ -47,7 +47,7 @@ class StudySamplesHandler(RESTHandler):
             self.fail('No samples provided', 400)
             return
 
-        categories = set(study.sample_template.categories())
+        categories = set(study.sample_template.categories)
 
         if set(data.columns) != categories:
             if set(data.columns).issubset(categories):
@@ -99,7 +99,7 @@ class StudySamplesCategoriesHandler(RESTHandler):
             self.fail('Study does not have sample information', 404)
             return
 
-        available_categories = set(study.sample_template.categories())
+        available_categories = set(study.sample_template.categories)
         not_found = set(categories) - available_categories
         if not_found:
             self.fail('Category not found', 404,
@@ -130,7 +130,7 @@ class StudySamplesInfoHandler(RESTHandler):
                     'categories': []}
         else:
             info = {'number-of-samples': len(st),
-                    'categories': st.categories()}
+                    'categories': st.categories}
 
         self.write(json_encode(info))
         self.finish()

--- a/qiita_pet/handlers/study_handlers/ebi_handlers.py
+++ b/qiita_pet/handlers/study_handlers/ebi_handlers.py
@@ -58,7 +58,7 @@ class EBISubmitHandler(BaseHandler):
         sample_template = study.sample_template
         stats = {
             'Number of samples': len(prep_template),
-            'Number of metadata headers': len(sample_template.categories()),
+            'Number of metadata headers': len(sample_template.categories),
             'Number of sequences': 'N/A',
             'Total forward': 'N/A',
             'Total reverse': 'N/A'

--- a/qiita_pet/handlers/study_handlers/sample_template.py
+++ b/qiita_pet/handlers/study_handlers/sample_template.py
@@ -375,7 +375,7 @@ def sample_template_overview_handler_get_request(study_id, user):
         # the number of samples. Doing len(list(st.keys())) creates a list
         # that we are not using
         num_samples = sum(1 for _ in st.keys())
-        columns = st.categories()
+        columns = st.categories
         # The number of columns
         num_cols = len(columns)
         specimen_id_column = Study(study_id).specimen_id_column
@@ -435,7 +435,7 @@ def sample_template_columns_get_req(study_id, column, user):
     sample_template_checks(study_id, user, check_exists=True)
 
     if column is None:
-        reply = SampleTemplate(study_id).categories()
+        reply = SampleTemplate(study_id).categories
     else:
         reply = list(SampleTemplate(study_id).get_category(column).values())
 

--- a/qiita_pet/handlers/study_handlers/tests/test_sample_template.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_sample_template.py
@@ -201,7 +201,7 @@ class TestHelpers(TestHandlerBase):
 
         # Wait until the job is done
         wait_for_processing_job(loads(job_info)['job_id'])
-        self.assertNotIn('col2', st.categories())
+        self.assertNotIn('col2', st.categories)
 
         # TESTS FOR OPERATION: replace
         # Test incorrect path parameter with replace

--- a/qiita_pet/handlers/study_handlers/vamps_handlers.py
+++ b/qiita_pet/handlers/study_handlers/vamps_handlers.py
@@ -48,7 +48,7 @@ class VAMPSHandler(BaseHandler):
         sample_template = study.sample_template
         stats = [('Number of samples', len(prep_template)),
                  ('Number of metadata headers',
-                  len(sample_template.categories()))]
+                  len(sample_template.categories))]
 
         demux = [x['fp'] for x in preprocessed_data.filepaths
                  if x['fp_type'] == 'preprocessed_demux']

--- a/qiita_ware/ebi.py
+++ b/qiita_ware/ebi.py
@@ -1019,7 +1019,7 @@ class EBISubmission(object):
             rev_read = r[1] if r is not None else None
             fps.append((sample_name, (fwd_read, rev_read)))
 
-        if 'run_prefix' in self.prep_template.categories():
+        if 'run_prefix' in self.prep_template.categories:
             rps = [(k, v) for k, v in
                    self.prep_template.get_category('run_prefix').items()]
         else:

--- a/qiita_ware/test/test_metadata_pipeline.py
+++ b/qiita_ware/test/test_metadata_pipeline.py
@@ -72,12 +72,12 @@ class TestMetadataPipeline(TestCase):
                "dna_extracted", "sample_type", "host_subject_id", "latitude",
                "longitude", "taxon_id", "scientific_name",
                "collection_timestamp", "description"}
-        self.assertEqual(set(obs_st.categories()), exp)
+        self.assertEqual(set(obs_st.categories), exp)
 
         exp = {"barcode", "primer", "center_name", "run_prefix", "platform",
                "library_construction_protocol", "instrument_model",
                "experiment_design_description"}
-        self.assertEqual(set(obs_pt.categories()), exp)
+        self.assertEqual(set(obs_pt.categories), exp)
 
     def test_create_templates_from_qiime_mapping_file_reverse_linker(self):
         with TRN:
@@ -101,12 +101,12 @@ class TestMetadataPipeline(TestCase):
                "dna_extracted", "sample_type", "host_subject_id", "latitude",
                "longitude", "taxon_id", "scientific_name",
                "collection_timestamp", "description"}
-        self.assertEqual(set(obs_st.categories()), exp)
+        self.assertEqual(set(obs_st.categories), exp)
 
         exp = {"barcode", "primer", "center_name", "run_prefix", "platform",
                "library_construction_protocol", "instrument_model",
                "experiment_design_description", "reverselinkerprimer"}
-        self.assertEqual(set(obs_pt.categories()), exp)
+        self.assertEqual(set(obs_pt.categories), exp)
 
     def test_create_templates_from_qiime_mapping_file_error(self):
         with self.assertRaises(QiitaWareError):

--- a/qiita_ware/test/test_private_plugin.py
+++ b/qiita_ware/test/test_private_plugin.py
@@ -542,7 +542,7 @@ class TestPrivatePluginDeleteTests(BaseTestPrivatePlugin):
                                 'name': 'season_environment'})
         private_task(job.id)
         self.assertEqual(job.status, 'success')
-        self.assertNotIn('season_environment', st.categories())
+        self.assertNotIn('season_environment', st.categories)
 
         # Delete a sample template sample - need to add one
         # sample that we will remove
@@ -567,7 +567,7 @@ class TestPrivatePluginDeleteTests(BaseTestPrivatePlugin):
                                 'name': 'target_subfragment'})
         private_task(job.id)
         self.assertEqual(job.status, 'success')
-        self.assertNotIn('target_subfragment', pt.categories())
+        self.assertNotIn('target_subfragment', pt.categories)
 
         # Delete a prep template sample
         metadata = pd.DataFrame.from_dict(

--- a/scripts/qiita-auto-processing
+++ b/scripts/qiita-auto-processing
@@ -114,7 +114,7 @@ def _check_requirements(requirements, template):
     satisfied = True
     for req in requirements:
         if satisfied:
-            if req['column'] not in template.categories():
+            if req['column'] not in template.categories:
                 if req['equal']:
                     satisfied = False
                 continue


### PR DESCRIPTION
After review, the only code that is kind of duplicated is the code between BaseSample._get_categories and MetadataTemplate.categories; which we are merging in a single helper function in this PR + made MetadataTemplate.categories a property. 