### PR TITLE
fix #3515: run register_commands off the ioloop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Deployed on TBD
 * Fixed the broken "Unselect All" button on the upload page. [#3510](https://github.com/qiita-spots/qiita/pull/3510) (fixes [#3488](https://github.com/qiita-spots/qiita/issues/3488))
 * Test framework migrated from `nose` to `pytest`; obsolete `__test__ = False` markers removed and test artifacts are now auto-cleaned. [#3509](https://github.com/qiita-spots/qiita/pull/3509), [#3511](https://github.com/qiita-spots/qiita/pull/3511), [#3502](https://github.com/qiita-spots/qiita/pull/3502)
 * Added `CLAUDE.md` to guide Claude Code sessions in this repository. [#3508](https://github.com/qiita-spots/qiita/pull/3508)
+* Fixed a deadlock in `/apitest/reload_plugins/` where the master Tornado ioloop blocked on the plugin-registration subprocess, causing intermittent 504s from nginx when plugin callbacks were round-robined back to master (fixes [#3515](https://github.com/qiita-spots/qiita/issues/3515)).
 
 
 Version 2026.01

--- a/qiita_db/handlers/plugin.py
+++ b/qiita_db/handlers/plugin.py
@@ -10,6 +10,7 @@ from glob import glob
 from json import loads
 from os.path import join
 
+from tornado.ioloop import IOLoop
 from tornado.web import HTTPError
 
 import qiita_db as qdb
@@ -260,7 +261,7 @@ class CommandActivateHandler(OauthBaseHandler):
 
 class ReloadPluginAPItestHandler(OauthBaseHandler):
     @authenticate_oauth
-    def post(self):
+    async def post(self):
         """Reloads the plugins"""
         conf_files = sorted(glob(join(qiita_config.plugin_dir, "*.conf")))
         software = set(
@@ -268,11 +269,15 @@ class ReloadPluginAPItestHandler(OauthBaseHandler):
         )
         definition = set([s for s in software if s.type == "artifact definition"])
         transformation = software - definition
+        # register_commands shells out via Popen.communicate; run it in the
+        # default executor so the master ioloop can still serve the plugin's
+        # /activate/ callbacks that nginx may round-robin back here (#3515).
+        loop = IOLoop.current()
         for s in definition:
             s.activate()
-            s.register_commands()
+            await loop.run_in_executor(None, s.register_commands)
         for s in transformation:
             s.activate()
-            s.register_commands()
+            await loop.run_in_executor(None, s.register_commands)
 
         self.finish()


### PR DESCRIPTION
## Summary

- Fixes #3515. `ReloadPluginAPItestHandler.post()` was calling `register_commands()` synchronously, which shells out via `Popen.communicate()` and blocks the master Tornado ioloop for the duration of the plugin register subprocess.
- The subprocess calls back into qiita through nginx, which round-robins across master and workers — so any callback that lands on master while it is still blocked times out (504), breaking CI for plugins that register more than one command (e.g. `qtp-biom`).
- This change awaits `register_commands()` on the default `IOLoop` executor so master stays responsive to the `/activate/` callbacks while the subprocess runs. `_system_call` and `register_commands` are untouched; all their other callers already run outside an ioloop context.

## Why this shape

- `@authenticate_oauth` is already compatible with `async def` — `APIAnalysisMetadataHandler.get` in `qiita_db/handlers/analysis.py` uses the same pattern.
- `activate()` stays synchronous: it is a fast `TRN` write, not the thing that blocks.
- Only `ReloadPluginAPItestHandler` calls `register_commands()` anywhere in the repo, so the blast radius is this one method.

## Test plan

- [x] `pytest qiita_db/handlers/tests/test_plugin.py::ReloadPluginAPItestHandlerTests -v` passes locally.
- [x] CI green on the `qiita_pet qiita_core qiita_ware` matrix leg, which exercises this handler with a real plugin subprocess.
- [x] Confirm the qtp-biom flake in qiita-spots/qtp-biom#33 no longer reproduces against this branch (with nginx upstream restored — i.e. master un-`down`ned).

Generated with [Claude Code](https://claude.com/claude-code)
