### PR TITLE
docs: expand CLAUDE.md with CI-sourced runtime notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Deployed on TBD
 * Test framework migrated from `nose` to `pytest`; obsolete `__test__ = False` markers removed and test artifacts are now auto-cleaned. [#3509](https://github.com/qiita-spots/qiita/pull/3509), [#3511](https://github.com/qiita-spots/qiita/pull/3511), [#3502](https://github.com/qiita-spots/qiita/pull/3502)
 * Added `CLAUDE.md` to guide Claude Code sessions in this repository. [#3508](https://github.com/qiita-spots/qiita/pull/3508)
 * Fixed a deadlock in `/apitest/reload_plugins/` where the master Tornado ioloop blocked on the plugin-registration subprocess, causing intermittent 504s from nginx when plugin callbacks were round-robined back to master (fixes [#3515](https://github.com/qiita-spots/qiita/issues/3515)).
+* Expanded `CLAUDE.md` with CI-sourced runtime details (webdis/nginx/supervisord, `QIITA_JOB_SCHEDULER_EPILOGUE`, `qiita-env make --no-load-ontologies`, `qiita-test-install`, `qiita plugins update`, production-DB zero-rows invariant, and the non-`qiita_db` matrix post-test checks).
 
 
 Version 2026.01

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,11 +33,13 @@ Plugins communicate via API proxy handlers in `qiita_pet/handlers/api_proxy/`.
 - Python 3.9 (setup.py incorrectly says 3.6 — CI and INSTALL.md use 3.9)
 - PostgreSQL 13
 - Redis 2.8.17+ — typically two instances: main on port 7777, redbiom on 6379
+- Full integration environment (what CI runs) also requires **webdis** (Redis HTTP bridge), **nginx**, and **supervisord** to drive multiple qiita workers. Canonical wiring lives in `qiita_pet/supervisor_example.conf` and `qiita_pet/nginx_example.conf`; see `.github/workflows/qiita-ci.yml` for the full startup sequence
 
 ## Configuration
 
 - Template config: `qiita_core/support_files/config_test.cfg` — copy and point `QIITA_CONFIG_FP` at it
 - Other env vars that matter: `REDBIOM_HOST`, `QIITA_ROOTCA_CERT`
+- `QIITA_JOB_SCHEDULER_EPILOGUE` must be *set* for the test suite to run, but does not need to point at a real file (CI sets it to a placeholder path)
 
 ## Common Commands
 
@@ -45,7 +47,10 @@ Plugins communicate via API proxy handlers in `qiita_pet/handlers/api_proxy/`.
 # Environment setup
 export QIITA_CONFIG_FP=/path/to/config.cfg
 qiita-env make                    # Create database environment
+qiita-env make --no-load-ontologies  # Faster env creation (skips ontology load; what CI uses)
 qiita-env drop                    # Drop database environment
+qiita-test-install                # Register test plugins after qiita-env make
+qiita plugins update              # Refresh installed plugins after config changes
 
 # Web server
 qiita pet webserver start         # Start on port 21174
@@ -65,6 +70,7 @@ CI specifics:
 - CI invokes `coverage run -m pytest`, not bare `pytest`
 - The `qtp-biom` plugin must be installed for the full suite to pass
 - Two flaky EBI tests are deselected: `test_submit_EBI_parse_EBI_reply_failure`, `test_full_submission`
+- The `qiita_pet qiita_core qiita_ware` matrix leg runs three additional post-test checks that will not surface if you only run pytest locally: `test_data_studies/commands.sh` (CLI study creation), `all-qiita-cron-job` (cron smoke test), and the fresh-production-DB row-count validation above
 
 ## Testing Conventions
 
@@ -89,6 +95,7 @@ Schema changes require patch files, never direct modification of the base schema
 - All patches prior to 92.sql were merged into the base schema (patch 91.sql consolidation, May 2024)
 - Test-only SQL changes go in `patches/test_db_sql/`
 - Python patches go in `patches/python_patches/` with the same basename as their SQL patch (e.g., `4.py` for `4.sql`)
+- A freshly-created **production** environment (`TEST_ENVIRONMENT = FALSE`) must result in zero rows across the `qiita` schema — CI fails the job if the summed `reltuples` is nonzero, so patches must not pre-populate production data
 
 ## SQL Style
 


### PR DESCRIPTION
## Summary

Expands `CLAUDE.md` with five small, additive clarifications sourced from `.github/workflows/qiita-ci.yml`. No sections are removed or rewritten. The goal is to save future Claude Code sessions from rediscovering CI-only facts from the workflow YAML.

- **Runtime Requirements**: notes that the full integration environment (what CI runs) also needs webdis, nginx, and supervisord, with pointers to the example conf files.
- **Configuration**: flags `QIITA_JOB_SCHEDULER_EPILOGUE` as a required-but-unused env var for the test suite.
- **Common Commands**: adds `qiita-env make --no-load-ontologies`, `qiita-test-install`, and `qiita plugins update`.
- **Database Schema Changes**: documents the invariant that a freshly-created production DB must have zero rows across the `qiita` schema (CI enforces this).
- **CI specifics**: calls out the three extra post-test checks that only run on the `qiita_pet qiita_core qiita_ware` matrix leg (`test_data_studies/commands.sh`, `all-qiita-cron-job`, production-DB row-count validation).

## Test plan

- [x] CI lint passes (`ruff` — CLAUDE.md is not a Python file, so only a sanity check).
- [x] Reviewer skims the diff and confirms each new line is accurate against `.github/workflows/qiita-ci.yml`.

Generated with [Claude Code](https://claude.com/claude-code)
